### PR TITLE
mark EventKind/IsExpression/IsRenderNode as unsafe

### DIFF
--- a/gdk4/src/event.rs
+++ b/gdk4/src/event.rs
@@ -230,7 +230,9 @@ impl fmt::Debug for Event {
     }
 }
 
-pub trait EventKind: StaticType + FromGlibPtrFull<*mut ffi::GdkEvent> + 'static {
+pub unsafe trait EventKind:
+    StaticType + FromGlibPtrFull<*mut ffi::GdkEvent> + 'static
+{
     fn event_types() -> &'static [EventType];
 }
 
@@ -252,7 +254,7 @@ macro_rules! define_event {
             }
         }
 
-        impl EventKind for $rust_type {
+        unsafe impl EventKind for $rust_type {
             fn event_types() -> &'static [EventType] {
                 $event_event_types
             }

--- a/gsk4/src/render_node.rs
+++ b/gsk4/src/render_node.rs
@@ -129,7 +129,7 @@ impl RenderNode {
     }
 }
 
-pub trait IsRenderNode:
+pub unsafe trait IsRenderNode:
     StaticType
     + FromGlibPtrFull<*mut ffi::GskRenderNode>
     + std::convert::AsRef<crate::RenderNode>
@@ -183,7 +183,7 @@ macro_rules! define_render_node {
             }
         }
 
-        impl crate::render_node::IsRenderNode for $rust_type {
+        unsafe impl crate::render_node::IsRenderNode for $rust_type {
             const NODE_TYPE: RenderNodeType = $node_type;
 
             fn upcast(self) -> crate::RenderNode {

--- a/gtk4/src/expression.rs
+++ b/gtk4/src/expression.rs
@@ -30,7 +30,7 @@ impl AsRef<Expression> for Expression {
 
 pub const NONE_EXPRESSION: Option<&Expression> = None;
 
-pub trait IsExpression:
+pub unsafe trait IsExpression:
     glib::StaticType + FromGlibPtrFull<*mut ffi::GtkExpression> + 'static
 {
 }
@@ -269,7 +269,7 @@ macro_rules! define_expression {
             }
         }
 
-        impl IsExpression for $rust_type {}
+        unsafe impl IsExpression for $rust_type {}
 
         impl<'a> glib::value::FromValueOptional<'a> for $rust_type {
             unsafe fn from_value_optional(value: &'a Value) -> Option<Self> {


### PR DESCRIPTION
users shouldn't implement them for their custom types