### PR TITLE
subclass/widget: Ensure TemplateChild types are registered

### DIFF
--- a/examples/src/bin/composite_template.ui
+++ b/examples/src/bin/composite_template.ui
@@ -7,6 +7,11 @@
     <child type="titlebar">
       <object class="GtkHeaderBar" id="headerbar">
         <property name="show_title_buttons">True</property>
+        <child type="end">
+          <object class="ExMenuButton" id="menubutton">
+            <property name="halign">center</property>
+          </object>
+        </child>
       </object>
     </child>
     <child>

--- a/examples/src/bin/composite_template_child.ui
+++ b/examples/src/bin/composite_template_child.ui
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="ExMenuButton" parent="GtkWidget">
+    <property name="layout-manager">
+      <object class="GtkBinLayout"/>
+    </property>
+    <child>
+      <object class="GtkToggleButton" id="toggle">
+        <property name="child">
+          <object class="GtkBox">
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="label">Custom Menu</property>
+                <style>
+                  <class name="title"/>
+                </style>
+              </object>
+            </child>
+            <child>
+              <object class="GtkImage">
+                <property name="icon-name">pan-down-symbolic</property>
+              </object>
+            </child>
+          </object>
+        </property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkPopover" id="popover">
+        <property name="child">
+          <object class="GtkLabel">
+            <property name="label">Hello from a custom child widget!</property>
+          </object>
+        </property>
+      </object>
+    </child>
+  </template>
+</interface>
+

--- a/gtk4/src/subclass/widget.rs
+++ b/gtk4/src/subclass/widget.rs
@@ -974,6 +974,8 @@ where
     T: ObjectType + FromGlibPtrNone<*mut <T as ObjectType>::GlibType>,
 {
     fn default() -> Self {
+        T::static_type();
+
         Self {
             ptr: std::ptr::null_mut(),
         }


### PR DESCRIPTION
Ensures types used as TemplateChild<T> are registered.
This gets rid of a step for application developers
using custom types within templates.

Closes https://github.com/gtk-rs/gtk4-rs/issues/116