### PR TITLE
split expressions/events to multiple files

### DIFF
--- a/gdk4/Gir.toml
+++ b/gdk4/Gir.toml
@@ -62,7 +62,6 @@ manual = [
     "Gdk.CrossingEvent",
     "Gdk.DeleteEvent",
     "Gdk.DNDEvent",
-    "Gdk.Event", # Fundemental type, manual
     "Gdk.FocusEvent",
     "Gdk.GrabBrokenEvent",
     "Gdk.KeyEvent",
@@ -402,6 +401,11 @@ status = "generate"
     [[object.function]]
     name = "read_async"
     manual = true # const ptr
+
+[[object]]
+name = "Gdk.Event"
+status = "manual" # fundemental type
+final_type = true # avoids the usage of EventExt trait
 
 [[object]]
 name = "Gdk.GLTexture"

--- a/gdk4/src/button_event.rs
+++ b/gdk4/src/button_event.rs
@@ -1,0 +1,27 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::EventType;
+use glib::translate::*;
+use std::fmt;
+
+define_event! {
+    ButtonEvent,
+    ffi::GdkButtonEvent,
+    ffi::gdk_button_event_get_type,
+    &[EventType::ButtonPress, EventType::ButtonRelease]
+}
+
+impl ButtonEvent {
+    #[doc(alias = "gdk_button_event_get_button")]
+    pub fn button(&self) -> u32 {
+        unsafe { ffi::gdk_button_event_get_button(self.to_glib_none().0) }
+    }
+}
+
+impl fmt::Display for ButtonEvent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("ButtonEvent")
+            .field("button", &self.button())
+            .finish()
+    }
+}

--- a/gdk4/src/crossing_event.rs
+++ b/gdk4/src/crossing_event.rs
@@ -1,0 +1,39 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::{CrossingMode, EventType, NotifyType};
+use glib::translate::*;
+use std::fmt;
+
+define_event! {
+    CrossingEvent,
+    ffi::GdkCrossingEvent,
+    ffi::gdk_crossing_event_get_type,
+    &[EventType::EnterNotify, EventType::LeaveNotify]
+}
+
+impl CrossingEvent {
+    #[doc(alias = "gdk_crossing_event_get_detail")]
+    pub fn detail(&self) -> NotifyType {
+        unsafe { from_glib(ffi::gdk_crossing_event_get_detail(self.to_glib_none().0)) }
+    }
+
+    #[doc(alias = "gdk_crossing_event_get_focus")]
+    pub fn gets_focus(&self) -> bool {
+        unsafe { from_glib(ffi::gdk_crossing_event_get_focus(self.to_glib_none().0)) }
+    }
+
+    #[doc(alias = "gdk_crossing_event_get_mode")]
+    pub fn mode(&self) -> CrossingMode {
+        unsafe { from_glib(ffi::gdk_crossing_event_get_mode(self.to_glib_none().0)) }
+    }
+}
+
+impl fmt::Display for CrossingEvent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("PadEvent")
+            .field("detail", &self.detail())
+            .field("focus", &self.gets_focus())
+            .field("mode", &self.mode())
+            .finish()
+    }
+}

--- a/gdk4/src/delete_event.rs
+++ b/gdk4/src/delete_event.rs
@@ -1,0 +1,18 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::EventType;
+use glib::translate::*;
+use std::fmt;
+
+define_event! {
+    DeleteEvent,
+    ffi::GdkDeleteEvent,
+    ffi::gdk_delete_event_get_type,
+    &[EventType::Delete]
+}
+
+impl fmt::Display for DeleteEvent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("DeleteEvent")
+    }
+}

--- a/gdk4/src/dnd_event.rs
+++ b/gdk4/src/dnd_event.rs
@@ -1,0 +1,27 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::{Drop, EventType};
+use glib::translate::*;
+use std::fmt;
+
+define_event! {
+    DNDEvent,
+    ffi::GdkDNDEvent,
+    ffi::gdk_dnd_event_get_type,
+    &[EventType::DragEnter, EventType::DragLeave, EventType::DragMotion, EventType::DropStart]
+}
+
+impl DNDEvent {
+    #[doc(alias = "gdk_dnd_event_get_drop")]
+    pub fn drop(&self) -> Option<Drop> {
+        unsafe { from_glib_none(ffi::gdk_dnd_event_get_drop(self.to_glib_none().0)) }
+    }
+}
+
+impl fmt::Display for DNDEvent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("DNDEvent")
+            .field("drop", &self.drop())
+            .finish()
+    }
+}

