### PR TITLE
Properly mark functions as renamed

### DIFF
--- a/gdk4/Gir.toml
+++ b/gdk4/Gir.toml
@@ -422,10 +422,8 @@ generate_builder = true
 [[object]]
 name = "Gdk.PopupLayout"
 status = "generate"
-manual_traits = ["PopupLayoutExtManual"]
     [[object.function]]
     name = "get_offset"
-    doc_trait_name = "PopupLayoutExtManual"
     manual = true # invalid mutability
 
 [[object]]

--- a/gdk4/src/alias.rs
+++ b/gdk4/src/alias.rs
@@ -1,5 +1,0 @@
-// Take a look at the license at the top of the repository in the LICENSE file.
-
-use glib::GString;
-
-pub type Atom = GString;

--- a/gdk4/src/lib.rs
+++ b/gdk4/src/lib.rs
@@ -41,7 +41,6 @@ mod auto;
 #[macro_use]
 mod event;
 
-mod alias;
 pub mod prelude;
 pub mod subclass;
 
@@ -83,7 +82,6 @@ mod touchpad_event;
 pub use self::auto::functions::*;
 pub use auto::*;
 
-pub use alias::*;
 pub use functions::*;
 
 pub use button_event::ButtonEvent;

--- a/gdk4/src/popup_layout.rs
+++ b/gdk4/src/popup_layout.rs
@@ -3,13 +3,9 @@
 use crate::PopupLayout;
 use glib::translate::*;
 
