### PR TITLE
gtk: add getters/setters for Border

### DIFF
--- a/gtk4/src/border.rs
+++ b/gtk4/src/border.rs
@@ -36,6 +36,38 @@ impl Border {
         assert_initialized_main_thread!();
         unsafe { from_glib_full(ffi::gtk_border_new()) }
     }
+
+    pub fn left(&self) -> i16 {
+        self.left
+    }
+
+    pub fn set_left(&mut self, left: i16) {
+        self.left = left;
+    }
+
+    pub fn right(&self) -> i16 {
+        self.right
+    }
+
+    pub fn set_right(&mut self, right: i16) {
+        self.right = right;
+    }
+
+    pub fn top(&self) -> i16 {
+        self.top
+    }
+
+    pub fn set_top(&mut self, top: i16) {
+        self.top = top;
+    }
+
+    pub fn bottom(&self) -> i16 {
+        self.bottom
+    }
+
+    pub fn set_bottom(&mut self, bottom: i16) {
+        self.bottom = bottom;
+    }
 }
 
 impl Default for Border {
@@ -47,10 +79,10 @@ impl Default for Border {
 impl fmt::Debug for Border {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         fmt.debug_struct("Border")
-            .field("left", &self.left)
-            .field("right", &self.right)
-            .field("top", &self.top)
-            .field("bottom", &self.bottom)
+            .field("left", &self.left())
+            .field("right", &self.right())
+            .field("top", &self.top())
+            .field("bottom", &self.bottom())
             .finish()
     }
 }

--- a/gtk4/src/border.rs
+++ b/gtk4/src/border.rs
@@ -86,3 +86,54 @@ impl fmt::Debug for Border {
             .finish()
     }
 }
+
+#[derive(Clone, Default)]
+pub struct BorderBuilder {
+    left: Option<i16>,
+    right: Option<i16>,
+    bottom: Option<i16>,
+    top: Option<i16>,
+}
+
+impl BorderBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn left(mut self, left: i16) -> Self {
+        self.left = Some(left);
+        self
+    }
+
+    pub fn right(mut self, right: i16) -> Self {
+        self.right = Some(right);
+        self
+    }
+
+    pub fn bottom(mut self, bottom: i16) -> Self {
+        self.bottom = Some(bottom);
+        self
+    }
+
+    pub fn top(mut self, top: i16) -> Self {
+        self.top = Some(top);
+        self
+    }
+
+    pub fn build(self) -> Border {
+        let mut border = Border::default();
+        if let Some(left) = self.left {
+            border.set_left(left);
+        }
+        if let Some(right) = self.right {
+            border.set_right(right);
+        }
+        if let Some(bottom) = self.bottom {
+            border.set_bottom(bottom);
+        }
+        if let Some(top) = self.top {
+            border.set_top(top);
+        }
+        border
+    }
+}

--- a/gtk4/src/lib.rs
+++ b/gtk4/src/lib.rs
@@ -328,7 +328,7 @@ mod tree_view_column;
 mod widget;
 
 pub use bitset_iter::BitsetIter;
-pub use border::Border;
+pub use border::{Border, BorderBuilder};
 pub use closure_expression::ClosureExpression;
 pub use constant_expression::ConstantExpression;
 pub use css_location::CssLocation;


### PR DESCRIPTION
Instead of having to go through DerefMut/Deref