--- a/gdk4/src/focus_event.rs
+++ b/gdk4/src/focus_event.rs
@@ -1,0 +1,27 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::EventType;
+use glib::translate::*;
+use std::fmt;
+
+define_event! {
+    FocusEvent,
+    ffi::GdkFocusEvent,
+    ffi::gdk_focus_event_get_type,
+    &[EventType::FocusChange]
+}
+
+impl FocusEvent {
+    #[doc(alias = "gdk_focus_event_get_in")]
+    pub fn is_in(&self) -> bool {
+        unsafe { from_glib(ffi::gdk_focus_event_get_in(self.to_glib_none().0)) }
+    }
+}
+
+impl fmt::Display for FocusEvent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("FocusEvent")
+            .field("in", &self.is_in())
+            .finish()
+    }
+}

--- a/gdk4/src/grab_broken_event.rs
+++ b/gdk4/src/grab_broken_event.rs
@@ -1,0 +1,41 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::{EventType, Surface};
+use glib::translate::*;
+use std::fmt;
+
+define_event! {
+    GrabBrokenEvent,
+    ffi::GdkGrabBrokenEvent,
+    ffi::gdk_grab_broken_event_get_type,
+    &[EventType::GrabBroken]
+}
+
+impl GrabBrokenEvent {
+    #[doc(alias = "gdk_grab_broken_event_get_grab_surface")]
+    pub fn grab_surface(&self) -> Option<Surface> {
+        unsafe {
+            from_glib_none(ffi::gdk_grab_broken_event_get_grab_surface(
+                self.to_glib_none().0,
+            ))
+        }
+    }
+
+    #[doc(alias = "gdk_grab_broken_event_get_implicit")]
+    pub fn is_implicit(&self) -> bool {
+        unsafe {
+            from_glib(ffi::gdk_grab_broken_event_get_implicit(
+                self.to_glib_none().0,
+            ))
+        }
+    }
+}
+
+impl fmt::Display for GrabBrokenEvent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("GrabBrokenEvent")
+            .field("grab_surface", &self.grab_surface())
+            .field("implicit", &self.is_implicit())
+            .finish()
+    }
+}

--- a/gdk4/src/key_event.rs
+++ b/gdk4/src/key_event.rs
@@ -1,0 +1,93 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::{keys::Key, EventType, KeyMatch, ModifierType};
+use glib::translate::*;
+use std::fmt;
+use std::mem;
+
+define_event! {
+    KeyEvent,
+    ffi::GdkKeyEvent,
+    ffi::gdk_key_event_get_type,
+    &[EventType::KeyPress, EventType::KeyRelease]
+}
+
+impl KeyEvent {
+    #[doc(alias = "gdk_key_event_get_consumed_modifiers")]
+    pub fn consumed_modifiers(&self) -> ModifierType {
+        unsafe {
+            from_glib(ffi::gdk_key_event_get_consumed_modifiers(
+                self.to_glib_none().0,
+            ))
+        }
+    }
+
+    #[doc(alias = "gdk_key_event_get_keycode")]
+    pub fn keycode(&self) -> u32 {
+        unsafe { ffi::gdk_key_event_get_keycode(self.to_glib_none().0) }
+    }
+    #[doc(alias = "gdk_key_event_get_keyval")]
+    pub fn keyval(&self) -> Key {
+        unsafe { ffi::gdk_key_event_get_keyval(self.to_glib_none().0).into() }
+    }
+
+    #[doc(alias = "gdk_key_event_get_layout")]
+    pub fn layout(&self) -> u32 {
+        unsafe { ffi::gdk_key_event_get_layout(self.to_glib_none().0) }
+    }
+
+    #[doc(alias = "gdk_key_event_get_level")]
+    pub fn level(&self) -> u32 {
+        unsafe { ffi::gdk_key_event_get_level(self.to_glib_none().0) }
+    }
+
+    #[doc(alias = "gdk_key_event_get_match")]
+    pub fn match_(&self) -> Option<(Key, ModifierType)> {
+        unsafe {
+            let mut keyval = mem::MaybeUninit::uninit();
+            let mut modifiers = mem::MaybeUninit::uninit();
+            let ret = from_glib(ffi::gdk_key_event_get_match(
+                self.to_glib_none().0,
+                keyval.as_mut_ptr(),
+                modifiers.as_mut_ptr(),
+            ));
+            if ret {
+                let keyval: Key = keyval.assume_init().into();
+                let modifiers = modifiers.assume_init();
+                Some((keyval, from_glib(modifiers)))
+            } else {
+                None
+            }
+        }
+    }
+
+    #[doc(alias = "gdk_key_event_is_modifier")]
+    pub fn is_modifier(&self) -> bool {
+        unsafe { from_glib(ffi::gdk_key_event_is_modifier(self.to_glib_none().0)) }
+    }
+
+    #[doc(alias = "gdk_key_event_matches")]
+    pub fn matches(&self, keyval: Key, modifiers: ModifierType) -> KeyMatch {
+        unsafe {
+            from_glib(ffi::gdk_key_event_matches(
+                self.to_glib_none().0,
+                keyval.into_glib(),
+                modifiers.into_glib(),
+            ))
+        }
+    }
+}
+
+impl fmt::Display for KeyEvent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("KeyEvent")
+            .field("consumed_modifiers", &self.consumed_modifiers())
+            .field("keycode", &self.keycode())
+            .field("keyval", &self.keyval())
+            .field("layout", &self.layout())
+            .field("level", &self.level())
+            .field("match", &self.match_())
+            .field("is_modifier", &self.is_modifier())
+            .finish()
+    }
+}

