### PR TITLE
gdkx11/gdkwayland: export missed dependencies

### DIFF
--- a/gdk4-wayland/src/lib.rs
+++ b/gdk4-wayland/src/lib.rs
@@ -1,6 +1,9 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 pub use ffi;
+pub use gdk;
+pub use gio;
+pub use glib;
 pub use wayland_client;
 
 #[allow(unused_imports)]

--- a/gdk4-x11/src/lib.rs
+++ b/gdk4-x11/src/lib.rs
@@ -3,7 +3,11 @@
 #![allow(deprecated)]
 
 pub use ffi;
+pub use gdk;
+pub use gio;
+pub use glib;
 pub use x11;
+
 #[macro_use]
 mod rt;
 


### PR DESCRIPTION
mostly missed from #105 