### PR TITLE
gtk: subclassing round 8

### DIFF
--- a/gtk4/src/subclass/accessible.rs
+++ b/gtk4/src/subclass/accessible.rs
@@ -1,0 +1,14 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::Accessible;
+use glib::subclass::prelude::*;
+
+pub trait AccessibleImpl: ObjectImpl {}
+
+unsafe impl<T: AccessibleImpl> IsImplementable<T> for Accessible {
+    unsafe extern "C" fn interface_init(
+        _iface: glib::ffi::gpointer,
+        _iface_data: glib::ffi::gpointer,
+    ) {
+    }
+}

--- a/gtk4/src/subclass/app_chooser.rs
+++ b/gtk4/src/subclass/app_chooser.rs
@@ -1,0 +1,14 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::AppChooser;
+use glib::subclass::prelude::*;
+
+pub trait AppChooserImpl: ObjectImpl {}
+
+unsafe impl<T: AppChooserImpl> IsImplementable<T> for AppChooser {
+    unsafe extern "C" fn interface_init(
+        _iface: glib::ffi::gpointer,
+        _iface_data: glib::ffi::gpointer,
+    ) {
+    }
+}

--- a/gtk4/src/subclass/constraint_target.rs
+++ b/gtk4/src/subclass/constraint_target.rs
@@ -1,0 +1,14 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::ConstraintTarget;
+use glib::subclass::prelude::*;
+
+pub trait ConstraintTargetImpl: ObjectImpl {}
+
+unsafe impl<T: ConstraintTargetImpl> IsImplementable<T> for ConstraintTarget {
+    unsafe extern "C" fn interface_init(
+        _iface: glib::ffi::gpointer,
+        _iface_data: glib::ffi::gpointer,
+    ) {
+    }
+}

--- a/gtk4/src/subclass/file_chooser.rs
+++ b/gtk4/src/subclass/file_chooser.rs
@@ -1,0 +1,14 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::FileChooser;
+use glib::subclass::prelude::*;
+
+pub trait FileChooserImpl: ObjectImpl {}
+
+unsafe impl<T: FileChooserImpl> IsImplementable<T> for FileChooser {
+    unsafe extern "C" fn interface_init(
+        _iface: glib::ffi::gpointer,
+        _iface_data: glib::ffi::gpointer,
+    ) {
+    }
+}

--- a/gtk4/src/subclass/mod.rs
+++ b/gtk4/src/subclass/mod.rs
@@ -33,6 +33,7 @@ pub mod text_buffer;
 pub mod text_view;
 pub mod toggle_button;
 pub mod tree_drag_dest;
+pub mod tree_drag_source;
 pub mod widget;
 pub mod window;
 
