### PR TITLE
gtk: set the controller signals that return inhibit

### DIFF
--- a/gtk4/Gir.toml
+++ b/gtk4/Gir.toml
@@ -70,7 +70,6 @@ generate = [
     "Gtk.EmojiChooser",
     "Gtk.EntryIconPosition",
     "Gtk.EventControllerFocus",
-    "Gtk.EventControllerLegacy",
     "Gtk.EventControllerMotion",
     "Gtk.EventControllerScrollFlags",
     "Gtk.EventSequenceState",
@@ -911,7 +910,6 @@ name = "Gtk.EventController"
 status = "generate"
 trust_return_value_nullability = false
 
-
 [[object]]
 name = "Gtk.EventControllerKey"
 status = "generate"
@@ -927,9 +925,19 @@ trust_return_value_nullability = false
     inhibit = true
 
 [[object]]
+name = "Gtk.EventControllerLegacy"
+status = "generate"
+    [[object.signal]]
+    name = "event"
+    inhibit = true
+
+[[object]]
 name = "Gtk.EventControllerScroll"
 status = "generate"
 generate_builder = true
+    [[object.signal]]
+    name = "scroll"
+    inhibit = true
 
 [[object]]
 name = "Gtk.Expander"

--- a/gtk4/src/auto/event_controller_legacy.rs
+++ b/gtk4/src/auto/event_controller_legacy.rs
@@ -29,12 +29,14 @@ impl EventControllerLegacy {
         }
     }
 
-    pub fn connect_event<F: Fn(&EventControllerLegacy, &gdk::Event) -> bool + 'static>(
+    pub fn connect_event<
+        F: Fn(&EventControllerLegacy, &gdk::Event) -> glib::signal::Inhibit + 'static,
+    >(
         &self,
         f: F,
     ) -> SignalHandlerId {
         unsafe extern "C" fn event_trampoline<
-            F: Fn(&EventControllerLegacy, &gdk::Event) -> bool + 'static,
+            F: Fn(&EventControllerLegacy, &gdk::Event) -> glib::signal::Inhibit + 'static,
         >(
             this: *mut ffi::GtkEventControllerLegacy,
             event: *mut gdk::ffi::GdkEvent,

--- a/gtk4/src/auto/event_controller_scroll.rs
+++ b/gtk4/src/auto/event_controller_scroll.rs
@@ -79,12 +79,14 @@ impl EventControllerScroll {
         }
     }
 
-    pub fn connect_scroll<F: Fn(&EventControllerScroll, f64, f64) -> bool + 'static>(
+    pub fn connect_scroll<
+        F: Fn(&EventControllerScroll, f64, f64) -> glib::signal::Inhibit + 'static,
+    >(
         &self,
         f: F,
     ) -> SignalHandlerId {
         unsafe extern "C" fn scroll_trampoline<
-            F: Fn(&EventControllerScroll, f64, f64) -> bool + 'static,
+            F: Fn(&EventControllerScroll, f64, f64) -> glib::signal::Inhibit + 'static,
         >(
             this: *mut ffi::GtkEventControllerScroll,
             dx: libc::c_double,


### PR DESCRIPTION
For consistency and readability between the various signals.