-pub trait PopupLayoutExtManual {
+impl PopupLayout {
     #[doc(alias = "gdk_popup_layout_get_offset")]
-    fn offset(&self) -> (i32, i32);
-}
-
-impl PopupLayoutExtManual for PopupLayout {
-    fn offset(&self) -> (i32, i32) {
+    pub fn offset(&self) -> (i32, i32) {
         let mut dx = 0;
         let mut dy = 0;
         unsafe {

--- a/gdk4/src/prelude.rs
+++ b/gdk4/src/prelude.rs
@@ -7,7 +7,6 @@ pub use crate::auto::traits::*;
 pub use crate::cairo_interaction::{GdkCairoContextExt, GdkCairoSurfaceExt};
 pub use crate::content_provider::ContentProviderExtManual;
 pub use crate::draw_context::DrawContextExtManual;
-pub use crate::popup_layout::PopupLayoutExtManual;
 pub use crate::surface::SurfaceExtManual;
 pub use crate::texture::TextureExtManual;
 pub use crate::toplevel::ToplevelExtManual;

--- a/gtk4/Gir.toml
+++ b/gtk4/Gir.toml
@@ -2265,6 +2265,7 @@ manual_traits = ["TreeStoreExtManual"]
     ignore = true
     [[object.function]]
     pattern = "insert_with_valuesv"
+    rename = "insert_with_values"
     manual = true
     doc_trait_name = "TreeStoreExtManual"
     [[object.function]]

--- a/gtk4/Gir.toml
+++ b/gtk4/Gir.toml
@@ -1315,6 +1315,7 @@ manual_traits = ["GtkListStoreExtManual"]
     ignore = true
     [[object.function]]
     pattern = "insert_with_valuesv"
+    rename = "insert_with_values"
     manual = true
     doc_trait_name = "GtkListStoreExtManual"
     [[object.function]]

--- a/gtk4/Gir.toml
+++ b/gtk4/Gir.toml
@@ -2083,8 +2083,12 @@ status = "generate"
         name = "ancestor"
         const = true
     [[object.function]]
-    name = "get_indices"
+    name = "get_indices_with_depth"
     manual = true
+    rename = "indices"
+    [[object.function]]
+    name = "get_indices" # bindings should use get_indices_with_depth
+    ignore = true
     [[object.function]]
     name = "to_string"
         [[object.function.parameter]]

--- a/gtk4/Gir.toml
+++ b/gtk4/Gir.toml
@@ -1359,6 +1359,7 @@ manual_traits = ["MediaStreamExtManual"]
     [[object.function]]
     name = "gerror"
     manual = true
+    rename = "set_error"
     doc_trait_name = "MediaStreamExtManual"
 
 [[object]]

--- a/gtk4/Gir.toml
+++ b/gtk4/Gir.toml
@@ -877,7 +877,12 @@ status = "generate"
     # manual: FromGlibPtrBorrow<*mut GValue>` is not implemented for `Value`
     ignore = true
     [[object.function]]
-    pattern = "(get|set)_gtypes"
+    name = "get_gtypes"
+    rename = "types"
+    manual = true
+    [[object.function]]
+    name = "set_gtypes"
+    rename = "set_types"
     manual = true
 
 [[object]]

--- a/gtk4/Gir.toml
+++ b/gtk4/Gir.toml
@@ -458,7 +458,18 @@ manual_traits = ["AccessibleExtManual"]
     pattern = "update_(property|state|relation)"
     ignore = true
     [[object.function]]
-    pattern = "update_(property|state|relation)_value"
+    pattern = "update_property_value"
+    rename = "update_property"
+    doc_trait_name = "AccessibleExtManual"
+    manual = true
+    [[object.function]]
+    pattern = "update_state_value"
+    rename = "update_state"
+    doc_trait_name = "AccessibleExtManual"
+    manual = true
+    [[object.function]]
+    pattern = "update_relation_value"
+    rename = "update_relation"
     doc_trait_name = "AccessibleExtManual"
     manual = true
 

--- a/gtk4/src/auto/tree_path.rs
+++ b/gtk4/src/auto/tree_path.rs
@@ -4,7 +4,6 @@
 
 use glib::translate::*;
 use std::cmp;
-use std::mem;
 
 glib::wrapper! {
     #[derive(Debug, Hash)]
@@ -70,21 +69,6 @@ impl TreePath {
     #[doc(alias = "gtk_tree_path_get_depth")]
     pub fn depth(&self) -> i32 {
         unsafe { ffi::gtk_tree_path_get_depth(mut_override(self.to_glib_none().0)) }
-    }
-
-    #[doc(alias = "gtk_tree_path_get_indices_with_depth")]
-    pub fn indices_with_depth(&mut self) -> Vec<i32> {
-        unsafe {
-            let mut depth = mem::MaybeUninit::uninit();
-            let ret = FromGlibContainer::from_glib_none_num(
-                ffi::gtk_tree_path_get_indices_with_depth(
-                    self.to_glib_none_mut().0,
-                    depth.as_mut_ptr(),
-                ),
-                depth.assume_init() as usize,
-            );
-            ret
-        }
     }
 
     #[doc(alias = "gtk_tree_path_is_ancestor")]

--- a/gtk4/src/constant_expression.rs
+++ b/gtk4/src/constant_expression.rs
@@ -10,14 +10,6 @@ define_expression!(
 );
 
 impl ConstantExpression {
-    /// Creates a `GtkExpression` that evaluates to the
-    /// object given by the arguments.
-    /// ## `value_type`
-    /// The type of the object
-    ///
-    /// # Returns
-    ///
-    /// a new `GtkExpression`
     #[doc(alias = "gtk_constant_expression_new")]
     pub fn new<V: ToValue>(value: &V) -> Self {
         assert_initialized_main_thread!();
@@ -28,13 +20,6 @@ impl ConstantExpression {
         }
     }
 
-    /// Creates an expression that always evaluates to the given `value`.
-    /// ## `value`
-    /// a `GValue`
-    ///
-    /// # Returns
-    ///
-    /// a new `GtkExpression`
     #[doc(alias = "gtk_constant_expression_new_for_value")]
     pub fn for_value(value: &Value) -> Self {
         assert_initialized_main_thread!();
@@ -45,11 +30,6 @@ impl ConstantExpression {
         }
     }
 
-    /// Gets the value that a constant expression evaluates to.
-    ///
-    /// # Returns
-    ///
-    /// the value
     #[doc(alias = "gtk_constant_expression_get_value")]
     pub fn value(&self) -> Value {
         unsafe {


### PR DESCRIPTION
Some functions were only marked as manual but they were renamed which makes rustdoc-stripper not capable for re-adding the docs. The same for function names that were defined as pattern. 

This also drops uneeded `GdkAtom`  which is a gtk3 thing along with an unwanted function that was already manually implemented. In general, this adds more docs to the generated code as an end-result