--- a/gdk4/src/lib.rs
+++ b/gdk4/src/lib.rs
@@ -38,32 +38,47 @@ macro_rules! skip_assert_initialized {
 #[allow(unused_imports)]
 mod auto;
 
+#[macro_use]
+mod event;
+
 mod alias;
 pub mod prelude;
 pub mod subclass;
 
+mod button_event;
 mod cairo_interaction;
 mod clipboard;
 mod content_deserializer;
 mod content_formats;
 mod content_formats_builder;
 mod content_provider;
+mod crossing_event;
+mod delete_event;
 mod display;
+mod dnd_event;
 mod draw_context;
 mod drop;
-mod event;
+mod focus_event;
 mod functions;
 mod gl_texture;
+mod grab_broken_event;
+mod key_event;
 mod keymap_key;
 pub mod keys;
+mod motion_event;
+mod pad_event;
 mod popup_layout;
+mod proximity_event;
 mod rectangle;
 mod rgba;
+mod scroll_event;
 mod surface;
 mod texture;
 mod time_coord;
 mod toplevel;
 mod toplevel_size;
+mod touch_event;
+mod touchpad_event;
 
 pub use self::auto::functions::*;
 pub use auto::*;
@@ -71,12 +86,25 @@ pub use auto::*;
 pub use alias::*;
 pub use functions::*;
 
-pub use event::*;
+pub use button_event::ButtonEvent;
+pub use crossing_event::CrossingEvent;
+pub use delete_event::DeleteEvent;
+pub use dnd_event::DNDEvent;
+pub use event::{Event, NONE_EVENT};
+pub use focus_event::FocusEvent;
+pub use grab_broken_event::GrabBrokenEvent;
+pub use key_event::KeyEvent;
 pub use keymap_key::KeymapKey;
+pub use motion_event::MotionEvent;
+pub use pad_event::PadEvent;
+pub use proximity_event::ProximityEvent;
 pub use rectangle::Rectangle;
 pub use rgba::{RgbaParseError, RGBA};
+pub use scroll_event::ScrollEvent;
 pub use time_coord::TimeCoord;
 pub use toplevel_size::ToplevelSize;
+pub use touch_event::TouchEvent;
+pub use touchpad_event::TouchpadEvent;
 
 // This is the priority that the idle handler processing surface updates is given in the glib::MainLoop.
 #[doc(alias = "GDK_PRIORITY_REDRAW")]

--- a/gdk4/src/motion_event.rs
+++ b/gdk4/src/motion_event.rs
@@ -1,0 +1,18 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::EventType;
+use glib::translate::*;
+use std::fmt;
+
+define_event! {
+    MotionEvent,
+    ffi::GdkMotionEvent,
+    ffi::gdk_motion_event_get_type,
+    &[EventType::MotionNotify]
+}
+
+impl fmt::Display for MotionEvent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("MotionEvent")
+    }
+}

