### PR TITLE
gtk: make sure gtk::disable_setlocale has to be called before gtk::init()

### DIFF
--- a/gtk4/Gir.toml
+++ b/gtk4/Gir.toml
@@ -335,6 +335,9 @@ trust_return_value_nullability = false
     [[object.function]]
     name = "accelerator_valid"
     manual = true # to make use of gdk::keys::Key
+    [[object.function]]
+    name = "disable_setlocale"
+    assertion = "not-initialized"
 
 [[object]]
 name = "Gtk.AboutDialog"

--- a/gtk4/src/auto/functions.rs
+++ b/gtk4/src/auto/functions.rs
@@ -126,7 +126,7 @@ pub fn css_parser_warning_quark() -> glib::Quark {
 
 #[doc(alias = "gtk_disable_setlocale")]
 pub fn disable_setlocale() {
-    assert_initialized_main_thread!();
+    assert_not_initialized!();
     unsafe {
         ffi::gtk_disable_setlocale();
     }


### PR DESCRIPTION


fixes #195