### PR TITLE
update bitflags to 1.2

### DIFF
--- a/gdk4/Cargo.toml
+++ b/gdk4/Cargo.toml
@@ -33,7 +33,7 @@ git = "https://github.com/gtk-rs/lgpl-docs"
 
 [dependencies]
 libc = "0.2"
-bitflags = "1.0"
+bitflags = "1.2"
 ffi = { package = "gdk4-sys", path = "./sys" }
 cairo-rs = { git = "https://github.com/gtk-rs/gtk-rs" }
 gdk-pixbuf = { git = "https://github.com/gtk-rs/gtk-rs" }

--- a/gsk4/Cargo.toml
+++ b/gsk4/Cargo.toml
@@ -35,7 +35,7 @@ git = "https://github.com/gtk-rs/lgpl-docs"
 
 [dependencies]
 libc = "0.2"
-bitflags = "1.0"
+bitflags = "1.2"
 ffi = { package = "gsk4-sys", path = "./sys" }
 cairo-rs = { git = "https://github.com/gtk-rs/gtk-rs" }
 glib = { git = "https://github.com/gtk-rs/gtk-rs" }

--- a/gtk4/Cargo.toml
+++ b/gtk4/Cargo.toml
@@ -38,7 +38,7 @@ git = "https://github.com/gtk-rs/lgpl-docs"
 
 [dependencies]
 libc = "0.2"
-bitflags = "1.0"
+bitflags = "1.2"
 field-offset = "0.3"
 once_cell = "1.0"
 ffi =  { package = "gtk4-sys", path = "./sys" }


### PR DESCRIPTION
PR gtk-rs/gtk-rs#230 exists to update bitflags to 1.2.  This should be applied at the same time so cargo can pick a proper version of bitflags.