### PR TITLE
Re-export glib::signal::Inhibit to gtk4 crate root like gtk3's bindings.

### DIFF
--- a/gtk4/src/lib.rs
+++ b/gtk4/src/lib.rs
@@ -328,3 +328,4 @@ pub use requisition::Requisition;
 pub use response_type::ResponseType;
 pub use tree_sortable::SortColumn;
 pub use widget::TickCallbackId;
+pub use glib::signal::Inhibit;

--- a/gtk4/src/lib.rs
+++ b/gtk4/src/lib.rs
@@ -318,6 +318,7 @@ pub use expression::{
 #[cfg_attr(feature = "dox", doc(cfg(target_os = "linux")))]
 pub use flags::PrintCapabilities;
 pub use functions::*;
+pub use glib::signal::Inhibit;
 pub use keyval_trigger::KeyvalTrigger;
 pub use pad_action_entry::PadActionEntry;
 pub use page_range::PageRange;
@@ -326,4 +327,3 @@ pub use requisition::Requisition;
 pub use response_type::ResponseType;
 pub use tree_sortable::SortColumn;
 pub use widget::TickCallbackId;
-pub use glib::signal::Inhibit;

--- a/gtk4/src/lib.rs
+++ b/gtk4/src/lib.rs
@@ -218,8 +218,6 @@ mod rt;
 #[allow(unused_imports)]
 mod auto;
 
-mod signal;
-
 #[macro_use]
 pub mod subclass;
 

--- a/gtk4/src/signal.rs
+++ b/gtk4/src/signal.rs
@@ -1,3 +1,0 @@
-// Take a look at the license at the top of the repository in the LICENSE file.
-
-pub use glib::signal::Inhibit;


### PR DESCRIPTION
This pull request re-exports `glib::signal::Inhibit` to `gtk4`'s crate root like `gtk3`'s bindings.

This will help with gtk-rs developers translating to gtk4-rs as it is not immediately apparent where Inhibit is in the new API.