--- a/gdk4/src/pad_event.rs
+++ b/gdk4/src/pad_event.rs
@@ -1,0 +1,62 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::EventType;
+use glib::translate::*;
+use std::fmt;
+use std::mem;
+
+define_event! {
+    PadEvent,
+    ffi::GdkPadEvent,
+    ffi::gdk_pad_event_get_type,
+    &[EventType::PadButtonPress, EventType::PadButtonRelease, EventType::PadRing, EventType::PadStrip, EventType::PadGroupMode]
+}
+
+impl PadEvent {
+    #[doc(alias = "gdk_pad_event_get_axis_value")]
+    pub fn axis_value(&self) -> (u32, f64) {
+        unsafe {
+            let mut index = mem::MaybeUninit::uninit();
+            let mut value = mem::MaybeUninit::uninit();
+            ffi::gdk_pad_event_get_axis_value(
+                self.to_glib_none().0,
+                index.as_mut_ptr(),
+                value.as_mut_ptr(),
+            );
+            let index = index.assume_init();
+            let value = value.assume_init();
+            (index, value)
+        }
+    }
+
+    #[doc(alias = "gdk_pad_event_get_button")]
+    pub fn button(&self) -> u32 {
+        unsafe { ffi::gdk_pad_event_get_button(self.to_glib_none().0) }
+    }
+
+    #[doc(alias = "gdk_pad_event_get_group_mode")]
+    pub fn group_mode(&self) -> (u32, u32) {
+        unsafe {
+            let mut group = mem::MaybeUninit::uninit();
+            let mut mode = mem::MaybeUninit::uninit();
+            ffi::gdk_pad_event_get_group_mode(
+                self.to_glib_none().0,
+                group.as_mut_ptr(),
+                mode.as_mut_ptr(),
+            );
+            let group = group.assume_init();
+            let mode = mode.assume_init();
+            (group, mode)
+        }
+    }
+}
+
+impl fmt::Display for PadEvent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("PadEvent")
+            .field("axis_value", &self.axis_value())
+            .field("button", &self.button())
+            .field("group_mode", &self.group_mode())
+            .finish()
+    }
+}

--- a/gdk4/src/proximity_event.rs
+++ b/gdk4/src/proximity_event.rs
@@ -1,0 +1,18 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::EventType;
+use glib::translate::*;
+use std::fmt;
+
+define_event! {
+    ProximityEvent,
+    ffi::GdkProximityEvent,
+    ffi::gdk_proximity_event_get_type,
+    &[EventType::ProximityIn, EventType::ProximityOut]
+}
+
+impl fmt::Display for ProximityEvent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("ProximityEvent")
+    }
+}

--- a/gdk4/src/scroll_event.rs
+++ b/gdk4/src/scroll_event.rs
@@ -1,0 +1,51 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::{EventType, ScrollDirection};
+use glib::translate::*;
+use std::fmt;
+use std::mem;
+
+define_event! {
+    ScrollEvent,
+    ffi::GdkScrollEvent,
+    ffi::gdk_scroll_event_get_type,
+    &[EventType::Scroll]
+}
+
+impl ScrollEvent {
+    #[doc(alias = "gdk_scroll_event_get_deltas")]
+    pub fn deltas(&self) -> (f64, f64) {
+        unsafe {
+            let mut delta_x = mem::MaybeUninit::uninit();
+            let mut delta_y = mem::MaybeUninit::uninit();
+            ffi::gdk_scroll_event_get_deltas(
+                self.to_glib_none().0,
+                delta_x.as_mut_ptr(),
+                delta_y.as_mut_ptr(),
+            );
+            let delta_x = delta_x.assume_init();
+            let delta_y = delta_y.assume_init();
+            (delta_x, delta_y)
+        }
+    }
+
+    #[doc(alias = "gdk_scroll_event_get_direction")]
+    pub fn direction(&self) -> ScrollDirection {
+        unsafe { from_glib(ffi::gdk_scroll_event_get_direction(self.to_glib_none().0)) }
+    }
+
+    #[doc(alias = "gdk_scroll_event_is_stop")]
+    pub fn is_stop(&self) -> bool {
+        unsafe { from_glib(ffi::gdk_scroll_event_is_stop(self.to_glib_none().0)) }
+    }
+}
+
+impl fmt::Display for ScrollEvent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("ScrollEvent")
+            .field("deltas", &self.deltas())
+            .field("direction", &self.direction())
+            .field("is_stop", &self.is_stop())
+            .finish()
+    }
+}

