### PR TITLE
misc: bump default features

### DIFF
--- a/gdk4-wayland/Cargo.toml
+++ b/gdk4-wayland/Cargo.toml
@@ -24,9 +24,11 @@ wayland-client = { version = "0.28", features = ["use_system_lib"] }
 
 [dependencies.glib]
 git = "https://github.com/gtk-rs/gtk-rs"
+features = ["v2_66"]
 
 [dependencies.gio]
 git = "https://github.com/gtk-rs/gtk-rs"
+features = ["v2_66"]
 
 [dependencies.gdk]
 path = "../gdk4"

--- a/gdk4-x11/Cargo.toml
+++ b/gdk4-x11/Cargo.toml
@@ -24,9 +24,11 @@ x11 = "2.18"
 
 [dependencies.glib]
 git = "https://github.com/gtk-rs/gtk-rs"
+features = ["v2_66"]
 
 [dependencies.gio]
 git = "https://github.com/gtk-rs/gtk-rs"
+features = ["v2_66"]
 
 [dependencies.gdk]
 path = "../gdk4"

--- a/gdk4/Cargo.toml
+++ b/gdk4/Cargo.toml
@@ -36,11 +36,11 @@ git = "https://github.com/gtk-rs/lgpl-docs"
 libc = "0.2"
 bitflags = "1.0"
 ffi = { package = "gdk4-sys", path = "./sys" }
-cairo-rs = { git = "https://github.com/gtk-rs/gtk-rs" }
+cairo-rs = { git = "https://github.com/gtk-rs/gtk-rs", features = ["v1_14"] }
 gdk-pixbuf = { git = "https://github.com/gtk-rs/gtk-rs" }
-gio = { git = "https://github.com/gtk-rs/gtk-rs", features = ["v2_46"]  }
-glib = { git = "https://github.com/gtk-rs/gtk-rs" }
-pango = { git = "https://github.com/gtk-rs/gtk-rs" }
+gio = { git = "https://github.com/gtk-rs/gtk-rs", features = ["v2_66"] }
+glib = { git = "https://github.com/gtk-rs/gtk-rs", features = ["v2_66"] }
+pango = { git = "https://github.com/gtk-rs/gtk-rs", features = ["v1_46"] }
 
 [dev-dependencies]
 gir-format-check = "^0.1"

--- a/gsk4/Cargo.toml
+++ b/gsk4/Cargo.toml
@@ -38,11 +38,11 @@ git = "https://github.com/gtk-rs/lgpl-docs"
 libc = "0.2"
 bitflags = "1.0"
 ffi = { package = "gsk4-sys", path = "./sys" }
-cairo-rs = { git = "https://github.com/gtk-rs/gtk-rs" }
-glib = { git = "https://github.com/gtk-rs/gtk-rs" }
+cairo-rs = { git = "https://github.com/gtk-rs/gtk-rs", features = ["v1_14"] }
+glib = { git = "https://github.com/gtk-rs/gtk-rs", features = ["v2_66"] }
 gdk = { package = "gdk4", path = "../gdk4" }
 graphene = { package = "graphene-rs", git = "https://github.com/gtk-rs/gtk-rs" }
-pango = { git = "https://github.com/gtk-rs/gtk-rs" }
+pango = { git = "https://github.com/gtk-rs/gtk-rs", features = ["v1_46"] }
 
 [dev-dependencies]
 gir-format-check = "^0.1"

--- a/gtk4/Cargo.toml
+++ b/gtk4/Cargo.toml
@@ -43,9 +43,9 @@ futures-channel = "0.3"
 once_cell = "1.0"
 ffi =  { package = "gtk4-sys", path = "./sys" }
 gtk4-macros =  { path = "../gtk4-macros" }
-cairo-rs = { git = "https://github.com/gtk-rs/gtk-rs" }
-gio = { git = "https://github.com/gtk-rs/gtk-rs", features = ["v2_46"] }
-glib = { git = "https://github.com/gtk-rs/gtk-rs" }
+cairo-rs = { git = "https://github.com/gtk-rs/gtk-rs", features = ["v1_14"] }
+gio = { git = "https://github.com/gtk-rs/gtk-rs", features = ["v2_66"] }
+glib = { git = "https://github.com/gtk-rs/gtk-rs", features = ["v2_66"] }
 gdk = { package = "gdk4", path = "../gdk4" }
 graphene = { package = "graphene-rs", git = "https://github.com/gtk-rs/gtk-rs" }
 gsk = { package = "gsk4", path = "../gsk4" }


### PR DESCRIPTION
this bumps the default features per the requirements of gtk4 to be built
and allows us to expose recent enough glib/gio/cairo

users can still include specific crates with different features if needed

fixes #242