### PR TITLE
Subclassing round 2

### DIFF
--- a/gtk4/src/subclass/check_button.rs
+++ b/gtk4/src/subclass/check_button.rs
@@ -1,0 +1,52 @@
+use gtk_sys;
+
+use glib::subclass::prelude::*;
+use glib::translate::*;
+use glib::Cast;
+
+use super::widget::WidgetImpl;
+use CheckButton;
+use Widget;
+
+pub trait CheckButtonImpl: CheckButtonImplExt + WidgetImpl {
+    fn toggled(&self, check_button: &Self::Type) {
+        self.parent_toggled(check_button)
+    }
+}
+
+pub trait CheckButtonImplExt: ObjectSubclass {
+    fn parent_toggled(&self, check_button: &Self::Type);
+}
+
+impl<T: CheckButtonImpl> CheckButtonImplExt for T {
+    fn parent_toggled(&self, check_button: &Self::Type) {
+        unsafe {
+            let data = T::type_data();
+            let parent_class =
+                data.as_ref().get_parent_class() as *mut gtk_sys::GtkCheckButtonClass;
+            if let Some(f) = (*parent_class).toggled {
+                f(check_button
+                    .unsafe_cast_ref::<CheckButton>()
+                    .to_glib_none()
+                    .0)
+            }
+        }
+    }
+}
+
+unsafe impl<T: CheckButtonImpl> IsSubclassable<T> for CheckButton {
+    fn override_vfuncs(class: &mut glib::Class<Self>) {
+        <Widget as IsSubclassable<T>>::override_vfuncs(class);
+
+        let klass = class.as_mut();
+        klass.toggled = Some(check_button_toggled::<T>);
+    }
+}
+
+unsafe extern "C" fn check_button_toggled<T: CheckButtonImpl>(ptr: *mut gtk_sys::GtkCheckButton) {
+    let instance = &*(ptr as *mut T::Instance);
+    let imp = instance.get_impl();
+    let wrap: Borrowed<CheckButton> = from_glib_borrow(ptr);
+
+    imp.toggled(wrap.unsafe_cast_ref())
+}

--- a/gtk4/src/subclass/dialog.rs
+++ b/gtk4/src/subclass/dialog.rs
@@ -29,13 +29,12 @@ impl<T: DialogImpl> DialogImplExt for T {
         unsafe {
             let data = T::type_data();
             let parent_class = data.as_ref().get_parent_class() as *mut gtk_sys::GtkDialogClass;
-            let f = (*parent_class)
-                .response
-                .expect("No parent class impl for \"response\"");
-            f(
-                dialog.unsafe_cast_ref::<Dialog>().to_glib_none().0,
-                response.to_glib(),
-            )
+            if let Some(f) = (*parent_class).response {
+                f(
+                    dialog.unsafe_cast_ref::<Dialog>().to_glib_none().0,
+                    response.to_glib(),
+                )
+            }
         }
     }
 
@@ -43,10 +42,9 @@ impl<T: DialogImpl> DialogImplExt for T {
         unsafe {
             let data = T::type_data();
             let parent_class = data.as_ref().get_parent_class() as *mut gtk_sys::GtkDialogClass;
-            let f = (*parent_class)
-                .close
-                .expect("No parent class impl for \"close\"");
-            f(dialog.unsafe_cast_ref::<Dialog>().to_glib_none().0)
+            if let Some(f) = (*parent_class).close {
+                f(dialog.unsafe_cast_ref::<Dialog>().to_glib_none().0)
+            }
         }
     }
 }

