### PR TITLE
gdk: manually bind ContentFormats::mime_types

### DIFF
--- a/gdk4/Gir.toml
+++ b/gdk4/Gir.toml
@@ -240,6 +240,9 @@ status = "generate"
     [[object.function]]
     name = "get_gtypes"
     manual = true
+    [[object.function]]
+    name = "get_mime_types"
+    manual = true # remove once https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/3488 gets merged
 
 [[object]]
 name = "Gdk.ContentFormatsBuilder"

--- a/gdk4/src/auto/content_formats.rs
+++ b/gdk4/src/auto/content_formats.rs
@@ -4,7 +4,6 @@
 
 use glib::translate::*;
 use std::fmt;
-use std::mem;
 
 glib::wrapper! {
     #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -53,20 +52,6 @@ impl ContentFormats {
                 self.to_glib_none().0,
                 mime_type.to_glib_none().0,
             ))
-        }
-    }
-
-    #[doc(alias = "gdk_content_formats_get_mime_types")]
-    pub fn mime_types(&self) -> (Vec<glib::GString>, usize) {
-        unsafe {
-            let mut n_mime_types = mem::MaybeUninit::uninit();
-            let ret =
-                FromGlibPtrContainer::from_glib_none(ffi::gdk_content_formats_get_mime_types(
-                    self.to_glib_none().0,
-                    n_mime_types.as_mut_ptr(),
-                ));
-            let n_mime_types = n_mime_types.assume_init();
-            (ret, n_mime_types)
         }
     }
 

--- a/gdk4/src/content_formats.rs
+++ b/gdk4/src/content_formats.rs
@@ -14,4 +14,19 @@ impl ContentFormats {
             FromGlibContainer::from_glib_container_num(types, n_types.assume_init() as usize)
         }
     }
+
+    #[doc(alias = "gdk_content_formats_get_mime_types")]
+    pub fn mime_types(&self) -> Vec<glib::GString> {
+        unsafe {
+            let mut n_mime_types = std::mem::MaybeUninit::uninit();
+            let mime_types = ffi::gdk_content_formats_get_mime_types(
+                self.to_glib_none().0,
+                n_mime_types.as_mut_ptr(),
+            );
+            FromGlibContainer::from_glib_container_num(
+                mime_types,
+                n_mime_types.assume_init() as usize,
+            )
+        }
+    }
 }


### PR DESCRIPTION
Until https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/3488 gets merged
& shows up in a future Gir file.

Fixes #334