--- a/gdk4/src/touch_event.rs
+++ b/gdk4/src/touch_event.rs
@@ -1,0 +1,31 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::EventType;
+use glib::translate::*;
+use std::fmt;
+
+define_event! {
+    TouchEvent,
+    ffi::GdkTouchEvent,
+    ffi::gdk_touch_event_get_type,
+    &[EventType::TouchBegin, EventType::TouchUpdate, EventType::TouchEnd, EventType::TouchCancel]
+}
+
+impl TouchEvent {
+    #[doc(alias = "gdk_touch_event_get_emulating_pointer")]
+    pub fn emulates_pointer(&self) -> bool {
+        unsafe {
+            from_glib(ffi::gdk_touch_event_get_emulating_pointer(
+                self.to_glib_none().0,
+            ))
+        }
+    }
+}
+
+impl fmt::Display for TouchEvent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("TouchEvent")
+            .field("emulating_pointer", &self.emulates_pointer())
+            .finish()
+    }
+}

--- a/gdk4/src/touchpad_event.rs
+++ b/gdk4/src/touchpad_event.rs
@@ -1,0 +1,67 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::{EventType, TouchpadGesturePhase};
+use glib::translate::*;
+use std::fmt;
+use std::mem;
+
+define_event! {
+    TouchpadEvent,
+    ffi::GdkTouchpadEvent,
+    ffi::gdk_touchpad_event_get_type,
+    &[EventType::TouchpadSwipe, EventType::TouchpadPinch]
+}
+
+impl TouchpadEvent {
+    #[doc(alias = "gdk_touchpad_event_get_deltas")]
+    pub fn deltas(&self) -> (f64, f64) {
+        unsafe {
+            let mut dx = mem::MaybeUninit::uninit();
+            let mut dy = mem::MaybeUninit::uninit();
+            ffi::gdk_touchpad_event_get_deltas(
+                self.to_glib_none().0,
+                dx.as_mut_ptr(),
+                dy.as_mut_ptr(),
+            );
+            let dx = dx.assume_init();
+            let dy = dy.assume_init();
+            (dx, dy)
+        }
+    }
+
+    #[doc(alias = "gdk_touchpad_event_get_gesture_phase")]
+    pub fn gesture_phase(&self) -> TouchpadGesturePhase {
+        unsafe {
+            from_glib(ffi::gdk_touchpad_event_get_gesture_phase(
+                self.to_glib_none().0,
+            ))
+        }
+    }
+
+    #[doc(alias = "gdk_touchpad_event_get_n_fingers")]
+    pub fn n_fingers(&self) -> u32 {
+        unsafe { ffi::gdk_touchpad_event_get_n_fingers(self.to_glib_none().0) }
+    }
+
+    #[doc(alias = "gdk_touchpad_event_get_pinch_angle_delta")]
+    pub fn pinch_angle_delta(&self) -> f64 {
+        unsafe { ffi::gdk_touchpad_event_get_pinch_angle_delta(self.to_glib_none().0) }
+    }
+
+    #[doc(alias = "gdk_touchpad_event_get_pinch_scale")]
+    pub fn pinch_scale(&self) -> f64 {
+        unsafe { ffi::gdk_touchpad_event_get_pinch_scale(self.to_glib_none().0) }
+    }
+}
+
+impl fmt::Display for TouchpadEvent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("TouchpadEvent")
+            .field("deltas", &self.deltas())
+            .field("gesture_phase", &self.gesture_phase())
+            .field("n_fingers", &self.n_fingers())
+            .field("pinch_angle_delta", &self.pinch_angle_delta())
+            .field("pinch_scale", &self.pinch_scale())
+            .finish()
+    }
+}