--- a/gtk4/src/subclass/entry.rs
+++ b/gtk4/src/subclass/entry.rs
@@ -1,0 +1,48 @@
+use gtk_sys;
+
+use glib::subclass::prelude::*;
+use glib::translate::*;
+use glib::Cast;
+
+use super::widget::WidgetImpl;
+use Entry;
+use Widget;
+
+pub trait EntryImpl: EntryImplExt + WidgetImpl {
+    fn activate(&self, entry: &Self::Type) {
+        self.parent_activate(entry)
+    }
+}
+
+pub trait EntryImplExt: ObjectSubclass {
+    fn parent_activate(&self, entry: &Self::Type);
+}
+
+impl<T: EntryImpl> EntryImplExt for T {
+    fn parent_activate(&self, entry: &Self::Type) {
+        unsafe {
+            let data = T::type_data();
+            let parent_class = data.as_ref().get_parent_class() as *mut gtk_sys::GtkEntryClass;
+            if let Some(f) = (*parent_class).activate {
+                f(entry.unsafe_cast_ref::<Entry>().to_glib_none().0)
+            }
+        }
+    }
+}
+
+unsafe impl<T: EntryImpl> IsSubclassable<T> for Entry {
+    fn override_vfuncs(class: &mut glib::Class<Self>) {
+        <Widget as IsSubclassable<T>>::override_vfuncs(class);
+
+        let klass = class.as_mut();
+        klass.activate = Some(entry_activate::<T>);
+    }
+}
+
+unsafe extern "C" fn entry_activate<T: EntryImpl>(ptr: *mut gtk_sys::GtkEntry) {
+    let instance = &*(ptr as *mut T::Instance);
+    let imp = instance.get_impl();
+    let wrap: Borrowed<Entry> = from_glib_borrow(ptr);
+
+    imp.activate(wrap.unsafe_cast_ref())
+}

--- a/gtk4/src/subclass/mod.rs
+++ b/gtk4/src/subclass/mod.rs
@@ -10,6 +10,7 @@ pub mod button;
 pub mod check_button;
 pub mod dialog;
 pub mod drawing_area;
+pub mod entry;
 pub mod flow_box_child;
 pub mod list_box_row;
 pub mod popover;
