### PR TITLE
Add initial support for GTK composite templates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
   "gsk4/sys",
   "gtk4",
   "gtk4/sys",
+  "gtk4-macros",
 ]
 
 exclude = ["checker", "gir"]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -13,8 +13,14 @@ package = "gtk4"
 [dependencies.gio]
 git = "https://github.com/gtk-rs/gtk-rs"
 
+[dependencies.glib]
+git = "https://github.com/gtk-rs/gtk-rs"
+
 [[bin]]
 name = "basic"
 
 [[bin]]
 name = "builder_basics"
+
+[[bin]]
+name = "composite_template"

--- a/examples/src/bin/composite_template.rs
+++ b/examples/src/bin/composite_template.rs
@@ -2,15 +2,10 @@
 //!
 //! This sample demonstrates how to create a widget using GTK's composite templates.
 
-#[macro_use]
-extern crate glib;
-#[macro_use]
-extern crate gtk;
-
 use gio::{prelude::ApplicationExtManual, ApplicationExt};
 use glib::subclass::prelude::*;
-use glib::{Cast, StaticType};
-use gtk::WidgetExt;
+use glib::{glib_object_subclass, glib_wrapper, Cast, StaticType};
+use gtk::{CompositeTemplate, WidgetExt};
 
 mod imp {
     use super::*;

--- a/examples/src/bin/composite_template.rs
+++ b/examples/src/bin/composite_template.rs
@@ -8,68 +8,74 @@ extern crate glib;
 extern crate gtk;
 
 use gio::{prelude::ApplicationExtManual, ApplicationExt};
-use glib::subclass;
 use glib::subclass::prelude::*;
 use glib::{Cast, StaticType};
-use gtk::subclass::prelude::*;
-use gtk::subclass::widget::*;
 use gtk::WidgetExt;
 
-/// The private struct, which can hold widgets and other data.
-#[derive(Debug, CompositeTemplate)]
-pub struct ExApplicationWindowPriv {
-    // The #[template_child] attribute tells the CompositeTemplate macro
-    // that a field is meant to be a child within the template.
-    #[template_child(id = "headerbar")]
-    headerbar: TemplateChild<gtk::HeaderBar>,
-    #[template_child(id = "label")]
-    label: TemplateChild<gtk::Label>,
-    #[template_child(id = "subtitle_label")]
-    subtitle: TemplateChild<gtk::Label>,
-}
+mod imp {
+    use super::*;
+    use glib::subclass;
+    use gtk::subclass::prelude::*;
+    use gtk::subclass::widget::*;
+    use gtk::WidgetExt;
 
-impl ObjectSubclass for ExApplicationWindowPriv {
-    const NAME: &'static str = "ExApplicationWindow";
-    type Type = ExApplicationWindow;
-    type ParentType = gtk::ApplicationWindow;
-    type Instance = subclass::simple::InstanceStruct<Self>;
-    type Class = subclass::simple::ClassStruct<Self>;
+    /// The private struct, which can hold widgets and other data.
+    #[derive(Debug, CompositeTemplate)]
+    pub struct ExApplicationWindow {
+        // The #[template_child] attribute tells the CompositeTemplate macro
+        // that a field is meant to be a child within the template.
+        #[template_child(id = "headerbar")]
+        pub headerbar: TemplateChild<gtk::HeaderBar>,
+        #[template_child(id = "label")]
+        pub label: TemplateChild<gtk::Label>,
+        #[template_child(id = "subtitle_label")]
+        pub subtitle: TemplateChild<gtk::Label>,
+    }
 
-    glib_object_subclass!();
+    impl ObjectSubclass for ExApplicationWindow {
+        const NAME: &'static str = "ExApplicationWindow";
+        type Type = super::ExApplicationWindow;
+        type ParentType = gtk::ApplicationWindow;
+        type Instance = subclass::simple::InstanceStruct<Self>;
+        type Class = subclass::simple::ClassStruct<Self>;
 
-    fn new() -> Self {
-        Self {
-            headerbar: TemplateChild::default(),
-            label: TemplateChild::default(),
-            subtitle: TemplateChild::default(),
+        glib_object_subclass!();
+
+        fn new() -> Self {
+            Self {
+                headerbar: TemplateChild::default(),
+                label: TemplateChild::default(),
+                subtitle: TemplateChild::default(),
+            }
+        }
+
+        // Within class_init() you must set the template
+        // and bind it's children. The CompositeTemplate
+        // derive macro provides a convenience function
+        // bind_template_children() to bind all children
+        // at once.
+        fn class_init(klass: &mut Self::Class) {
+            let template = include_bytes!("composite_template.ui");
+            klass.set_template(template);
+            Self::bind_template_children(klass);
         }
     }
 
-    // Within class_init() you must set the template
-    // and bind it's children. The CompositeTemplate
-    // derive macro provides a convenience function
-    // bind_template_children() to bind all children
-    // at once.
-    fn class_init(klass: &mut Self::Class) {
-        let template = include_bytes!("composite_template.ui");
-        klass.set_template(template);
-        Self::bind_template_children(klass);
+    impl ObjectImpl for ExApplicationWindow {
+        fn constructed(&self, obj: &Self::Type) {
+            obj.init_template();
+            obj.init_label();
+            self.parent_constructed(obj);
+        }
     }
-}
 
-impl ObjectImpl for ExApplicationWindowPriv {
-    fn constructed(&self, obj: &Self::Type) {
-        obj.init_template();
-        obj.init_label();
-        self.parent_constructed(obj);
-    }
+    impl WidgetImpl for ExApplicationWindow {}
+    impl WindowImpl for ExApplicationWindow {}
+    impl ApplicationWindowImpl for ExApplicationWindow {}
 }
-impl WidgetImpl for ExApplicationWindowPriv {}
-impl WindowImpl for ExApplicationWindowPriv {}
-impl ApplicationWindowImpl for ExApplicationWindowPriv {}
 
 glib_wrapper! {
-    pub struct ExApplicationWindow(ObjectSubclass<ExApplicationWindowPriv>)
+    pub struct ExApplicationWindow(ObjectSubclass<imp::ExApplicationWindow>)
         @extends gtk::Widget, gtk::Window, gtk::ApplicationWindow, @implements gio::ActionMap, gio::ActionGroup;
 }
 
@@ -84,7 +90,7 @@ impl ExApplicationWindow {
     pub fn init_label(&self) {
         // To access fields such as template children, you must get
         // the private struct.
-        let self_ = ExApplicationWindowPriv::from_instance(self);
+        let self_ = imp::ExApplicationWindow::from_instance(self);
         self_
             .subtitle
             .get()

--- a/examples/src/bin/composite_template.rs
+++ b/examples/src/bin/composite_template.rs
@@ -57,7 +57,13 @@ impl ObjectSubclass for ExApplicationWindowPriv {
     }
 }
 
-impl ObjectImpl for ExApplicationWindowPriv {}
+impl ObjectImpl for ExApplicationWindowPriv {
+    fn constructed(&self, obj: &Self::Type) {
+        obj.init_template();
+        obj.init_label();
+        self.parent_constructed(obj);
+    }
+}
 impl WidgetImpl for ExApplicationWindowPriv {}
 impl WindowImpl for ExApplicationWindowPriv {}
 impl ApplicationWindowImpl for ExApplicationWindowPriv {}
@@ -69,14 +75,10 @@ glib_wrapper! {
 
 impl ExApplicationWindow {
     pub fn new<P: glib::IsA<gtk::Application> + glib::value::ToValue>(app: &P) -> Self {
-        let win = glib::Object::new(Self::static_type(), &[("application", app)])
+        glib::Object::new(Self::static_type(), &[("application", app)])
             .expect("Failed to create ExApplicationWindow")
             .downcast::<ExApplicationWindow>()
-            .expect("Created object is of wrong type");
-        // init_template() must be run after the object is constructed.
-        win.init_template();
-        win.init_label();
-        win
+            .expect("Created object is of wrong type")
     }
 
     pub fn init_label(&self) {

--- a/examples/src/bin/composite_template.rs
+++ b/examples/src/bin/composite_template.rs
@@ -52,7 +52,7 @@ impl ObjectSubclass for ExApplicationWindowPriv {
     // at once.
     fn class_init(klass: &mut Self::Class) {
         let template = include_bytes!("composite_template.ui");
-        Self::set_template(klass, template);
+        klass.set_template(template);
         Self::bind_template_children(klass);
     }
 }

--- a/examples/src/bin/composite_template.rs
+++ b/examples/src/bin/composite_template.rs
@@ -1,0 +1,106 @@
+//! # Composite Template Example
+//!
+//! This sample demonstrates how to create a widget using GTK's composite templates.
+
+#[macro_use]
+extern crate glib;
+#[macro_use]
+extern crate gtk;
+
+use gio::{prelude::ApplicationExtManual, ApplicationExt};
+use glib::subclass;
+use glib::subclass::prelude::*;
+use glib::{Cast, StaticType};
+use gtk::subclass::prelude::*;
+use gtk::subclass::widget::*;
+use gtk::WidgetExt;
+
+/// The private struct, which can hold widgets and other data.
+#[derive(Debug, CompositeTemplate)]
+pub struct ExApplicationWindowPriv {
+    // The #[template_child] attribute tells the CompositeTemplate macro
+    // that a field is meant to be a child within the template.
+    #[template_child(id = "headerbar")]
+    headerbar: TemplateChild<gtk::HeaderBar>,
+    #[template_child(id = "label")]
+    label: TemplateChild<gtk::Label>,
+    #[template_child(id = "subtitle_label")]
+    subtitle: TemplateChild<gtk::Label>,
+}
+
+impl ObjectSubclass for ExApplicationWindowPriv {
+    const NAME: &'static str = "ExApplicationWindow";
+    type Type = ExApplicationWindow;
+    type ParentType = gtk::ApplicationWindow;
+    type Instance = subclass::simple::InstanceStruct<Self>;
+    type Class = subclass::simple::ClassStruct<Self>;
+
+    glib_object_subclass!();
+
+    fn new() -> Self {
+        Self {
+            headerbar: TemplateChild::default(),
+            label: TemplateChild::default(),
+            subtitle: TemplateChild::default(),
+        }
+    }
+
+    // Within class_init() you must set the template
+    // and bind it's children. The CompositeTemplate
+    // derive macro provides a convenience function
+    // bind_template_children() to bind all children
+    // at once.
+    fn class_init(klass: &mut Self::Class) {
+        let template = include_bytes!("composite_template.ui");
+        Self::set_template(klass, template);
+        Self::bind_template_children(klass);
+    }
+}
+
+impl ObjectImpl for ExApplicationWindowPriv {}
+impl WidgetImpl for ExApplicationWindowPriv {}
+impl WindowImpl for ExApplicationWindowPriv {}
+impl ApplicationWindowImpl for ExApplicationWindowPriv {}
+
+glib_wrapper! {
+    pub struct ExApplicationWindow(ObjectSubclass<ExApplicationWindowPriv>)
+        @extends gtk::Widget, gtk::Window, gtk::ApplicationWindow, @implements gio::ActionMap, gio::ActionGroup;
+}
+
+impl ExApplicationWindow {
+    pub fn new<P: glib::IsA<gtk::Application> + glib::value::ToValue>(app: &P) -> Self {
+        let win = glib::Object::new(Self::static_type(), &[("application", app)])
+            .expect("Failed to create ExApplicationWindow")
+            .downcast::<ExApplicationWindow>()
+            .expect("Created object is of wrong type");
+        // init_template() must be run after the object is constructed.
+        win.init_template();
+        win.init_label();
+        win
+    }
+
+    pub fn init_label(&self) {
+        // To access fields such as template children, you must get
+        // the private struct.
+        let self_ = ExApplicationWindowPriv::from_instance(self);
+        self_
+            .subtitle
+            .get()
+            .set_text("This is an example window made using composite templates");
+    }
+}
+
+fn main() {
+    let application = gtk::Application::new(
+        Some("com.github.gtk-rs.examples.composite_template"),
+        Default::default(),
+    )
+    .expect("Failed to initialize application");
+
+    application.connect_activate(|app| {
+        let win = ExApplicationWindow::new(app);
+        win.show();
+    });
+
+    application.run(&std::env::args().collect::<Vec<_>>());
+}

--- a/examples/src/bin/composite_template.rs
+++ b/examples/src/bin/composite_template.rs
@@ -2,17 +2,16 @@
 //!
 //! This sample demonstrates how to create a widget using GTK's composite templates.
 
-use gio::{prelude::ApplicationExtManual, ApplicationExt};
+use gio::prelude::*;
 use glib::subclass::prelude::*;
-use glib::{glib_object_subclass, glib_wrapper, Cast, StaticType};
-use gtk::{CompositeTemplate, WidgetExt};
+use glib::{glib_object_subclass, glib_wrapper};
+use gtk::{prelude::*, CompositeTemplate};
 
 mod imp {
     use super::*;
     use glib::subclass;
     use gtk::subclass::prelude::*;
     use gtk::subclass::widget::*;
-    use gtk::WidgetExt;
 
     /// The private struct, which can hold widgets and other data.
     #[derive(Debug, CompositeTemplate)]

--- a/examples/src/bin/composite_template.rs
+++ b/examples/src/bin/composite_template.rs
@@ -74,7 +74,7 @@ glib_wrapper! {
 }
 
 impl ExApplicationWindow {
-    pub fn new<P: glib::IsA<gtk::Application> + glib::value::ToValue>(app: &P) -> Self {
+    pub fn new<P: glib::IsA<gtk::Application>>(app: &P) -> Self {
         glib::Object::new(Self::static_type(), &[("application", app)])
             .expect("Failed to create ExApplicationWindow")
             .downcast::<ExApplicationWindow>()

--- a/examples/src/bin/composite_template.ui
+++ b/examples/src/bin/composite_template.ui
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="ExApplicationWindow" parent="GtkApplicationWindow">
+    <property name="default_width">600</property>
+    <property name="default_height">300</property>
+    <property name="title">Example Application Window</property>
+    <child type="titlebar">
+      <object class="GtkHeaderBar" id="headerbar">
+        <property name="show_title_buttons">True</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="orientation">vertical</property>
+        <property name="valign">center</property>
+        <property name="spacing">6</property>
+        <property name="margin_start">12</property>
+        <property name="margin_end">12</property>
+        <property name="margin_top">12</property>
+        <property name="margin_bottom">12</property>
+        <child>
+          <object class="GtkLabel" id="label">
+            <property name="label">Composite Template</property>
+            <style>
+              <class name="large-title"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="subtitle_label">
+            <property name="wrap">True</property>
+            <property name="justify">center</property>
+            <style>
+              <class name="dim-label"/>
+            </style>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>
+

--- a/gtk4-macros/Cargo.toml
+++ b/gtk4-macros/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+documentation = "https://gtk-rs.org/docs/gtk4-macros/"
+categories = ["api-bindings", "gui"]
+license = "MIT"
+description = "Rust bindings for the GTK 4 library"
+homepage = "https://gtk-rs.org/"
+name = "gtk4-macros"
+version = "0.1.0"
+authors = ["The Gtk-rs Project Developers"]
+edition = "2018"
+keywords = ["gtk", "gtk4", "gtk-rs", "gnome", "GUI"]
+repository = "https://github.com/gtk-rs/gtk4-rs"
+exclude = [
+    "gir-files/*",
+]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+anyhow = "1.0"
+heck = "0.3"
+itertools = "0.9"
+proc-macro-error = "1.0"
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = "1.0"
+proc-macro-crate = "0.1"

--- a/gtk4-macros/src/composite_template_derive.rs
+++ b/gtk4-macros/src/composite_template_derive.rs
@@ -1,0 +1,67 @@
+use proc_macro2::TokenStream;
+use proc_macro_error::abort_call_site;
+use quote::quote;
+use syn::Data;
+
+use std::string::ToString;
+
+use crate::util::*;
+
+fn gen_template_child_bindings(fields: &syn::Fields) -> TokenStream {
+    let crate_ident = crate_ident_new();
+
+    let recurse = fields.iter().map(|f| {
+        let filtered_attrs = f
+            .attrs
+            .clone()
+            .into_iter()
+            .filter(|a| a.path.is_ident("template_child"))
+            .collect::<Vec<syn::Attribute>>();
+        if !filtered_attrs.is_empty() {
+            let ident = f.ident.as_ref().unwrap();
+            let mut value_id = String::new();
+
+            if let Ok(attrs) = parse_template_child_attributes("template_child", &filtered_attrs) {
+                attrs.into_iter().for_each(|a| match a {
+                    TemplateChildAttribute::Id(id) => value_id = id,
+                });
+            }
+
+            quote! {
+                Self::bind_template_child_with_offset(
+                    klass,
+                    &#value_id,
+                    #crate_ident::offset_of!(Self => #ident),
+                );
+            }
+        } else {
+            quote! {}
+        }
+    });
+
+    quote! {
+        #(#recurse)*
+    }
+}
+
+pub fn impl_composite_template(input: &syn::DeriveInput) -> TokenStream {
+    let name = &input.ident;
+    let crate_ident = crate_ident_new();
+
+    let fields = match input.data {
+        Data::Struct(ref s) => &s.fields,
+        _ => abort_call_site!("derive(CompositeTemplate) only supports structs"),
+    };
+
+    let template_children = gen_template_child_bindings(&fields);
+
+    quote! {
+        impl #crate_ident::subclass::widget::CompositeTemplate for #name {
+            fn bind_template_children(klass: &mut Self::Class) {
+                unsafe {
+                    #template_children
+                }
+            }
+        }
+    }
+}

--- a/gtk4-macros/src/composite_template_derive.rs
+++ b/gtk4-macros/src/composite_template_derive.rs
@@ -28,8 +28,7 @@ fn gen_template_child_bindings(fields: &syn::Fields) -> TokenStream {
             }
 
             quote! {
-                Self::bind_template_child_with_offset(
-                    klass,
+                klass.bind_template_child_with_offset(
                     &#value_id,
                     #crate_ident::offset_of!(Self => #ident),
                 );

--- a/gtk4-macros/src/lib.rs
+++ b/gtk4-macros/src/lib.rs
@@ -1,0 +1,14 @@
+mod composite_template_derive;
+mod util;
+
+use proc_macro::TokenStream;
+use proc_macro_error::proc_macro_error;
+use syn::{parse_macro_input, DeriveInput};
+
+#[proc_macro_derive(CompositeTemplate, attributes(template_child))]
+#[proc_macro_error]
+pub fn composite_template_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let gen = composite_template_derive::impl_composite_template(&input);
+    gen.into()
+}

--- a/gtk4-macros/src/util.rs
+++ b/gtk4-macros/src/util.rs
@@ -1,0 +1,82 @@
+use anyhow::{bail, Result};
+use itertools::Itertools;
+use proc_macro2::{Ident, Span};
+use proc_macro_crate::crate_name;
+use syn::{Attribute, Lit, Meta, MetaList, NestedMeta};
+
+// find the #[@attr_name] attribute in @attrs
+fn find_attribute_meta(attrs: &[Attribute], attr_name: &str) -> Result<Option<MetaList>> {
+    let meta = match attrs.iter().find(|a| a.path.is_ident(attr_name)) {
+        Some(a) => a.parse_meta(),
+        _ => return Ok(None),
+    };
+    match meta? {
+        Meta::List(n) => Ok(Some(n)),
+        _ => bail!("wrong meta type"),
+    }
+}
+
+#[derive(Debug)]
+pub enum TemplateChildAttribute {
+    Id(String),
+}
+
+fn parse_attribute(meta: &NestedMeta) -> Result<(String, String)> {
+    let meta = match &meta {
+        NestedMeta::Meta(m) => m,
+        _ => bail!("wrong meta type: not a NestedMeta::Meta"),
+    };
+    let meta = match meta {
+        Meta::NameValue(n) => n,
+        _ => bail!("wrong meta type: not a Meta::NameValue"),
+    };
+    let value = match &meta.lit {
+        Lit::Str(s) => s.value(),
+        _ => bail!("wrong meta type: not a Lit::Str"),
+    };
+
+    let ident = match meta.path.get_ident() {
+        None => bail!("missing ident"),
+        Some(ident) => ident,
+    };
+
+    Ok((ident.to_string(), value))
+}
+
+fn parse_template_child_attribute(meta: &NestedMeta) -> Result<TemplateChildAttribute> {
+    let (ident, v) = parse_attribute(meta)?;
+
+    match ident.as_ref() {
+        "id" => Ok(TemplateChildAttribute::Id(v)),
+        s => bail!("Unknown item meta {}", s),
+    }
+}
+
+pub fn parse_template_child_attributes(
+    attr_name: &str,
+    attrs: &[Attribute],
+) -> Result<Vec<TemplateChildAttribute>> {
+    let meta_list = find_attribute_meta(attrs, attr_name)?;
+    let v = match meta_list {
+        Some(meta) => meta
+            .nested
+            .iter()
+            .map(|m| parse_template_child_attribute(&m))
+            .fold_results(Vec::new(), |mut v, a| {
+                v.push(a);
+                v
+            })?,
+        None => Vec::new(),
+    };
+
+    Ok(v)
+}
+
+pub fn crate_ident_new() -> Ident {
+    let crate_name = match crate_name("gtk4") {
+        Ok(x) => x,
+        Err(_) => "gtk4".to_owned(),
+    };
+
+    Ident::new(&crate_name, Span::call_site())
+}

--- a/gtk4/Cargo.toml
+++ b/gtk4/Cargo.toml
@@ -39,8 +39,10 @@ git = "https://github.com/gtk-rs/lgpl-docs"
 [dependencies]
 libc = "0.2"
 bitflags = "1.0"
+field-offset = "0.3"
 once_cell = "1.0"
 ffi =  { package = "gtk4-sys", path = "./sys" }
+gtk4-macros =  { path = "../gtk4-macros" }
 cairo-rs = { git = "https://github.com/gtk-rs/gtk-rs" }
 gio = { git = "https://github.com/gtk-rs/gtk-rs", features = ["v2_46"] }
 glib = { git = "https://github.com/gtk-rs/gtk-rs" }

--- a/gtk4/src/lib.rs
+++ b/gtk4/src/lib.rs
@@ -14,6 +14,19 @@
 #![allow(deprecated)]
 
 pub use ffi;
+#[macro_use]
+#[doc(hidden)]
+#[allow(unused_imports)]
+pub extern crate field_offset;
+#[macro_use]
+#[doc(hidden)]
+#[allow(unused_imports)]
+pub extern crate gtk4_macros;
+
+#[doc(hidden)]
+pub use field_offset::*;
+#[doc(hidden)]
+pub use gtk4_macros::*;
 
 pub const STYLE_PROVIDER_PRIORITY_FALLBACK: u32 = ffi::GTK_STYLE_PROVIDER_PRIORITY_FALLBACK as u32;
 pub const STYLE_PROVIDER_PRIORITY_THEME: u32 = ffi::GTK_STYLE_PROVIDER_PRIORITY_THEME as u32;

--- a/gtk4/src/subclass/widget.rs
+++ b/gtk4/src/subclass/widget.rs
@@ -1,5 +1,6 @@
 use std::mem;
 
+use glib::prelude::*;
 use glib::subclass::prelude::*;
 use glib::translate::*;
 use glib::Cast;
@@ -819,4 +820,117 @@ unsafe extern "C" fn widget_unroot<T: WidgetImpl>(ptr: *mut ffi::GtkWidget) {
     let wrap: Borrowed<Widget> = from_glib_borrow(ptr);
 
     imp.unroot(wrap.unsafe_cast_ref())
+}
+
+pub unsafe trait WidgetClassSubclassExt: ObjectSubclass + WidgetImpl {
+    fn set_template_bytes(klass: &mut <Self as ObjectSubclass>::Class, template: &glib::Bytes) {
+        unsafe {
+            let type_class = klass as *mut _ as *mut glib::gobject_ffi::GTypeClass;
+            let widget_class =
+                glib::gobject_ffi::g_type_check_class_cast(type_class, ffi::gtk_widget_get_type())
+                    as *mut ffi::GtkWidgetClass;
+            ffi::gtk_widget_class_set_template(widget_class, template.to_glib_none().0);
+        }
+    }
+
+    fn set_template(klass: &mut <Self as ObjectSubclass>::Class, template: &[u8]) {
+        let template_bytes = glib::Bytes::from(template);
+        Self::set_template_bytes(klass, &template_bytes);
+    }
+
+    fn set_template_static(klass: &mut <Self as ObjectSubclass>::Class, template: &'static [u8]) {
+        let template_bytes = glib::Bytes::from_static(template);
+        Self::set_template_bytes(klass, &template_bytes);
+    }
+
+    fn set_template_from_resource(
+        klass: &mut <Self as ObjectSubclass>::Class,
+        resource_name: &str,
+    ) {
+        unsafe {
+            let type_class = klass as *mut _ as *mut glib::gobject_ffi::GTypeClass;
+            let widget_class =
+                glib::gobject_ffi::g_type_check_class_cast(type_class, ffi::gtk_widget_get_type())
+                    as *mut ffi::GtkWidgetClass;
+            ffi::gtk_widget_class_set_template_from_resource(
+                widget_class,
+                resource_name.to_glib_none().0,
+            );
+        }
+    }
+
+    fn bind_template_child(klass: &mut <Self as ObjectSubclass>::Class, name: &str) {
+        unsafe {
+            let type_class = klass as *mut _ as *mut glib::gobject_ffi::GTypeClass;
+            let widget_class =
+                glib::gobject_ffi::g_type_check_class_cast(type_class, ffi::gtk_widget_get_type())
+                    as *mut ffi::GtkWidgetClass;
+            ffi::gtk_widget_class_bind_template_child_full(
+                widget_class,
+                name.to_glib_none().0,
+                false as glib::ffi::gboolean,
+                0,
+            );
+        }
+    }
+
+    #[allow(clippy::missing_safety_doc)]
+    unsafe fn bind_template_child_with_offset<T>(
+        klass: &mut <Self as ObjectSubclass>::Class,
+        name: &str,
+        offset: field_offset::FieldOffset<Self, TemplateChild<T>>,
+    ) where
+        T: ObjectType + FromGlibPtrNone<*mut <T as ObjectType>::GlibType>,
+    {
+        let type_class = klass as *mut _ as *mut glib::gobject_ffi::GTypeClass;
+        let widget_class =
+            glib::gobject_ffi::g_type_check_class_cast(type_class, ffi::gtk_widget_get_type())
+                as *mut ffi::GtkWidgetClass;
+        let private_offset = Self::type_data().as_ref().private_offset;
+        ffi::gtk_widget_class_bind_template_child_full(
+            widget_class,
+            name.to_glib_none().0,
+            false as glib::ffi::gboolean,
+            private_offset + (offset.get_byte_offset() as isize),
+        )
+    }
+}
+
+unsafe impl<T: ObjectSubclass + WidgetImpl> WidgetClassSubclassExt for T {}
+
+#[derive(Debug, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct TemplateChild<T>
+where
+    T: ObjectType + FromGlibPtrNone<*mut <T as ObjectType>::GlibType>,
+{
+    ptr: *mut <T as ObjectType>::GlibType,
+}
+
+impl<T> Default for TemplateChild<T>
+where
+    T: ObjectType + FromGlibPtrNone<*mut <T as ObjectType>::GlibType>,
+{
+    fn default() -> Self {
+        Self {
+            ptr: std::ptr::null_mut(),
+        }
+    }
+}
+
+impl<T> TemplateChild<T>
+where
+    T: ObjectType + FromGlibPtrNone<*mut <T as ObjectType>::GlibType>,
+{
+    #[track_caller]
+    pub fn get(&self) -> T {
+        unsafe {
+            Option::<T>::from_glib_none(self.ptr)
+                .expect("Failed to retrieve template child. Please check that it has been bound.")
+        }
+    }
+}
+
+pub trait CompositeTemplate: WidgetClassSubclassExt {
+    fn bind_template_children(klass: &mut Self::Class);
 }


### PR DESCRIPTION
Adds support for composite templates in gtk4-rs.
For now this only adds support for objects as template
children. We will need to figure out signals/callbacks later.