### PR TITLE
Examples: add video player/entry 

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -40,4 +40,7 @@ name = "entry_undo"
 name = "text_viewer"
 
 [[bin]]
+name = "video_player"
+
+[[bin]]
 name = "widget_subclass"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -34,6 +34,9 @@ name = "css"
 name = "entry_completion"
 
 [[bin]]
+name = "entry_undo"
+
+[[bin]]
 name = "text_viewer"
 
 [[bin]]

--- a/examples/src/bin/entry_undo.rs
+++ b/examples/src/bin/entry_undo.rs
@@ -1,0 +1,42 @@
+//! # Entry: Enabling undo
+
+use gtk::prelude::*;
+use std::env::args;
+
+fn build_ui(application: &gtk::Application) {
+    let window = gtk::ApplicationWindow::new(application);
+
+    window.set_title(Some("Entry Undo"));
+    window.set_default_size(450, 250);
+
+    let vbox = gtk::Box::new(gtk::Orientation::Vertical, 12);
+    vbox.set_halign(gtk::Align::Center);
+    vbox.set_valign(gtk::Align::Center);
+
+    let label = gtk::Label::new(Some(
+        "Use Control + Z or Control + Shift + Z to redo changes",
+    ));
+    vbox.append(&label);
+
+    let entry = gtk::Entry::new();
+    entry.set_enable_undo(true);
+    vbox.append(&entry);
+
+    window.set_child(Some(&vbox));
+
+    window.show();
+}
+
+fn main() {
+    let application = gtk::Application::new(
+        Some("com.github.gtk-rs.examples.entry-undo"),
+        Default::default(),
+    )
+    .expect("Initialization failed...");
+
+    application.connect_activate(|app| {
+        build_ui(app);
+    });
+
+    application.run(&args().collect::<Vec<_>>());
+}

--- a/examples/src/bin/ui/builder_basics.ui
+++ b/examples/src/bin/ui/builder_basics.ui
@@ -2,8 +2,8 @@
 <interface>
   <object class="GtkApplicationWindow" id="window">
     <property name="title" translatable="yes">Builder Basics</property>
-    <property name="default_width">320</property>
-    <property name="default_height">240</property>
+    <property name="default-width">320</property>
+    <property name="default-height">240</property>
     <child>
       <object class="GtkButton" id="button">
         <property name="label" translatable="yes">Big Useless Button</property>

--- a/examples/src/bin/ui/text_viewer.ui
+++ b/examples/src/bin/ui/text_viewer.ui
@@ -2,8 +2,8 @@
 <interface>
   <object class="GtkApplicationWindow" id="window">
     <property name="title" translatable="yes">Text File Viewer</property>
-    <property name="default_width">400</property>
-    <property name="default_height">480</property>
+    <property name="default-width">400</property>
+    <property name="default-height">480</property>
     <child>
       <object class="GtkBox" id="v_box">
         <property name="orientation">vertical</property>

--- a/examples/src/bin/ui/video_player.ui
+++ b/examples/src/bin/ui/video_player.ui
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="VideoPlayerWindow" parent="GtkApplicationWindow">
+    <property name="default_width">600</property>
+    <property name="default_height">300</property>
+    <property name="title">Video Player</property>
+    <child type="titlebar">
+      <object class="GtkHeaderBar">
+        <property name="show_title_buttons">True</property>
+        <child type="start">
+            <object class="GtkButton">
+                <property name="action-name">win.open</property>
+                <property name="label">Open</property>
+            </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkVideo" id="video">
+        <property name="autoplay">True</property>
+        <property name="loop">False</property>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/examples/src/bin/ui/video_player.ui
+++ b/examples/src/bin/ui/video_player.ui
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <template class="VideoPlayerWindow" parent="GtkApplicationWindow">
-    <property name="default_width">600</property>
-    <property name="default_height">300</property>
+    <property name="default-width">600</property>
+    <property name="default-height">300</property>
     <property name="title">Video Player</property>
     <child type="titlebar">
       <object class="GtkHeaderBar">
-        <property name="show_title_buttons">True</property>
+        <property name="show-title-buttons">True</property>
         <child type="start">
             <object class="GtkButton">
                 <property name="action-name">win.open</property>