@@ -26,6 +27,7 @@ pub mod prelude {
     pub use super::check_button::CheckButtonImpl;
     pub use super::dialog::DialogImpl;
     pub use super::drawing_area::DrawingAreaImpl;
+    pub use super::entry::EntryImpl;
     pub use super::flow_box_child::FlowBoxChildImpl;
     pub use super::list_box_row::ListBoxRowImpl;
     pub use super::popover::PopoverImpl;

--- a/gtk4/src/subclass/mod.rs
+++ b/gtk4/src/subclass/mod.rs
@@ -13,6 +13,7 @@ pub mod drawing_area;
 pub mod entry;
 pub mod flow_box_child;
 pub mod list_box_row;
+pub mod native_dialog;
 pub mod popover;
 pub mod toggle_button;
 pub mod widget;
@@ -30,6 +31,7 @@ pub mod prelude {
     pub use super::entry::EntryImpl;
     pub use super::flow_box_child::FlowBoxChildImpl;
     pub use super::list_box_row::ListBoxRowImpl;
+    pub use super::native_dialog::NativeDialogImpl;
     pub use super::popover::PopoverImpl;
     pub use super::toggle_button::ToggleButtonImpl;
     pub use super::widget::WidgetImpl;

--- a/gtk4/src/subclass/mod.rs
+++ b/gtk4/src/subclass/mod.rs
@@ -12,6 +12,7 @@ pub mod drawing_area;
 pub mod flow_box_child;
 pub mod list_box_row;
 pub mod popover;
+pub mod toggle_button;
 pub mod widget;
 pub mod window;
 
@@ -26,6 +27,7 @@ pub mod prelude {
     pub use super::flow_box_child::FlowBoxChildImpl;
     pub use super::list_box_row::ListBoxRowImpl;
     pub use super::popover::PopoverImpl;
+    pub use super::toggle_button::ToggleButtonImpl;
     pub use super::widget::WidgetImpl;
     pub use super::window::WindowImpl;
     pub use gio::subclass::prelude::*;

--- a/gtk4/src/subclass/mod.rs
+++ b/gtk4/src/subclass/mod.rs
@@ -15,6 +15,7 @@ pub mod flow_box_child;
 pub mod list_box_row;
 pub mod native_dialog;
 pub mod popover;
+pub mod style_context;
 pub mod toggle_button;
 pub mod widget;
 pub mod window;
@@ -33,6 +34,7 @@ pub mod prelude {
     pub use super::list_box_row::ListBoxRowImpl;
     pub use super::native_dialog::NativeDialogImpl;
     pub use super::popover::PopoverImpl;
+    pub use super::style_context::StyleContextImpl;
     pub use super::toggle_button::ToggleButtonImpl;
     pub use super::widget::WidgetImpl;
     pub use super::window::WindowImpl;

--- a/gtk4/src/subclass/mod.rs
+++ b/gtk4/src/subclass/mod.rs
@@ -7,6 +7,7 @@ pub mod application;
 pub mod application_window;
 pub mod box_;
 pub mod button;
+pub mod check_button;
 pub mod dialog;
 pub mod drawing_area;
 pub mod flow_box_child;
@@ -22,6 +23,7 @@ pub mod prelude {
     pub use super::application_window::ApplicationWindowImpl;
     pub use super::box_::BoxImpl;
     pub use super::button::ButtonImpl;
+    pub use super::check_button::CheckButtonImpl;
     pub use super::dialog::DialogImpl;
     pub use super::drawing_area::DrawingAreaImpl;
     pub use super::flow_box_child::FlowBoxChildImpl;

--- a/gtk4/src/subclass/mod.rs
+++ b/gtk4/src/subclass/mod.rs
@@ -11,6 +11,7 @@ pub mod dialog;
 pub mod drawing_area;
 pub mod flow_box_child;
 pub mod list_box_row;
+pub mod popover;
 pub mod widget;
 pub mod window;
 
@@ -24,6 +25,7 @@ pub mod prelude {
     pub use super::drawing_area::DrawingAreaImpl;
     pub use super::flow_box_child::FlowBoxChildImpl;
     pub use super::list_box_row::ListBoxRowImpl;
+    pub use super::popover::PopoverImpl;
     pub use super::widget::WidgetImpl;
     pub use super::window::WindowImpl;
     pub use gio::subclass::prelude::*;

--- a/gtk4/src/subclass/native_dialog.rs
+++ b/gtk4/src/subclass/native_dialog.rs
@@ -1,0 +1,108 @@
+use gtk_sys;
+
+use glib::subclass::object::ObjectImpl;
+use glib::subclass::prelude::*;
+use glib::translate::*;
+use glib::{Cast, Object};
+
+use NativeDialog;
+use ResponseType;
+
+pub trait NativeDialogImpl: NativeDialogImplExt + ObjectImpl {
+    fn response(&self, dialog: &Self::Type, response: ResponseType) {
+        self.parent_response(dialog, response)
+    }
+
+    fn show(&self, dialog: &Self::Type) {
+        self.parent_show(dialog)
+    }
+
+    fn hide(&self, dialog: &Self::Type) {
+        self.parent_hide(dialog)
+    }
+}
+
+pub trait NativeDialogImplExt: ObjectSubclass {
+    fn parent_response(&self, dialog: &Self::Type, response: ResponseType);
+    fn parent_show(&self, dialog: &Self::Type);
+    fn parent_hide(&self, dialog: &Self::Type);
+}
+
+impl<T: NativeDialogImpl> NativeDialogImplExt for T {
+    fn parent_response(&self, dialog: &Self::Type, response: ResponseType) {
+        unsafe {
+            let data = T::type_data();
+            let parent_class =
+                data.as_ref().get_parent_class() as *mut gtk_sys::GtkNativeDialogClass;
+            if let Some(f) = (*parent_class).response {
+                f(
+                    dialog.unsafe_cast_ref::<NativeDialog>().to_glib_none().0,
+                    response.to_glib(),
+                )
+            }
+        }
+    }
+
+    fn parent_show(&self, dialog: &Self::Type) {
+        unsafe {
+            let data = T::type_data();
+            let parent_class =
+                data.as_ref().get_parent_class() as *mut gtk_sys::GtkNativeDialogClass;
+            let f = (*parent_class)
+                .show
+                .expect("No parent class impl for \"show\"");
+            f(dialog.unsafe_cast_ref::<NativeDialog>().to_glib_none().0)
+        }
+    }
+
+    fn parent_hide(&self, dialog: &Self::Type) {
+        unsafe {
+            let data = T::type_data();
+            let parent_class =
+                data.as_ref().get_parent_class() as *mut gtk_sys::GtkNativeDialogClass;
+            let f = (*parent_class)
+                .hide
+                .expect("No parent class impl for \"hide\"");
+            f(dialog.unsafe_cast_ref::<NativeDialog>().to_glib_none().0)
+        }
+    }
+}
+
+unsafe impl<T: NativeDialogImpl> IsSubclassable<T> for NativeDialog {
+    fn override_vfuncs(class: &mut glib::Class<Self>) {
+        <Object as IsSubclassable<T>>::override_vfuncs(class);
+
+        let klass = class.as_mut();
+        klass.response = Some(dialog_response::<T>);
+        klass.show = Some(dialog_show::<T>);
+        klass.hide = Some(dialog_hide::<T>);
+    }
+}
+
+unsafe extern "C" fn dialog_response<T: NativeDialogImpl>(
+    ptr: *mut gtk_sys::GtkNativeDialog,
+    responseptr: i32,
+) {
+    let instance = &*(ptr as *mut T::Instance);
+    let imp = instance.get_impl();
+    let wrap: Borrowed<NativeDialog> = from_glib_borrow(ptr);
+    let res: ResponseType = from_glib(responseptr);
+
+    imp.response(wrap.unsafe_cast_ref(), res)
+}
+
+unsafe extern "C" fn dialog_show<T: NativeDialogImpl>(ptr: *mut gtk_sys::GtkNativeDialog) {
+    let instance = &*(ptr as *mut T::Instance);
+    let imp = instance.get_impl();
+    let wrap: Borrowed<NativeDialog> = from_glib_borrow(ptr);
+
+    imp.show(wrap.unsafe_cast_ref())
+}
+
+unsafe extern "C" fn dialog_hide<T: NativeDialogImpl>(ptr: *mut gtk_sys::GtkNativeDialog) {
+    let instance = &*(ptr as *mut T::Instance);
+    let imp = instance.get_impl();
+    let wrap: Borrowed<NativeDialog> = from_glib_borrow(ptr);
+
+    imp.hide(wrap.unsafe_cast_ref())
+}

--- a/gtk4/src/subclass/popover.rs
+++ b/gtk4/src/subclass/popover.rs
@@ -1,0 +1,72 @@
+use gtk_sys;
+
+use glib::subclass::prelude::*;
+use glib::translate::*;
+use glib::Cast;
+
+use super::widget::WidgetImpl;
+use Popover;
+use Widget;
+
+pub trait PopoverImpl: PopoverImplExt + WidgetImpl {
+    fn activate_default(&self, button: &Self::Type) {
+        self.parent_activate_default(button)
+    }
+
+    fn closed(&self, button: &Self::Type) {
+        self.parent_closed(button)
+    }
+}
+
+pub trait PopoverImplExt: ObjectSubclass {
+    fn parent_activate_default(&self, button: &Self::Type);
+    fn parent_closed(&self, button: &Self::Type);
+}
+
+impl<T: PopoverImpl> PopoverImplExt for T {
+    fn parent_activate_default(&self, button: &Self::Type) {
+        unsafe {
+            let data = T::type_data();
+            let parent_class = data.as_ref().get_parent_class() as *mut gtk_sys::GtkPopoverClass;
+            if let Some(f) = (*parent_class).activate_default {
+                f(button.unsafe_cast_ref::<Popover>().to_glib_none().0)
+            }
+        }
+    }
+
+    fn parent_closed(&self, button: &Self::Type) {
+        unsafe {
+            let data = T::type_data();
+            let parent_class = data.as_ref().get_parent_class() as *mut gtk_sys::GtkPopoverClass;
+            if let Some(f) = (*parent_class).closed {
+                f(button.unsafe_cast_ref::<Popover>().to_glib_none().0)
+            }
+        }
+    }
+}
+
+unsafe impl<T: PopoverImpl> IsSubclassable<T> for Popover {
+    fn override_vfuncs(class: &mut glib::Class<Self>) {
+        <Widget as IsSubclassable<T>>::override_vfuncs(class);
+
+        let klass = class.as_mut();
+        klass.activate_default = Some(popover_activate_default::<T>);
+        klass.closed = Some(popover_closed::<T>);
+    }
+}
+
+unsafe extern "C" fn popover_activate_default<T: PopoverImpl>(ptr: *mut gtk_sys::GtkPopover) {
+    let instance = &*(ptr as *mut T::Instance);
+    let imp = instance.get_impl();
+    let wrap: Borrowed<Popover> = from_glib_borrow(ptr);
+
+    imp.activate_default(wrap.unsafe_cast_ref())
+}
+
+unsafe extern "C" fn popover_closed<T: PopoverImpl>(ptr: *mut gtk_sys::GtkPopover) {
+    let instance = &*(ptr as *mut T::Instance);
+    let imp = instance.get_impl();
+    let wrap: Borrowed<Popover> = from_glib_borrow(ptr);
+
+    imp.closed(wrap.unsafe_cast_ref())
+}

--- a/gtk4/src/subclass/style_context.rs
+++ b/gtk4/src/subclass/style_context.rs
@@ -1,0 +1,53 @@
+use gtk_sys;
+
+use glib::subclass::object::ObjectImpl;
+use glib::subclass::prelude::*;
+use glib::translate::*;
+use glib::{Cast, Object};
+
+use StyleContext;
+
+pub trait StyleContextImpl: StyleContextImplExt + ObjectImpl {
+    fn changed(&self, style_context: &Self::Type) {
+        self.parent_changed(style_context)
+    }
+}
+
+pub trait StyleContextImplExt: ObjectSubclass {
+    fn parent_changed(&self, style_context: &Self::Type);
+}
+
+impl<T: StyleContextImpl> StyleContextImplExt for T {
+    fn parent_changed(&self, style_context: &Self::Type) {
+        unsafe {
+            let data = T::type_data();
+            let parent_class =
+                data.as_ref().get_parent_class() as *mut gtk_sys::GtkStyleContextClass;
+            if let Some(f) = (*parent_class).changed {
+                f(style_context
+                    .unsafe_cast_ref::<StyleContext>()
+                    .to_glib_none()
+                    .0)
+            }
+        }
+    }
+}
+
+unsafe impl<T: StyleContextImpl> IsSubclassable<T> for StyleContext {
+    fn override_vfuncs(class: &mut glib::Class<Self>) {
+        <Object as IsSubclassable<T>>::override_vfuncs(class);
+
+        let klass = class.as_mut();
+        klass.changed = Some(style_context_changed::<T>);
+    }
+}
+
+unsafe extern "C" fn style_context_changed<T: StyleContextImpl>(
+    ptr: *mut gtk_sys::GtkStyleContext,
+) {
+    let instance = &*(ptr as *mut T::Instance);
+    let imp = instance.get_impl();
+    let wrap: Borrowed<StyleContext> = from_glib_borrow(ptr);
+
+    imp.changed(wrap.unsafe_cast_ref())
+}

--- a/gtk4/src/subclass/toggle_button.rs
+++ b/gtk4/src/subclass/toggle_button.rs
@@ -1,0 +1,54 @@
+use gtk_sys;
+
+use glib::subclass::prelude::*;
+use glib::translate::*;
+use glib::Cast;
+
+use super::button::ButtonImpl;
+use Button;
+use ToggleButton;
+
+pub trait ToggleButtonImpl: ToggleButtonImplExt + ButtonImpl {
+    fn toggled(&self, toggle_button: &Self::Type) {
+        self.parent_toggled(toggle_button)
+    }
+}
+
+pub trait ToggleButtonImplExt: ObjectSubclass {
+    fn parent_toggled(&self, toggle_button: &Self::Type);
+}
+
+impl<T: ToggleButtonImpl> ToggleButtonImplExt for T {
+    fn parent_toggled(&self, toggle_button: &Self::Type) {
+        unsafe {
+            let data = T::type_data();
+            let parent_class =
+                data.as_ref().get_parent_class() as *mut gtk_sys::GtkToggleButtonClass;
+            if let Some(f) = (*parent_class).toggled {
+                f(toggle_button
+                    .unsafe_cast_ref::<ToggleButton>()
+                    .to_glib_none()
+                    .0)
+            }
+        }
+    }
+}
+
+unsafe impl<T: ToggleButtonImpl> IsSubclassable<T> for ToggleButton {
+    fn override_vfuncs(class: &mut glib::Class<Self>) {
+        <Button as IsSubclassable<T>>::override_vfuncs(class);
+
+        let klass = class.as_mut();
+        klass.toggled = Some(toggle_button_toggled::<T>);
+    }
+}
+
+unsafe extern "C" fn toggle_button_toggled<T: ToggleButtonImpl>(
+    ptr: *mut gtk_sys::GtkToggleButton,
+) {
+    let instance = &*(ptr as *mut T::Instance);
+    let imp = instance.get_impl();
+    let wrap: Borrowed<ToggleButton> = from_glib_borrow(ptr);
+
+    imp.toggled(wrap.unsafe_cast_ref())
+}


### PR DESCRIPTION
Add subclassing support of the following widgets/types

- `GtkPopover`
- `GtkToggleButton`
- `GtkCheckButton`
- `GtkEntry`
- `GtkNativeDialog`
- `GtkStyleContext`

Fixes/updates 
- `GtkDialog`

Part of #56 