### PR TITLE
gtk4/subclass: Add composite template support to prelude

### DIFF
--- a/examples/src/bin/composite_template.rs
+++ b/examples/src/bin/composite_template.rs
@@ -11,7 +11,6 @@ mod imp {
     use super::*;
     use glib::subclass;
     use gtk::subclass::prelude::*;
-    use gtk::subclass::widget::*;
 
     /// The private struct, which can hold widgets and other data.
     #[derive(Debug, CompositeTemplate)]

--- a/gtk4/src/subclass/mod.rs
+++ b/gtk4/src/subclass/mod.rs
@@ -68,6 +68,9 @@ pub mod prelude {
     pub use super::text_buffer::TextBufferImpl;
     pub use super::text_view::TextViewImpl;
     pub use super::toggle_button::ToggleButtonImpl;
+    pub use super::widget::CompositeTemplate;
+    pub use super::widget::TemplateChild;
+    pub use super::widget::WidgetClassSubclassExt;
     pub use super::widget::WidgetImpl;
     pub use super::window::WindowImpl;
     pub use gio::subclass::prelude::*;


### PR DESCRIPTION
Gets rid of an extra include.