### PR TITLE
gtk: implement From cmp::Ordering

### DIFF
--- a/gtk4/src/enums.rs
+++ b/gtk4/src/enums.rs
@@ -1,0 +1,25 @@
+use crate::Ordering;
+use std::cmp;
+
+impl From<cmp::Ordering> for Ordering {
+    fn from(o: cmp::Ordering) -> Self {
+        skip_assert_initialized!();
+        match o {
+            cmp::Ordering::Equal => Ordering::Equal,
+            cmp::Ordering::Greater => Ordering::Larger,
+            cmp::Ordering::Less => Ordering::Smaller,
+        }
+    }
+}
+
+impl From<Ordering> for cmp::Ordering {
+    fn from(o: Ordering) -> Self {
+        skip_assert_initialized!();
+        match o {
+            Ordering::Equal => cmp::Ordering::Equal,
+            Ordering::Larger => cmp::Ordering::Greater,
+            Ordering::Smaller => cmp::Ordering::Less,
+            Ordering::__Unknown(_) => unreachable!(),
+        }
+    }
+}

--- a/gtk4/src/lib.rs
+++ b/gtk4/src/lib.rs
@@ -73,6 +73,7 @@ mod editable;
 mod entry;
 mod entry_buffer;
 mod entry_completion;
+mod enums;
 mod file_chooser_dialog;
 mod icon_theme;
 mod im_context_simple;


### PR DESCRIPTION
Makes sense to allow converting between both types pretty easily :) 