### PR TITLE
gtk: bind BitsetIter manually

### DIFF
--- a/gtk4/Gir.toml
+++ b/gtk4/Gir.toml
@@ -351,6 +351,7 @@ manual = [
     "Gsk.RoundedRect",
     "Gsk.Shadow",
     "Gsk.Transform",
+    "Gtk.BitsetIter",
     "Gtk.Border",
     "Gtk.ClosureExpression",
     "Gtk.ConstantExpression",

--- a/gtk4/src/bitset_iter.rs
+++ b/gtk4/src/bitset_iter.rs
@@ -138,40 +138,28 @@ impl<'a> ToGlibPtr<'a, *const ffi::GtkBitsetIter> for BitsetIter<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::TEST_THREAD_WORKER;
 
     #[test]
     fn test_bitset_iter() {
-        crate::init().unwrap();
+        TEST_THREAD_WORKER
+            .push(move || {
+                let set = Bitset::new_range(0, 20);
+                let (mut iter, init_value) = BitsetIter::init_first(&set).unwrap();
+                assert_eq!(init_value, 0);
+                assert_eq!(iter.next(), Some(1));
+                assert_eq!(iter.previous(), Some(0));
 
-        let set = Bitset::new_range(0, 20);
-        let (mut iter, init_value) = BitsetIter::init_first(&set).unwrap();
-        assert_eq!(init_value, 0);
-        assert_eq!(iter.next(), Some(1));
-        assert_eq!(iter.previous(), Some(0));
-
-        let set2 = Bitset::new_range(0, 3);
-        let (mut iter, init_val) = BitsetIter::init_last(&set2).unwrap();
-        assert_eq!(init_val, 2);
-        assert_eq!(iter.previous(), Some(1));
-        assert_eq!(iter.previous(), Some(0));
-        assert_eq!(iter.previous(), None);
-        assert!(!iter.is_valid());
-        assert_eq!(iter.next(), Some(1));
-        assert!(iter.is_valid());
-    }
-
-    #[test]
-    fn test_bitset_iter_dropped_bitset() {
-        crate::init().unwrap();
-
-        let set = Bitset::new_range(0, 20);
-        let (mut iter, init_value) = BitsetIter::init_first(&set).unwrap();
-        unsafe {
-            ffi::gtk_bitset_unref(set.to_glib_none().0);
-        };
-        assert_eq!(init_value, 0);
-        assert_eq!(iter.next(), Some(1));
-        assert_eq!(iter.previous(), Some(0));
-        assert!(iter.is_valid());
+                let set2 = Bitset::new_range(0, 3);
+                let (mut iter, init_val) = BitsetIter::init_last(&set2).unwrap();
+                assert_eq!(init_val, 2);
+                assert_eq!(iter.previous(), Some(1));
+                assert_eq!(iter.previous(), Some(0));
+                assert_eq!(iter.previous(), None);
+                assert!(!iter.is_valid());
+                assert_eq!(iter.next(), Some(1));
+                assert!(iter.is_valid());
+            })
+            .expect("Failed to schedule a test call");
     }
 }