--- a/gsk4/Gir.toml
+++ b/gsk4/Gir.toml
@@ -61,7 +61,6 @@ manual = [
     "Gsk.OutsetShadowNode",
     "Gsk.ParseLocation",
     "Gsk.RadialGradientNode",
-    "Gsk.RenderNode",
     "Gsk.RepeatingLinearGradientNode",
     "Gsk.RepeatingRadialGradientNode",
     "Gsk.RepeatNode",
@@ -112,6 +111,11 @@ manual_traits = ["RendererExtManual"]
     # uses IsA<RenderNode> but RenderNode is not an Object
     manual = true
     doc_trait_name = "RendererExtManual"
+
+[[object]]
+name = "Gsk.RenderNode"
+status = "manual" # fundemental type
+final_type = true # avoids the usage of RenderNodeExt trait
 
 [[object]]
 name = "Gsk.Transform"

--- a/gtk4/src/closure_expression.rs
+++ b/gtk4/src/closure_expression.rs
@@ -1,0 +1,50 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::Expression;
+use glib::translate::*;
+use glib::{value::ValueType, StaticType, Value};
+
+define_expression!(
+    ClosureExpression,
+    ffi::GtkClosureExpression,
+    ffi::gtk_closure_expression_get_type
+);
+
+impl ClosureExpression {
+    #[doc(alias = "gtk_closure_expression_new")]
+    pub fn new<F, R>(callback: F, params: &[Expression]) -> Self
+    where
+        F: Fn(&[Value]) -> R + 'static,
+        R: ValueType,
+    {
+        assert_initialized_main_thread!();
+        let closure = glib::Closure::new_local(move |values| {
+            let ret = callback(values);
+            Some(ret.to_value())
+        });
+        unsafe {
+            from_glib_full(ffi::gtk_closure_expression_new(
+                R::Type::static_type().into_glib(),
+                closure.to_glib_none().0,
+                params.len() as u32,
+                params.to_glib_full(),
+            ))
+        }
+    }
+
+    #[doc(alias = "gtk_closure_expression_new")]
+    pub fn with_closure<R>(closure: glib::Closure, params: &[Expression]) -> Self
+    where
+        R: ValueType,
+    {
+        assert_initialized_main_thread!();
+        unsafe {
+            from_glib_full(ffi::gtk_closure_expression_new(
+                R::Type::static_type().into_glib(),
+                closure.to_glib_none().0,
+                params.len() as u32,
+                params.to_glib_full(),
+            ))
+        }
+    }
+}

--- a/gtk4/src/constant_expression.rs
+++ b/gtk4/src/constant_expression.rs
@@ -1,0 +1,83 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use glib::translate::*;
+use glib::{ToValue, Value};
+
+define_expression!(
+    ConstantExpression,
+    ffi::GtkConstantExpression,
+    ffi::gtk_constant_expression_get_type
+);
+
+impl ConstantExpression {
+    /// Creates a `GtkExpression` that evaluates to the
+    /// object given by the arguments.
+    /// ## `value_type`
+    /// The type of the object
+    ///
+    /// # Returns
+    ///
+    /// a new `GtkExpression`
+    #[doc(alias = "gtk_constant_expression_new")]
+    pub fn new<V: ToValue>(value: &V) -> Self {
+        assert_initialized_main_thread!();
+        unsafe {
+            from_glib_full(ffi::gtk_constant_expression_new_for_value(
+                value.to_value().to_glib_none().0,
+            ))
+        }
+    }
+
+    /// Creates an expression that always evaluates to the given `value`.
+    /// ## `value`
+    /// a `GValue`
+    ///
+    /// # Returns
+    ///
+    /// a new `GtkExpression`
+    #[doc(alias = "gtk_constant_expression_new_for_value")]
+    pub fn for_value(value: &Value) -> Self {
+        assert_initialized_main_thread!();
+        unsafe {
+            from_glib_full(ffi::gtk_constant_expression_new_for_value(
+                value.to_glib_none().0,
+            ))
+        }
+    }
+
+    /// Gets the value that a constant expression evaluates to.
+    ///
+    /// # Returns
+    ///
+    /// the value
+    #[doc(alias = "gtk_constant_expression_get_value")]
+    pub fn value(&self) -> Value {
+        unsafe {
+            from_glib_none(ffi::gtk_constant_expression_get_value(
+                self.to_glib_none().0,
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::TEST_THREAD_WORKER;
+
+    #[test]
+    fn test_expressions() {
+        TEST_THREAD_WORKER
+            .push(move || {
+                let expr1 = ConstantExpression::new(&23);
+                assert_eq!(expr1.value().get::<i32>().unwrap(), 23);
+                let expr2 = ConstantExpression::for_value(&"hello".to_value());
+                assert_eq!(expr2.value().get::<String>().unwrap(), "hello");
+                let expr1 = ConstantExpression::new(&23);
+                assert_eq!(expr1.value().get::<i32>().unwrap(), 23);
+                let expr2 = ConstantExpression::for_value(&"hello".to_value());
+                assert_eq!(expr2.value().get::<String>().unwrap(), "hello");
+            })
+            .expect("Failed to schedule a test call");
+    }
+}

--- a/gtk4/src/expression.rs
+++ b/gtk4/src/expression.rs
@@ -175,12 +175,12 @@ impl glib::value::ToValueOptional for Expression {
 
 /// Register Expression's ParamSpec support
 trait GtkParamSpecExt {
-    fn expression(name: &str, nick: &str, blurb: &str, flags: glib::ParamFlags) -> Self;
+    fn new_expression(name: &str, nick: &str, blurb: &str, flags: glib::ParamFlags) -> Self;
 }
 
 impl GtkParamSpecExt for glib::ParamSpec {
     #[doc(alias = "gtk_param_spec_expression")]
-    fn expression(name: &str, nick: &str, blurb: &str, flags: glib::ParamFlags) -> Self {
+    fn new_expression(name: &str, nick: &str, blurb: &str, flags: glib::ParamFlags) -> Self {
         assert_initialized_main_thread!();
         unsafe {
             from_glib_none(ffi::gtk_param_spec_expression(
@@ -296,7 +296,7 @@ mod tests {
     fn test_paramspec_expression() {
         TEST_THREAD_WORKER
             .push(move || {
-                let _pspec = glib::ParamSpec::expression(
+                let _pspec = glib::ParamSpec::new_expression(
                     "expression",
                     "Expression",
                     "Some Expression",

--- a/gtk4/src/expression_watch.rs
+++ b/gtk4/src/expression_watch.rs
@@ -1,0 +1,46 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use glib::translate::*;
+use glib::Value;
+
+glib::wrapper! {
+    #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    pub struct ExpressionWatch(Shared<ffi::GtkExpressionWatch>);
+
+    match fn {
+        ref => |ptr| ffi::gtk_expression_watch_ref(ptr),
+        unref => |ptr| ffi::gtk_expression_watch_unref(ptr),
+    }
+}
+
+impl ExpressionWatch {
+    #[doc(alias = "gtk_expression_watch_evaluate")]
+    pub fn evaluate(&self) -> Option<Value> {
+        assert_initialized_main_thread!();
+        unsafe {
+            let mut value = Value::uninitialized();
+            let ret = ffi::gtk_expression_watch_evaluate(
+                self.to_glib_none().0,
+                value.to_glib_none_mut().0,
+            );
+            if from_glib(ret) {
+                Some(value)
+            } else {
+                None
+            }
+        }
+    }
+
+    #[doc(alias = "gtk_expression_watch_unwatch")]
+    pub fn unwatch(&self) {
+        unsafe { ffi::gtk_expression_watch_unwatch(self.to_glib_none().0) }
+    }
+}
+
+#[cfg(any(feature = "v4_2", feature = "dox"))]
+impl glib::StaticType for ExpressionWatch {
+    #[doc(alias = "gtk_expression_watch_get_type")]
+    fn static_type() -> glib::Type {
+        unsafe { from_glib(ffi::gtk_expression_watch_get_type()) }
+    }
+}

--- a/gtk4/src/lib.rs
+++ b/gtk4/src/lib.rs
@@ -232,6 +232,8 @@ mod auto;
 
 #[macro_use]
 pub mod subclass;
+#[macro_use]
+mod expression;
 
 pub mod prelude;
 
@@ -251,8 +253,10 @@ mod cell_area;
 mod cell_editable;
 mod cell_layout;
 mod cell_renderer;
+mod closure_expression;
 mod color_chooser;
 mod combo_box;
+mod constant_expression;
 mod constraint_guide;
 mod css_location;
 mod custom_filter;
@@ -267,7 +271,7 @@ mod entry_buffer;
 mod entry_completion;
 mod enums;
 mod event_controller_key;
-mod expression;
+mod expression_watch;
 mod file_chooser_dialog;
 mod flags;
 mod flow_box;
@@ -289,6 +293,7 @@ mod message_dialog;
 mod mnemonic_trigger;
 mod notebook;
 mod numeric_sorter;
+mod object_expression;
 mod overlay;
 mod pad_action_entry;
 mod pad_controller;
@@ -296,6 +301,7 @@ mod page_range;
 #[cfg(any(target_os = "linux", feature = "dox"))]
 #[cfg_attr(feature = "dox", doc(cfg(target_os = "linux")))]
 mod print_job;
+mod property_expression;
 mod recent_data;
 mod requisition;
 mod response_type;
@@ -323,11 +329,11 @@ mod widget;
 
 pub use bitset_iter::BitsetIter;
 pub use border::Border;
+pub use closure_expression::ClosureExpression;
+pub use constant_expression::ConstantExpression;
 pub use css_location::CssLocation;
-pub use expression::{
-    ClosureExpression, ConstantExpression, Expression, ExpressionWatch, ObjectExpression,
-    PropertyExpression, NONE_EXPRESSION,
-};
+pub use expression::{Expression, NONE_EXPRESSION};
+pub use expression_watch::ExpressionWatch;
 #[cfg(any(target_os = "linux", feature = "dox"))]
 #[cfg_attr(feature = "dox", doc(cfg(target_os = "linux")))]
 pub use flags::PrintCapabilities;
@@ -335,8 +341,10 @@ pub use functions::*;
 pub use glib::signal::Inhibit;
 pub use keyval_trigger::KeyvalTrigger;
 pub use mnemonic_trigger::MnemonicTrigger;
+pub use object_expression::ObjectExpression;
 pub use pad_action_entry::PadActionEntry;
 pub use page_range::PageRange;
+pub use property_expression::PropertyExpression;
 pub use recent_data::RecentData;
 pub use requisition::Requisition;
 pub use response_type::ResponseType;

--- a/gtk4/src/object_expression.rs
+++ b/gtk4/src/object_expression.rs
@@ -1,0 +1,45 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use glib::translate::*;
+use glib::{IsA, Object, Value};
+
+define_expression!(
+    ObjectExpression,
+    ffi::GtkObjectExpression,
+    ffi::gtk_object_expression_get_type
+);
+
+impl ObjectExpression {
+    #[doc(alias = "gtk_property_expression_new")]
+    pub fn new<T: IsA<Object>>(object: &T) -> Self {
+        assert_initialized_main_thread!();
+        unsafe {
+            from_glib_full(ffi::gtk_object_expression_new(
+                object.as_ref().to_glib_none().0,
+            ))
+        }
+    }
+
+    #[doc(alias = "gtk_object_expression_get_object")]
+    pub fn object(&self) -> Option<Object> {
+        assert_initialized_main_thread!();
+        unsafe { from_glib_none(ffi::gtk_object_expression_get_object(self.to_glib_none().0)) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::TEST_THREAD_WORKER;
+
+    #[test]
+    fn test_object_expression() {
+        TEST_THREAD_WORKER
+            .push(move || {
+                let obj = crate::IconTheme::new();
+                let expr = ObjectExpression::new(&obj);
+                assert_eq!(expr.object().unwrap(), obj);
+            })
+            .expect("Failed to schedule a test call");
+    }
+}

--- a/gtk4/src/property_expression.rs
+++ b/gtk4/src/property_expression.rs
@@ -1,0 +1,80 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::expression::Expression;
+use glib::translate::*;
+use glib::{Type, Value};
+
+define_expression!(
+    PropertyExpression,
+    ffi::GtkPropertyExpression,
+    ffi::gtk_property_expression_get_type
+);
+
+impl PropertyExpression {
+    #[doc(alias = "gtk_property_expression_new")]
+    pub fn new<E: AsRef<Expression>>(
+        this_type: Type,
+        expression: Option<&E>,
+        property_name: &str,
+    ) -> Self {
+        assert_initialized_main_thread!();
+        unsafe {
+            from_glib_full(ffi::gtk_property_expression_new(
+                this_type.into_glib(),
+                expression.map(|e| e.as_ref()).to_glib_none().0,
+                property_name.to_glib_none().0,
+            ))
+        }
+    }
+
+    #[doc(alias = "gtk_property_expression_new_for_pspec")]
+    pub fn for_pspec<E: AsRef<Expression>>(expression: Option<&E>, pspec: glib::ParamSpec) -> Self {
+        assert_initialized_main_thread!();
+        unsafe {
+            from_glib_full(ffi::gtk_property_expression_new_for_pspec(
+                expression.map(|e| e.as_ref()).to_glib_none().0,
+                pspec.to_glib_none().0,
+            ))
+        }
+    }
+
+    #[doc(alias = "gtk_property_expression_get_expression")]
+    pub fn expression(&self) -> Option<Expression> {
+        assert_initialized_main_thread!();
+        unsafe {
+            from_glib_none(ffi::gtk_property_expression_get_expression(
+                self.to_glib_none().0,
+            ))
+        }
+    }
+
+    #[doc(alias = "gtk_property_expression_get_pspec")]
+    pub fn pspec(&self) -> glib::ParamSpec {
+        assert_initialized_main_thread!();
+        unsafe {
+            from_glib_none(ffi::gtk_property_expression_get_pspec(
+                self.to_glib_none().0,
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{NONE_EXPRESSION, TEST_THREAD_WORKER};
+    use glib::StaticType;
+
+    #[test]
+    fn test_property_expression() {
+        TEST_THREAD_WORKER
+            .push(move || {
+                let _prop_expr = PropertyExpression::new(
+                    crate::StringObject::static_type(),
+                    NONE_EXPRESSION,
+                    "string",
+                );
+            })
+            .expect("Failed to schedule a test call");
+    }
+}


### PR DESCRIPTION
it seems that otherwise, rustdoc-stripper fails to re-add the docs

Tried locally, it works fine after the split