### PR TITLE
reduce usage of allow clippy

### DIFF
--- a/gdk4-wayland/src/lib.rs
+++ b/gdk4-wayland/src/lib.rs
@@ -6,8 +6,6 @@ pub use gio;
 pub use glib;
 pub use wayland_client;
 
-#[allow(unused_imports)]
-#[allow(clippy::let_and_return)]
 mod auto;
 
 pub use auto::*;

--- a/gdk4-x11/src/lib.rs
+++ b/gdk4-x11/src/lib.rs
@@ -1,7 +1,5 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-#![allow(deprecated)]
-
 pub use ffi;
 pub use gdk;
 pub use gio;
@@ -11,7 +9,6 @@ pub use x11;
 #[macro_use]
 mod rt;
 
-#[allow(unused_imports)]
 #[allow(clippy::let_and_return)]
 #[allow(clippy::upper_case_acronyms)]
 mod auto;

--- a/gdk4-x11/src/rt.rs
+++ b/gdk4-x11/src/rt.rs
@@ -1,13 +1,13 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use std::cell::Cell;
-use std::sync::atomic::{AtomicBool, Ordering, ATOMIC_BOOL_INIT};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 thread_local! {
     static IS_MAIN_THREAD: Cell<bool> = Cell::new(false)
 }
 
-static INITIALIZED: AtomicBool = ATOMIC_BOOL_INIT;
+static INITIALIZED: AtomicBool = AtomicBool::new(false);
 
 macro_rules! assert_initialized_main_thread {
     () => {

--- a/gdk4/src/lib.rs
+++ b/gdk4/src/lib.rs
@@ -1,14 +1,9 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 #![cfg_attr(feature = "dox", feature(doc_cfg))]
-#![allow(clippy::let_unit_value)]
-#![allow(clippy::new_without_default)]
 #![allow(clippy::type_complexity)]
-#![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::derive_hash_xor_eq)]
-#![allow(clippy::needless_doctest_main)]
 #![allow(clippy::too_many_arguments)]
-#![allow(deprecated)]
 
 pub use cairo;
 pub use ffi;
@@ -27,13 +22,8 @@ macro_rules! skip_assert_initialized {
     () => {};
 }
 
-#[allow(clippy::match_same_arms)]
 #[allow(clippy::let_and_return)]
-#[allow(clippy::many_single_char_names)]
 #[allow(clippy::wrong_self_convention)]
-#[allow(clippy::cognitive_complexity)]
-#[allow(clippy::clone_on_copy)]
-#[allow(clippy::cast_ptr_alignment)]
 #[allow(clippy::upper_case_acronyms)]
 #[allow(unused_imports)]
 mod auto;

--- a/gsk4/src/lib.rs
+++ b/gsk4/src/lib.rs
@@ -1,14 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 #![cfg_attr(feature = "dox", feature(doc_cfg))]
-#![allow(clippy::let_unit_value)]
-#![allow(clippy::new_without_default)]
-#![allow(clippy::type_complexity)]
-#![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::derive_hash_xor_eq)]
-#![allow(clippy::needless_doctest_main)]
 #![allow(clippy::too_many_arguments)]
-#![allow(deprecated)]
 
 pub use cairo;
 pub use ffi;
@@ -27,13 +21,7 @@ macro_rules! skip_assert_initialized {
     () => {};
 }
 
-#[allow(clippy::match_same_arms)]
 #[allow(clippy::let_and_return)]
-#[allow(clippy::many_single_char_names)]
-#[allow(clippy::wrong_self_convention)]
-#[allow(clippy::cognitive_complexity)]
-#[allow(clippy::clone_on_copy)]
-#[allow(clippy::cast_ptr_alignment)]
 #[allow(clippy::upper_case_acronyms)]
 #[allow(unused_imports)]
 mod auto;

--- a/gsk4/src/rounded_rect.rs
+++ b/gsk4/src/rounded_rect.rs
@@ -17,29 +17,29 @@ impl RoundedRect {
     ) -> RoundedRect {
         assert_initialized_main_thread!();
         unsafe {
-            let mut rounded_rect = mem::uninitialized();
+            let mut rounded_rect = mem::MaybeUninit::uninit();
             ffi::gsk_rounded_rect_init(
-                &mut rounded_rect,
+                rounded_rect.as_mut_ptr(),
                 bounds.to_glib_none().0,
                 top_left.to_glib_none().0,
                 top_right.to_glib_none().0,
                 bottom_right.to_glib_none().0,
                 bottom_left.to_glib_none().0,
             );
-            RoundedRect(rounded_rect)
+            RoundedRect(rounded_rect.assume_init())
         }
     }
 
     pub fn new_from_rect(bounds: Rect, radius: f32) -> RoundedRect {
         assert_initialized_main_thread!();
         unsafe {
-            let mut rounded_rect = mem::uninitialized();
+            let mut rounded_rect = mem::MaybeUninit::uninit();
             ffi::gsk_rounded_rect_init_from_rect(
-                &mut rounded_rect,
+                rounded_rect.as_mut_ptr(),
                 bounds.to_glib_none().0,
                 radius,
             );
-            RoundedRect(rounded_rect)
+            RoundedRect(rounded_rect.assume_init())
         }
     }
 

--- a/gtk4/src/lib.rs
+++ b/gtk4/src/lib.rs
@@ -143,14 +143,8 @@
 //! not have easy access to the latest ones. The higher the version, the fewer
 //! users will have it installed.
 #![cfg_attr(feature = "dox", feature(doc_cfg))]
-#![allow(clippy::let_unit_value)]
-#![allow(clippy::new_without_default)]
-#![allow(clippy::type_complexity)]
-#![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::derive_hash_xor_eq)]
-#![allow(clippy::needless_doctest_main)]
 #![allow(clippy::too_many_arguments)]
-#![allow(deprecated)]
 
 pub use ffi;
 // Re-export gtk dependencies
@@ -218,15 +212,12 @@ pub(crate) static TEST_THREAD_WORKER: once_cell::sync::Lazy<glib::ThreadPool> =
         pool
     });
 