--- a/gtk4/src/bitset_iter.rs
+++ b/gtk4/src/bitset_iter.rs
@@ -1,0 +1,177 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::Bitset;
+use glib::translate::*;
+use std::marker::PhantomData;
+
+#[derive(Copy, Clone)]
+pub struct BitsetIter<'a>(ffi::GtkBitsetIter, PhantomData<&'a Bitset>);
+
+impl<'a> BitsetIter<'a> {
+    #[doc(alias = "gtk_bitset_iter_init_at")]
+    pub fn init_at(set: &'a Bitset, target: u32) -> Option<(Self, u32)> {
+        assert_initialized_main_thread!();
+        unsafe {
+            let mut iter = std::mem::MaybeUninit::uninit();
+            let mut value = std::mem::MaybeUninit::uninit();
+            let found: bool = from_glib(ffi::gtk_bitset_iter_init_at(
+                iter.as_mut_ptr(),
+                set.to_glib_none().0,
+                target,
+                value.as_mut_ptr(),
+            ));
+
+            if found {
+                Some((
+                    BitsetIter(iter.assume_init(), PhantomData),
+                    value.assume_init(),
+                ))
+            } else {
+                None
+            }
+        }
+    }
+
+    #[doc(alias = "gtk_bitset_iter_init_first")]
+    pub fn init_first(set: &'a Bitset) -> Option<(Self, u32)> {
+        assert_initialized_main_thread!();
+        unsafe {
+            let mut iter = std::mem::MaybeUninit::uninit();
+            let mut value = std::mem::MaybeUninit::uninit();
+            let found: bool = from_glib(ffi::gtk_bitset_iter_init_first(
+                iter.as_mut_ptr(),
+                set.to_glib_none().0,
+                value.as_mut_ptr(),
+            ));
+            if found {
+                Some((
+                    BitsetIter(iter.assume_init(), PhantomData),
+                    value.assume_init(),
+                ))
+            } else {
+                None
+            }
+        }
+    }
+
+    #[doc(alias = "gtk_bitset_iter_init_last")]
+    pub fn init_last(set: &'a Bitset) -> Option<(Self, u32)> {
+        assert_initialized_main_thread!();
+        unsafe {
+            let mut iter = std::mem::MaybeUninit::uninit();
+            let mut value = std::mem::MaybeUninit::uninit();
+            let found: bool = from_glib(ffi::gtk_bitset_iter_init_last(
+                iter.as_mut_ptr(),
+                set.to_glib_none().0,
+                value.as_mut_ptr(),
+            ));
+            if found {
+                Some((
+                    BitsetIter(iter.assume_init(), PhantomData),
+                    value.assume_init(),
+                ))
+            } else {
+                None
+            }
+        }
+    }
+
+    #[doc(alias = "gtk_bitset_iter_get_value")]
+    pub fn value(&self) -> u32 {
+        unsafe { ffi::gtk_bitset_iter_get_value(self.to_glib_none().0) }
+    }
+
+    #[doc(alias = "gtk_bitset_iter_is_valid")]
+    pub fn is_valid(&self) -> bool {
+        unsafe { from_glib(ffi::gtk_bitset_iter_is_valid(self.to_glib_none().0)) }
+    }
+
+    #[doc(alias = "gtk_bitset_iter_previous")]
+    pub fn previous(&mut self) -> Option<u32> {
+        unsafe {
+            let mut value = std::mem::MaybeUninit::uninit();
+
+            let found: bool = from_glib(ffi::gtk_bitset_iter_previous(
+                &mut self.0 as *mut _,
+                value.as_mut_ptr(),
+            ));
+            if found {
+                Some(value.assume_init())
+            } else {
+                None
+            }
+        }
+    }
+}
+
+impl<'a> Iterator for BitsetIter<'a> {
+    type Item = u32;
+
+    #[doc(alias = "gtk_bitset_iter_next")]
+    fn next(&mut self) -> Option<Self::Item> {
+        unsafe {
+            let mut value = std::mem::MaybeUninit::uninit();
+
+            let found: bool = from_glib(ffi::gtk_bitset_iter_next(
+                &mut self.0 as *mut _,
+                value.as_mut_ptr(),
+            ));
+            if found {
+                Some(value.assume_init())
+            } else {
+                None
+            }
+        }
+    }
+}
+
+#[doc(hidden)]
+impl<'a> ToGlibPtr<'a, *const ffi::GtkBitsetIter> for BitsetIter<'a> {
+    type Storage = &'a Self;
+
+    #[inline]
+    fn to_glib_none(&'a self) -> Stash<*const ffi::GtkBitsetIter, Self> {
+        Stash(&self.0 as *const ffi::GtkBitsetIter, self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bitset_iter() {
+        crate::init().unwrap();
+
+        let set = Bitset::new_range(0, 20);
+        let (mut iter, init_value) = BitsetIter::init_first(&set).unwrap();
+        assert_eq!(init_value, 0);
+        assert_eq!(iter.next(), Some(1));
+        assert_eq!(iter.previous(), Some(0));
+
+        let set2 = Bitset::new_range(0, 3);
+        let (mut iter, init_val) = BitsetIter::init_last(&set2).unwrap();
+        assert_eq!(init_val, 2);
+        assert_eq!(iter.previous(), Some(1));
+        assert_eq!(iter.previous(), Some(0));
+        assert_eq!(iter.previous(), None);
+        assert!(!iter.is_valid());
+        assert_eq!(iter.next(), Some(1));
+        assert!(iter.is_valid());
+    }
+
+    #[test]
+    fn test_bitset_iter_dropped_bitset() {
+        crate::init().unwrap();
+
+        let set = Bitset::new_range(0, 20);
+        let (mut iter, init_value) = BitsetIter::init_first(&set).unwrap();
+        unsafe {
+            ffi::gtk_bitset_unref(set.to_glib_none().0);
+        };
+        assert_eq!(init_value, 0);
+        assert_eq!(iter.next(), Some(1));
+        assert_eq!(iter.previous(), Some(0));
+        assert!(iter.is_valid());
+    }
+}

--- a/gtk4/src/expression.rs
+++ b/gtk4/src/expression.rs
@@ -483,38 +483,40 @@ impl ConstantExpression {
 
 #[cfg(test)]
 mod tests {
-    use glib::StaticType;
-
     use super::*;
+    use crate::TEST_THREAD_WORKER;
+    use glib::StaticType;
 
     #[test]
     fn test_expressions() {
-        crate::init().unwrap();
+        TEST_THREAD_WORKER
+            .push(move || {
+                let _pspec = glib::ParamSpec::expression(
+                    "expression",
+                    "Expression",
+                    "Some Expression",
+                    glib::ParamFlags::CONSTRUCT_ONLY | glib::ParamFlags::READABLE,
+                );
 
-        let _pspec = glib::ParamSpec::expression(
-            "expression",
-            "Expression",
-            "Some Expression",
-            glib::ParamFlags::CONSTRUCT_ONLY | glib::ParamFlags::READABLE,
-        );
+                let _prop_expr = PropertyExpression::new(
+                    crate::StringObject::static_type(),
+                    NONE_EXPRESSION,
+                    "string",
+                );
 
-        let _prop_expr = PropertyExpression::new(
-            crate::StringObject::static_type(),
-            NONE_EXPRESSION,
-            "string",
-        );
+                let obj = crate::IconTheme::new();
+                let expr = ObjectExpression::new(&obj);
+                assert_eq!(expr.object().unwrap(), obj);
 
-        let obj = crate::IconTheme::new();
-        let expr = ObjectExpression::new(&obj);
-        assert_eq!(expr.object().unwrap(), obj);
-
-        let expr1 = ConstantExpression::new(&23);
-        assert_eq!(expr1.value().get::<i32>().unwrap(), 23);
-        let expr2 = ConstantExpression::for_value(&"hello".to_value());
-        assert_eq!(expr2.value().get::<String>().unwrap(), "hello");
-        let expr1 = ConstantExpression::new(&23);
-        assert_eq!(expr1.value().get::<i32>().unwrap(), 23);
-        let expr2 = ConstantExpression::for_value(&"hello".to_value());
-        assert_eq!(expr2.value().get::<String>().unwrap(), "hello");
+                let expr1 = ConstantExpression::new(&23);
+                assert_eq!(expr1.value().get::<i32>().unwrap(), 23);
+                let expr2 = ConstantExpression::for_value(&"hello".to_value());
+                assert_eq!(expr2.value().get::<String>().unwrap(), "hello");
+                let expr1 = ConstantExpression::new(&23);
+                assert_eq!(expr1.value().get::<i32>().unwrap(), 23);
+                let expr2 = ConstantExpression::for_value(&"hello".to_value());
+                assert_eq!(expr2.value().get::<String>().unwrap(), "hello");
+            })
+            .expect("Failed to schedule a test call");
     }
 }

--- a/gtk4/src/lib.rs
+++ b/gtk4/src/lib.rs
@@ -231,6 +231,7 @@ mod accessible;
 mod actionable;
 mod application;
 mod assistant;
+mod bitset_iter;
 mod bool_filter;
 mod border;
 mod builder;
@@ -308,6 +309,7 @@ mod tree_view;
 mod tree_view_column;
 mod widget;
 
+pub use bitset_iter::BitsetIter;
 pub use border::Border;
 pub use css_location::CssLocation;
 pub use expression::{

--- a/gtk4/src/lib.rs
+++ b/gtk4/src/lib.rs
@@ -206,6 +206,18 @@ pub const TEXT_VIEW_PRIORITY_VALIDATE: u32 = ffi::GTK_TEXT_VIEW_PRIORITY_VALIDAT
 #[macro_use]
 mod rt;
 
+#[allow(dead_code)]
+#[cfg(test)]
+pub(crate) static TEST_THREAD_WORKER: once_cell::sync::Lazy<glib::ThreadPool> =
+    once_cell::sync::Lazy::new(|| {
+        let pool = glib::ThreadPool::new_exclusive(1).unwrap();
+        pool.push(move || {
+            crate::init().expect("Tests failed to initialize gtk");
+        })
+        .expect("Failed to schedule a test call");
+        pool
+    });
+
 #[allow(clippy::match_same_arms)]
 #[allow(clippy::let_and_return)]
 #[allow(clippy::many_single_char_names)]

--- a/gtk4/src/subclass/scrollable.rs
+++ b/gtk4/src/subclass/scrollable.rs
@@ -59,7 +59,12 @@ unsafe extern "C" fn scrollable_get_border<T: ScrollableImpl>(
         *borderptr = *border.to_glib_full();
         true.into_glib()
     } else {
-        *borderptr = *std::ptr::null();
+        *borderptr = ffi::GtkBorder {
+            top: 0,
+            right: 0,
+            left: 0,
+            bottom: 0,
+        };
         false.into_glib()
     }
 }


### PR DESCRIPTION
cc @jsparber as you requested it few days ago

sadly the tests has to be disabled as expression's tests initialize gtk already and couldn't find a nice/simple to initialize gtk globally when tests are run or a way to run them on the main thread maybe? no idea how to handle it. 