--- a/examples/src/bin/video_player.rs
+++ b/examples/src/bin/video_player.rs
@@ -1,0 +1,126 @@
+//! # Video Player
+//!
+//! This sample demonstrates how to use GtkVideo to play videos
+
+use glib::clone;
+use glib::subclass::prelude::*;
+use gtk::{gio, glib, prelude::*, CompositeTemplate};
+
+mod imp {
+    use super::*;
+    use glib::subclass;
+    use gtk::subclass::prelude::*;
+
+    #[derive(Debug, CompositeTemplate)]
+    pub struct VideoPlayerWindow {
+        #[template_child(id = "video")]
+        pub video: TemplateChild<gtk::Video>,
+        pub dialog: gtk::FileChooserNative,
+    }
+
+    impl ObjectSubclass for VideoPlayerWindow {
+        const NAME: &'static str = "VideoPlayerWindow";
+        type Type = super::VideoPlayerWindow;
+        type ParentType = gtk::ApplicationWindow;
+        type Instance = subclass::simple::InstanceStruct<Self>;
+        type Class = subclass::simple::ClassStruct<Self>;
+
+        glib::object_subclass!();
+
+        fn new() -> Self {
+            let dialog = gtk::FileChooserNative::new(
+                Some("Open File"),
+                gtk::NONE_WINDOW,
+                gtk::FileChooserAction::Open,
+                Some("Open"),
+                Some("Cancel"),
+            );
+            dialog.set_modal(true);
+
+            let videos_filter = gtk::FileFilter::new();
+            videos_filter.add_mime_type("video/*");
+            videos_filter.set_name(Some("Video"));
+            dialog.add_filter(&videos_filter);
+
+            let audio_filter = gtk::FileFilter::new();
+            audio_filter.add_mime_type("audio/*");
+            audio_filter.set_name(Some("Audio"));
+            dialog.add_filter(&audio_filter);
+
+            Self {
+                dialog,
+                video: TemplateChild::default(),
+            }
+        }
+
+        fn class_init(klass: &mut Self::Class) {
+            let template = include_bytes!("ui/video_player.ui");
+            klass.set_template(template);
+            Self::bind_template_children(klass);
+        }
+
+        fn instance_init(obj: &glib::subclass::InitializingObject<Self::Type>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for VideoPlayerWindow {
+        fn constructed(&self, obj: &Self::Type) {
+            obj.init_actions();
+            self.parent_constructed(obj);
+        }
+    }
+
+    impl WidgetImpl for VideoPlayerWindow {}
+    impl WindowImpl for VideoPlayerWindow {}
+    impl ApplicationWindowImpl for VideoPlayerWindow {}
+}
+
+glib::wrapper! {
+    pub struct VideoPlayerWindow(ObjectSubclass<imp::VideoPlayerWindow>)
+        @extends gtk::Widget, gtk::Window, gtk::ApplicationWindow, @implements gio::ActionMap, gio::ActionGroup;
+}
+
+impl VideoPlayerWindow {
+    pub fn new<P: glib::IsA<gtk::Application>>(app: &P) -> Self {
+        glib::Object::new(&[("application", app)]).expect("Failed to create VideoPlayerWindow")
+    }
+
+    fn init_actions(&self) {
+        let open = gio::SimpleAction::new("open", None);
+
+        open.connect_activate(clone!(@weak self as win => move |_, _| {
+            let self_ = imp::VideoPlayerWindow::from_instance(&win);
+            self_.dialog.set_transient_for(Some(&win));
+            self_.dialog.connect_response(clone!(@weak win => move |d, response| {
+                if response == gtk::ResponseType::Accept {
+                    win.set_video(d.get_file().unwrap());
+                }
+                d.destroy();
+            }));
+
+            self_.dialog.show();
+        }));
+        self.add_action(&open);
+    }
+
+    fn set_video(&self, video: gio::File) {
+        let self_ = imp::VideoPlayerWindow::from_instance(self);
+        self_.video.get().set_file(Some(&video));
+    }
+}
+
+fn main() {
+    let application = gtk::Application::new(
+        Some("com.github.gtk-rs.examples.video_player"),
+        Default::default(),
+    )
+    .expect("Failed to initialize application");
+
+    application.connect_activate(|app| {
+        let win = VideoPlayerWindow::new(app);
+        win.show();
+    });
+
+    application.run(&std::env::args().collect::<Vec<_>>());
+}

--- a/examples/src/bin/widget_subclass.rs
+++ b/examples/src/bin/widget_subclass.rs
@@ -1,9 +1,8 @@
 use std::cell::RefCell;
 use std::env;
 
-use glib::subclass::prelude::*;
+use gtk::glib;
 use gtk::prelude::*;
-use gtk::{gio, glib};
 
 mod imp {
     use super::*;


### PR DESCRIPTION
port two sample examples from C

1 - video player: I decided to use a composite template to avoid having a bunch of Rc<T>

2 - entry that exposes the new history manager on gtktextview/gtkeditable