@@ -77,6 +78,7 @@ pub mod prelude {
     pub use super::text_view::TextViewImpl;
     pub use super::toggle_button::ToggleButtonImpl;
     pub use super::tree_drag_dest::TreeDragDestImpl;
+    pub use super::tree_drag_source::TreeDragSourceImpl;
     pub use super::widget::CompositeTemplate;
     pub use super::widget::TemplateChild;
     pub use super::widget::WidgetClassSubclassExt;

--- a/gtk4/src/subclass/mod.rs
+++ b/gtk4/src/subclass/mod.rs
@@ -32,6 +32,7 @@ pub mod style_context;
 pub mod text_buffer;
 pub mod text_view;
 pub mod toggle_button;
+pub mod tree_drag_dest;
 pub mod widget;
 pub mod window;
 
@@ -75,6 +76,7 @@ pub mod prelude {
     pub use super::text_buffer::TextBufferImpl;
     pub use super::text_view::TextViewImpl;
     pub use super::toggle_button::ToggleButtonImpl;
+    pub use super::tree_drag_dest::TreeDragDestImpl;
     pub use super::widget::CompositeTemplate;
     pub use super::widget::TemplateChild;
     pub use super::widget::WidgetClassSubclassExt;

--- a/gtk4/src/subclass/mod.rs
+++ b/gtk4/src/subclass/mod.rs
@@ -1,7 +1,9 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+pub mod accessible;
 pub mod actionable;
 pub mod adjustment;
+pub mod app_chooser;
 pub mod application;
 pub mod application_window;
 pub mod box_;
@@ -9,10 +11,12 @@ pub mod button;
 pub mod cell_renderer;
 pub mod cell_renderer_text;
 pub mod check_button;
+pub mod constraint_target;
 pub mod dialog;
 pub mod drawing_area;
 pub mod editable;
 pub mod entry;
+pub mod file_chooser;
 pub mod filter;
 pub mod flow_box_child;
 pub mod frame;
@@ -21,10 +25,12 @@ pub mod layout_manager;
 pub mod list_box_row;
 pub mod media_file;
 pub mod media_stream;
+pub mod native;
 pub mod native_dialog;
 pub mod orientable;
 pub mod popover;
 pub mod recent_manager;
+pub mod root;
 pub mod scrollable;
 pub mod selection_model;
 pub mod shortcut_manager;
@@ -46,8 +52,10 @@ pub mod prelude {
     #[doc(hidden)]
     pub use glib::subclass::prelude::*;
 
+    pub use super::accessible::AccessibleImpl;
     pub use super::actionable::ActionableImpl;
     pub use super::adjustment::AdjustmentImpl;
+    pub use super::app_chooser::AppChooserImpl;
     pub use super::application::GtkApplicationImpl;
     pub use super::application_window::ApplicationWindowImpl;
     pub use super::box_::BoxImpl;
@@ -55,10 +63,12 @@ pub mod prelude {
     pub use super::cell_renderer::CellRendererImpl;
     pub use super::cell_renderer_text::CellRendererTextImpl;
     pub use super::check_button::CheckButtonImpl;
+    pub use super::constraint_target::ConstraintTargetImpl;
     pub use super::dialog::DialogImpl;
     pub use super::drawing_area::DrawingAreaImpl;
     pub use super::editable::EditableImpl;
     pub use super::entry::EntryImpl;
+    pub use super::file_chooser::FileChooserImpl;
     pub use super::filter::FilterImpl;
     pub use super::flow_box_child::FlowBoxChildImpl;
     pub use super::frame::FrameImpl;
@@ -67,10 +77,12 @@ pub mod prelude {
     pub use super::list_box_row::ListBoxRowImpl;
     pub use super::media_file::MediaFileImpl;
     pub use super::media_stream::MediaStreamImpl;
+    pub use super::native::NativeImpl;
     pub use super::native_dialog::NativeDialogImpl;
     pub use super::orientable::OrientableImpl;
     pub use super::popover::PopoverImpl;
     pub use super::recent_manager::RecentManagerImpl;
+    pub use super::root::RootImpl;
     pub use super::scrollable::ScrollableImpl;
     pub use super::selection_model::SelectionModelImpl;
     pub use super::shortcut_manager::ShortcutManagerImpl;

--- a/gtk4/src/subclass/mod.rs
+++ b/gtk4/src/subclass/mod.rs
@@ -26,6 +26,7 @@ pub mod orientable;
 pub mod popover;
 pub mod recent_manager;
 pub mod scrollable;
+pub mod selection_model;
 pub mod shortcut_manager;
 pub mod sorter;
 pub mod style_context;
@@ -71,6 +72,7 @@ pub mod prelude {
     pub use super::popover::PopoverImpl;
     pub use super::recent_manager::RecentManagerImpl;
     pub use super::scrollable::ScrollableImpl;
+    pub use super::selection_model::SelectionModelImpl;
     pub use super::shortcut_manager::ShortcutManagerImpl;
     pub use super::sorter::SorterImpl;
     pub use super::style_context::StyleContextImpl;

--- a/gtk4/src/subclass/native.rs
+++ b/gtk4/src/subclass/native.rs
@@ -1,0 +1,15 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::subclass::prelude::WidgetImpl;
+use crate::Native;
+use glib::subclass::prelude::*;
+
+pub trait NativeImpl: WidgetImpl {}
+
+unsafe impl<T: NativeImpl> IsImplementable<T> for Native {
+    unsafe extern "C" fn interface_init(
+        _iface: glib::ffi::gpointer,
+        _iface_data: glib::ffi::gpointer,
+    ) {
+    }
+}

--- a/gtk4/src/subclass/root.rs
+++ b/gtk4/src/subclass/root.rs
@@ -1,0 +1,15 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::subclass::prelude::NativeImpl;
+use crate::Root;
+use glib::subclass::prelude::*;
+
+pub trait RootImpl: NativeImpl {}
+
+unsafe impl<T: RootImpl> IsImplementable<T> for Root {
+    unsafe extern "C" fn interface_init(
+        _iface: glib::ffi::gpointer,
+        _iface_data: glib::ffi::gpointer,
+    ) {
+    }
+}

--- a/gtk4/src/subclass/selection_model.rs
+++ b/gtk4/src/subclass/selection_model.rs
@@ -1,0 +1,328 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::{Bitset, SelectionModel};
+use gio::subclass::prelude::*;
+use glib::translate::*;
+use glib::Cast;
+
+pub trait SelectionModelImpl: ObjectImpl + ListModelImpl {
+    fn get_selection_in_range(&self, model: &Self::Type, position: u32, n_items: u32) -> Bitset {
+        unsafe {
+            let type_ = ffi::gtk_selection_model_get_type();
+            let iface = glib::gobject_ffi::g_type_default_interface_ref(type_)
+                as *mut ffi::GtkSelectionModelInterface;
+            assert!(!iface.is_null());
+
+            let ret = ((*iface).get_selection_in_range.as_ref().unwrap())(
+                model.unsafe_cast_ref::<SelectionModel>().to_glib_none().0,
+                position,
+                n_items,
+            );
+
+            glib::gobject_ffi::g_type_default_interface_unref(iface as glib::ffi::gpointer);
+
+            from_glib_full(ret)
+        }
+    }
+
+    fn is_selected(&self, model: &Self::Type, position: u32) -> bool {
+        unsafe {
+            let type_ = ffi::gtk_selection_model_get_type();
+            let iface = glib::gobject_ffi::g_type_default_interface_ref(type_)
+                as *mut ffi::GtkSelectionModelInterface;
+            assert!(!iface.is_null());
+
+            let ret = ((*iface).is_selected.as_ref().unwrap())(
+                model.unsafe_cast_ref::<SelectionModel>().to_glib_none().0,
+                position,
+            );
+
+            glib::gobject_ffi::g_type_default_interface_unref(iface as glib::ffi::gpointer);
+
+            from_glib(ret)
+        }
+    }
+
+    fn select_all(&self, model: &Self::Type) -> bool {
+        unsafe {
+            let type_ = ffi::gtk_selection_model_get_type();
+            let iface = glib::gobject_ffi::g_type_default_interface_ref(type_)
+                as *mut ffi::GtkSelectionModelInterface;
+            assert!(!iface.is_null());
+
+            let ret = ((*iface).select_all.as_ref().unwrap())(
+                model.unsafe_cast_ref::<SelectionModel>().to_glib_none().0,
+            );
+
+            glib::gobject_ffi::g_type_default_interface_unref(iface as glib::ffi::gpointer);
+
+            from_glib(ret)
+        }
+    }
+
+    fn select_item(&self, model: &Self::Type, position: u32, unselect_rest: bool) -> bool {
+        unsafe {
+            let type_ = ffi::gtk_selection_model_get_type();
+            let iface = glib::gobject_ffi::g_type_default_interface_ref(type_)
+                as *mut ffi::GtkSelectionModelInterface;
+            assert!(!iface.is_null());
+
+            let ret = ((*iface).select_item.as_ref().unwrap())(
+                model.unsafe_cast_ref::<SelectionModel>().to_glib_none().0,
+                position,
+                unselect_rest.to_glib(),
+            );
+
+            glib::gobject_ffi::g_type_default_interface_unref(iface as glib::ffi::gpointer);
+
+            from_glib(ret)
+        }
+    }
+
+    fn select_range(
+        &self,
+        model: &Self::Type,
+        position: u32,
+        n_items: u32,
+        unselect_rest: bool,
+    ) -> bool {
+        unsafe {
+            let type_ = ffi::gtk_selection_model_get_type();
+            let iface = glib::gobject_ffi::g_type_default_interface_ref(type_)
+                as *mut ffi::GtkSelectionModelInterface;
+            assert!(!iface.is_null());
+
+            let ret = ((*iface).select_range.as_ref().unwrap())(
+                model.unsafe_cast_ref::<SelectionModel>().to_glib_none().0,
+                position,
+                n_items,
+                unselect_rest.to_glib(),
+            );
+
+            glib::gobject_ffi::g_type_default_interface_unref(iface as glib::ffi::gpointer);
+
+            from_glib(ret)
+        }
+    }
+
+    fn set_selection(&self, model: &Self::Type, selected: &Bitset, mask: &Bitset) -> bool {
+        unsafe {
+            let type_ = ffi::gtk_selection_model_get_type();
+            let iface = glib::gobject_ffi::g_type_default_interface_ref(type_)
+                as *mut ffi::GtkSelectionModelInterface;
+            assert!(!iface.is_null());
+
+            let ret = ((*iface).set_selection.as_ref().unwrap())(
+                model.unsafe_cast_ref::<SelectionModel>().to_glib_none().0,
+                selected.to_glib_none().0,
+                mask.to_glib_none().0,
+            );
+
+            glib::gobject_ffi::g_type_default_interface_unref(iface as glib::ffi::gpointer);
+
+            from_glib(ret)
+        }
+    }
+
+    fn unselect_all(&self, model: &Self::Type) -> bool {
+        unsafe {
+            let type_ = ffi::gtk_selection_model_get_type();
+            let iface = glib::gobject_ffi::g_type_default_interface_ref(type_)
+                as *mut ffi::GtkSelectionModelInterface;
+            assert!(!iface.is_null());
+
+            let ret = ((*iface).unselect_all.as_ref().unwrap())(
+                model.unsafe_cast_ref::<SelectionModel>().to_glib_none().0,
+            );
+
+            glib::gobject_ffi::g_type_default_interface_unref(iface as glib::ffi::gpointer);
+
+            from_glib(ret)
+        }
+    }
+
+    fn unselect_item(&self, model: &Self::Type, position: u32) -> bool {
+        unsafe {
+            let type_ = ffi::gtk_selection_model_get_type();
+            let iface = glib::gobject_ffi::g_type_default_interface_ref(type_)
+                as *mut ffi::GtkSelectionModelInterface;
+            assert!(!iface.is_null());
+
+            let ret = ((*iface).unselect_item.as_ref().unwrap())(
+                model.unsafe_cast_ref::<SelectionModel>().to_glib_none().0,
+                position,
+            );
+
+            glib::gobject_ffi::g_type_default_interface_unref(iface as glib::ffi::gpointer);
+
+            from_glib(ret)
+        }
+    }
+
+    fn unselect_range(&self, model: &Self::Type, position: u32, n_items: u32) -> bool {
+        unsafe {
+            let type_ = ffi::gtk_selection_model_get_type();
+            let iface = glib::gobject_ffi::g_type_default_interface_ref(type_)
+                as *mut ffi::GtkSelectionModelInterface;
+            assert!(!iface.is_null());
+
+            let ret = ((*iface).unselect_range.as_ref().unwrap())(
+                model.unsafe_cast_ref::<SelectionModel>().to_glib_none().0,
+                position,
+                n_items,
+            );
+
+            glib::gobject_ffi::g_type_default_interface_unref(iface as glib::ffi::gpointer);
+
+            from_glib(ret)
+        }
+    }
+}
+
+unsafe impl<T: SelectionModelImpl> IsImplementable<T> for SelectionModel {
+    unsafe extern "C" fn interface_init(
+        iface: glib::ffi::gpointer,
+        _iface_data: glib::ffi::gpointer,
+    ) {
+        let model_iface = &mut *(iface as *mut ffi::GtkSelectionModelInterface);
+        model_iface.get_selection_in_range = Some(model_get_selection_in_range::<T>);
+        model_iface.is_selected = Some(model_is_selected::<T>);
+        model_iface.select_all = Some(model_select_all::<T>);
+        model_iface.select_item = Some(model_select_item::<T>);
+        model_iface.select_range = Some(model_select_range::<T>);
+        model_iface.set_selection = Some(model_set_selection::<T>);
+        model_iface.unselect_all = Some(model_unselect_all::<T>);
+        model_iface.unselect_item = Some(model_unselect_item::<T>);
+        model_iface.unselect_range = Some(model_unselect_range::<T>);
+    }
+}
+
+unsafe extern "C" fn model_get_selection_in_range<T: SelectionModelImpl>(
+    model: *mut ffi::GtkSelectionModel,
+    position: u32,
+    n_items: u32,
+) -> *mut ffi::GtkBitset {
+    let instance = &*(model as *mut T::Instance);
+    let imp = instance.get_impl();
+
+    imp.get_selection_in_range(
+        from_glib_borrow::<_, SelectionModel>(model).unsafe_cast_ref(),
+        position,
+        n_items,
+    )
+    .to_glib_full()
+}
+
+unsafe extern "C" fn model_is_selected<T: SelectionModelImpl>(
+    model: *mut ffi::GtkSelectionModel,
+    position: u32,
+) -> glib::ffi::gboolean {
+    let instance = &*(model as *mut T::Instance);
+    let imp = instance.get_impl();
+
+    imp.is_selected(
+        from_glib_borrow::<_, SelectionModel>(model).unsafe_cast_ref(),
+        position,
+    )
+    .to_glib()
+}
+
+unsafe extern "C" fn model_select_all<T: SelectionModelImpl>(
+    model: *mut ffi::GtkSelectionModel,
+) -> glib::ffi::gboolean {
+    let instance = &*(model as *mut T::Instance);
+    let imp = instance.get_impl();
+
+    imp.select_all(from_glib_borrow::<_, SelectionModel>(model).unsafe_cast_ref())
+        .to_glib()
+}
+
+unsafe extern "C" fn model_select_item<T: SelectionModelImpl>(
+    model: *mut ffi::GtkSelectionModel,
+    position: u32,
+    unselect_rest: glib::ffi::gboolean,
+) -> glib::ffi::gboolean {
+    let instance = &*(model as *mut T::Instance);
+    let imp = instance.get_impl();
+
+    imp.select_item(
+        from_glib_borrow::<_, SelectionModel>(model).unsafe_cast_ref(),
+        position,
+        from_glib(unselect_rest),
+    )
+    .to_glib()
+}
+
+unsafe extern "C" fn model_select_range<T: SelectionModelImpl>(
+    model: *mut ffi::GtkSelectionModel,
+    position: u32,
+    n_items: u32,
+    unselect_rest: glib::ffi::gboolean,
+) -> glib::ffi::gboolean {
+    let instance = &*(model as *mut T::Instance);
+    let imp = instance.get_impl();
+
+    imp.select_range(
+        from_glib_borrow::<_, SelectionModel>(model).unsafe_cast_ref(),
+        position,
+        n_items,
+        from_glib(unselect_rest),
+    )
+    .to_glib()
+}
+
+unsafe extern "C" fn model_set_selection<T: SelectionModelImpl>(
+    model: *mut ffi::GtkSelectionModel,
+    selected_ptr: *mut ffi::GtkBitset,
+    mask_ptr: *mut ffi::GtkBitset,
+) -> glib::ffi::gboolean {
+    let instance = &*(model as *mut T::Instance);
+    let imp = instance.get_impl();
+
+    let wrap: Borrowed<SelectionModel> = from_glib_borrow(model);
+    let selected = from_glib_borrow(selected_ptr);
+    let mask = from_glib_borrow(mask_ptr);
+
+    imp.set_selection(wrap.unsafe_cast_ref(), &selected, &mask)
+        .to_glib()
+}
+
+unsafe extern "C" fn model_unselect_all<T: SelectionModelImpl>(
+    model: *mut ffi::GtkSelectionModel,
+) -> glib::ffi::gboolean {
+    let instance = &*(model as *mut T::Instance);
+    let imp = instance.get_impl();
+
+    imp.unselect_all(from_glib_borrow::<_, SelectionModel>(model).unsafe_cast_ref())
+        .to_glib()
+}
+
+unsafe extern "C" fn model_unselect_item<T: SelectionModelImpl>(
+    model: *mut ffi::GtkSelectionModel,
+    position: u32,
+) -> glib::ffi::gboolean {
+    let instance = &*(model as *mut T::Instance);
+    let imp = instance.get_impl();
+
+    imp.unselect_item(
+        from_glib_borrow::<_, SelectionModel>(model).unsafe_cast_ref(),
+        position,
+    )
+    .to_glib()
+}
+
+unsafe extern "C" fn model_unselect_range<T: SelectionModelImpl>(
+    model: *mut ffi::GtkSelectionModel,
+    position: u32,
+    n_items: u32,
+) -> glib::ffi::gboolean {
+    let instance = &*(model as *mut T::Instance);
+    let imp = instance.get_impl();
+
+    imp.unselect_range(
+        from_glib_borrow::<_, SelectionModel>(model).unsafe_cast_ref(),
+        position,
+        n_items,
+    )
+    .to_glib()
+}

--- a/gtk4/src/subclass/tree_drag_dest.rs
+++ b/gtk4/src/subclass/tree_drag_dest.rs
@@ -1,0 +1,70 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::{TreeDragDest, TreePath};
+use glib::subclass::prelude::*;
+use glib::translate::*;
+use glib::{Cast, Value};
+
+pub trait TreeDragDestImpl: ObjectImpl {
+    fn drag_data_received(
+        &self,
+        tree_drag_dest: &Self::Type,
+        dest: &TreePath,
+        value: Value,
+    ) -> bool;
+    fn row_drop_possible(
+        &self,
+        tree_drag_dest: &Self::Type,
+        dest_path: &TreePath,
+        value: Value,
+    ) -> bool;
+}
+
+unsafe impl<T: TreeDragDestImpl> IsImplementable<T> for TreeDragDest {
+    unsafe extern "C" fn interface_init(
+        iface: glib::ffi::gpointer,
+        _iface_data: glib::ffi::gpointer,
+    ) {
+        let tree_drag_dest_iface = &mut *(iface as *mut ffi::GtkTreeDragDestIface);
+
+        tree_drag_dest_iface.drag_data_received = Some(tree_drag_dest_drag_data_received::<T>);
+        tree_drag_dest_iface.row_drop_possible = Some(tree_drag_dest_row_drop_possible::<T>);
+    }
+}
+
+unsafe extern "C" fn tree_drag_dest_drag_data_received<T: TreeDragDestImpl>(
+    tree_drag_dest: *mut ffi::GtkTreeDragDest,
+    destptr: *mut ffi::GtkTreePath,
+    valueptr: *const glib::gobject_ffi::GValue,
+) -> glib::ffi::gboolean {
+    let instance = &*(tree_drag_dest as *mut T::Instance);
+    let imp = instance.get_impl();
+
+    let dest: Borrowed<TreePath> = from_glib_borrow(destptr);
+    let value: Value = from_glib_none(valueptr);
+
+    imp.drag_data_received(
+        from_glib_borrow::<_, TreeDragDest>(tree_drag_dest).unsafe_cast_ref(),
+        &dest,
+        value,
+    )
+    .to_glib()
+}
+
+unsafe extern "C" fn tree_drag_dest_row_drop_possible<T: TreeDragDestImpl>(
+    tree_drag_dest: *mut ffi::GtkTreeDragDest,
+    destptr: *mut ffi::GtkTreePath,
+    valueptr: *const glib::gobject_ffi::GValue,
+) -> glib::ffi::gboolean {
+    let instance = &*(tree_drag_dest as *mut T::Instance);
+    let imp = instance.get_impl();
+    let dest: Borrowed<TreePath> = from_glib_borrow(destptr);
+    let value: Value = from_glib_none(valueptr);
+
+    imp.row_drop_possible(
+        from_glib_borrow::<_, TreeDragDest>(tree_drag_dest).unsafe_cast_ref(),
+        &dest,
+        value,
+    )
+    .to_glib()
+}

--- a/gtk4/src/subclass/tree_drag_source.rs
+++ b/gtk4/src/subclass/tree_drag_source.rs
@@ -1,0 +1,74 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::{TreeDragSource, TreePath};
+use glib::subclass::prelude::*;
+use glib::translate::*;
+use glib::Cast;
+
+pub trait TreeDragSourceImpl: ObjectImpl {
+    fn row_draggable(&self, _tree_drag_source: &Self::Type, _path: &TreePath) -> bool {
+        // Assume the row is draggable by default
+        true
+    }
+    fn drag_data_get(&self, tree_drag_source: &Self::Type, path: &TreePath)
+        -> gdk::ContentProvider;
+    fn drag_data_delete(&self, tree_drag_source: &Self::Type, path: &TreePath) -> bool;
+}
+
+unsafe impl<T: TreeDragSourceImpl> IsImplementable<T> for TreeDragSource {
+    unsafe extern "C" fn interface_init(
+        iface: glib::ffi::gpointer,
+        _iface_data: glib::ffi::gpointer,
+    ) {
+        let tree_drag_source_iface = &mut *(iface as *mut ffi::GtkTreeDragSourceIface);
+
+        tree_drag_source_iface.row_draggable = Some(tree_drag_source_row_draggable::<T>);
+        tree_drag_source_iface.drag_data_get = Some(tree_drag_source_drag_data_get::<T>);
+        tree_drag_source_iface.drag_data_delete = Some(tree_drag_source_drag_data_delete::<T>);
+    }
+}
+
+unsafe extern "C" fn tree_drag_source_row_draggable<T: TreeDragSourceImpl>(
+    tree_drag_source: *mut ffi::GtkTreeDragSource,
+    pathptr: *mut ffi::GtkTreePath,
+) -> glib::ffi::gboolean {
+    let instance = &*(tree_drag_source as *mut T::Instance);
+    let imp = instance.get_impl();
+
+    let path: Borrowed<TreePath> = from_glib_borrow(pathptr);
+
+    imp.row_draggable(
+        from_glib_borrow::<_, TreeDragSource>(tree_drag_source).unsafe_cast_ref(),
+        &path,
+    )
+    .to_glib()
+}
+
+unsafe extern "C" fn tree_drag_source_drag_data_get<T: TreeDragSourceImpl>(
+    tree_drag_source: *mut ffi::GtkTreeDragSource,
+    pathptr: *mut ffi::GtkTreePath,
+) -> *mut gdk::ffi::GdkContentProvider {
+    let instance = &*(tree_drag_source as *mut T::Instance);
+    let imp = instance.get_impl();
+    let path: Borrowed<TreePath> = from_glib_borrow(pathptr);
+
+    imp.drag_data_get(
+        from_glib_borrow::<_, TreeDragSource>(tree_drag_source).unsafe_cast_ref(),
+        &path,
+    )
+    .to_glib_full()
+}
+
+unsafe extern "C" fn tree_drag_source_drag_data_delete<T: TreeDragSourceImpl>(
+    tree_drag_source: *mut ffi::GtkTreeDragSource,
+    pathptr: *mut ffi::GtkTreePath,
+) -> glib::ffi::gboolean {
+    let instance = &*(tree_drag_source as *mut T::Instance);
+    let imp = instance.get_impl();
+    let path: Borrowed<TreePath> = from_glib_borrow(pathptr);
+    imp.drag_data_delete(
+        from_glib_borrow::<_, TreeDragSource>(tree_drag_source).unsafe_cast_ref(),
+        &path,
+    )
+    .to_glib()
+}


### PR DESCRIPTION
Part of #56 

Adds subclassing support of the following types:

- GtkTreeDragDest
- GtkTreeDragSource
- GtkSelectionModel

Along with the following "empty" interfaces
- GtkAccessible
- GtkAppChooser
- GtkConstraintTarget
- GtkRoot
- GtkNative
