### PR TITLE
Update display of minimum supported Rust version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Those are common with the GTK 3 and GStreamer bindings and are part of the [gtk-
 
 For more information about each crate, please refer to their `README.md` file in their directory.
 
-__Required Rust version__: 1.48+
+## Minimum supported Rust version
+
+Currently, the minimum supported Rust version is `1.48.0`.
 
 ## Documentation
 

--- a/gdk4-wayland/README.md
+++ b/gdk4-wayland/README.md
@@ -4,7 +4,9 @@
 
 Rust bindings of __GDK 4's Wayland backend__, part of [gtk4-rs](https://github.com/gtk-rs/gtk4-rs/).
 
-__Required Rust version__: 1.48+
+## Minimum supported Rust version
+
+Currently, the minimum supported Rust version is `1.48.0`.
 
 ## Documentation
 

--- a/gdk4-x11/README.md
+++ b/gdk4-x11/README.md
@@ -4,7 +4,9 @@
 
 Rust bindings of __GDK 4's X11 backend__, part of [gtk4-rs](https://github.com/gtk-rs/gtk4-rs/).
 
-__Required Rust version__: 1.48+.
+## Minimum supported Rust version
+
+Currently, the minimum supported Rust version is `1.48.0`.
 
 ## Documentation
 

--- a/gdk4/README.md
+++ b/gdk4/README.md
@@ -4,7 +4,9 @@
 
 Rust bindings of __GDK 4__, part of [gtk4-rs](https://github.com/gtk-rs/gtk4-rs/).
 
-__Required Rust version__: 1.48+
+## Minimum supported Rust version
+
+Currently, the minimum supported Rust version is `1.48.0`.
 
 ## Documentation
 

--- a/gsk4/README.md
+++ b/gsk4/README.md
@@ -4,7 +4,9 @@
 
 Rust bindings of __GSK 4__, part of [gtk4-rs](https://github.com/gtk-rs/gtk4-rs/).
 
-__Required Rust version__: 1.48+.
+## Minimum supported Rust version
+
+Currently, the minimum supported Rust version is `1.48.0`.
 
 ## Documentation
 

--- a/gtk4-macros/README.md
+++ b/gtk4-macros/README.md
@@ -4,7 +4,9 @@
 
 Macro helpers for GTK 4 bindings, part of [gtk4-rs](https://github.com/gtk-rs/gtk4-rs/).
 
-__Required Rust version__: 1.48+.
+## Minimum supported Rust version
+
+Currently, the minimum supported Rust version is `1.48.0`.
 
 ## Documentation
 

--- a/gtk4/README.md
+++ b/gtk4/README.md
@@ -4,7 +4,9 @@
 
 Rust bindings of __GTK 4__, part of [gtk4-rs](https://github.com/gtk-rs/gtk4-rs/).
 
-__Required Rust version__: 1.48+.
+## Minimum supported Rust version
+
+Currently, the minimum supported Rust version is `1.48.0`.
 
 ## Documentation
 


### PR DESCRIPTION
To make it look like https://github.com/gtk-rs/gtk-rs/pull/429

cc @bilelmoussaoui 