### PR TITLE
widget: Implement Debug for TickCallbackId

### DIFF
--- a/gtk4/src/widget.rs
+++ b/gtk4/src/widget.rs
@@ -79,6 +79,12 @@ pub struct TickCallbackId {
     widget: WeakRef<Widget>,
 }
 
+impl PartialEq for TickCallbackId {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
 impl TickCallbackId {
     #[doc(alias = "gtk_widget_remove_tick_callback")]
     pub fn remove(self) {

--- a/gtk4/src/widget.rs
+++ b/gtk4/src/widget.rs
@@ -73,6 +73,7 @@ impl<O: IsA<Widget>> WidgetExtManual for O {
     }
 }
 
+#[derive(Debug)]
 pub struct TickCallbackId {
     id: u32,
     widget: WeakRef<Widget>,


### PR DESCRIPTION
So that any custom widget which has to store this id can be derived.