-#[allow(clippy::match_same_arms)]
 #[allow(clippy::let_and_return)]
-#[allow(clippy::many_single_char_names)]
 #[allow(clippy::wrong_self_convention)]
-#[allow(clippy::cognitive_complexity)]
 #[allow(clippy::clone_on_copy)]
 #[allow(clippy::many_single_char_names)]
-#[allow(clippy::cast_ptr_alignment)]
 #[allow(clippy::upper_case_acronyms)]
+#[allow(clippy::type_complexity)]
 #[allow(unused_imports)]
 mod auto;
 

--- a/gtk4/src/recent_data.rs
+++ b/gtk4/src/recent_data.rs
@@ -15,6 +15,7 @@ pub struct RecentData {
 
 #[doc(hidden)]
 impl<'a> ToGlibPtr<'a, *mut ffi::GtkRecentData> for RecentData {
+    #[allow(clippy::type_complexity)]
     type Storage = (
         Box<ffi::GtkRecentData>,
         [Stash<'a, *mut c_char, Option<String>>; 2],

--- a/gtk4/src/requisition.rs
+++ b/gtk4/src/requisition.rs
@@ -13,7 +13,7 @@ pub struct Requisition {
 impl Uninitialized for Requisition {
     #[inline]
     unsafe fn uninitialized() -> Self {
-        mem::uninitialized()
+        mem::zeroed()
     }
 }
 

--- a/gtk4/src/rt.rs
+++ b/gtk4/src/rt.rs
@@ -2,13 +2,13 @@
 
 use glib::translate::*;
 use std::cell::Cell;
-use std::sync::atomic::{AtomicBool, Ordering, ATOMIC_BOOL_INIT};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 thread_local! {
     static IS_MAIN_THREAD: Cell<bool> = Cell::new(false)
 }
 
-static INITIALIZED: AtomicBool = ATOMIC_BOOL_INIT;
+static INITIALIZED: AtomicBool = AtomicBool::new(false);
 
 /// Asserts that this is the main thread and `gtk::init` has been called.
 macro_rules! assert_initialized_main_thread {

--- a/gtk4/src/tree_sortable.rs
+++ b/gtk4/src/tree_sortable.rs
@@ -113,15 +113,16 @@ impl<O: IsA<TreeSortable>> TreeSortableExtManual for O {
     #[inline]
     fn sort_column_id(&self) -> Option<(SortColumn, SortType)> {
         unsafe {
-            let mut sort_column_id = mem::uninitialized();
-            let mut order = mem::uninitialized();
+            let mut sort_column_id = mem::MaybeUninit::uninit();
+            let mut order = mem::MaybeUninit::uninit();
             ffi::gtk_tree_sortable_get_sort_column_id(
                 self.as_ref().to_glib_none().0,
-                &mut sort_column_id,
-                &mut order,
+                sort_column_id.as_mut_ptr(),
+                order.as_mut_ptr(),
             );
+            let sort_column_id = sort_column_id.assume_init();
             if sort_column_id != ffi::GTK_TREE_SORTABLE_UNSORTED_SORT_COLUMN_ID {
-                Some((from_glib(sort_column_id), from_glib(order)))
+                Some((from_glib(sort_column_id), from_glib(order.assume_init())))
             } else {
                 None
             }


### PR DESCRIPTION
this mostly removes unused clippy warnings disabling guards
& replaces deprecated APIs