### PR TITLE
gtk: ignore css_parser_warning_quark

### DIFF
--- a/gtk4/Gir.toml
+++ b/gtk4/Gir.toml
@@ -441,6 +441,9 @@ trust_return_value_nullability = false
     [[object.function]]
     name = "test_list_all_types"
     manual = true
+    [[object.function]]
+    name = "css_parser_warning_quark"
+    ignore = true # error-domain expect _error_quark so it can't be used as ErrorDomain automatically
 
 
 [[object]]

--- a/gtk4/src/auto/functions.rs
+++ b/gtk4/src/auto/functions.rs
@@ -137,12 +137,6 @@ pub fn check_version(
     }
 }
 
-#[doc(alias = "gtk_css_parser_warning_quark")]
-pub fn css_parser_warning_quark() -> glib::Quark {
-    assert_initialized_main_thread!();
-    unsafe { from_glib(ffi::gtk_css_parser_warning_quark()) }
-}
-
 #[doc(alias = "gtk_disable_setlocale")]
 pub fn disable_setlocale() {
     assert_not_initialized!();

--- a/gtk4/src/enums.rs
+++ b/gtk4/src/enums.rs
@@ -1,6 +1,9 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::Ordering;
+use crate::{CssParserWarning, Ordering};
+use glib::error::ErrorDomain;
+use glib::translate::*;
+use glib::Quark;
 use std::cmp;
 
 impl From<cmp::Ordering> for Ordering {
@@ -22,6 +25,27 @@ impl From<Ordering> for cmp::Ordering {
             Ordering::Larger => Self::Greater,
             Ordering::Smaller => Self::Less,
             Ordering::__Unknown(_) => unreachable!(),
+        }
+    }
+}
+
+impl ErrorDomain for CssParserWarning {
+    fn domain() -> Quark {
+        skip_assert_initialized!();
+        unsafe { from_glib(ffi::gtk_css_parser_warning_quark()) }
+    }
+
+    fn code(self) -> i32 {
+        self.into_glib()
+    }
+
+    fn from(code: i32) -> Option<Self> {
+        skip_assert_initialized!();
+        match code {
+            ffi::GTK_CSS_PARSER_WARNING_DEPRECATED => Some(Self::Deprecated),
+            ffi::GTK_CSS_PARSER_WARNING_SYNTAX => Some(Self::Syntax),
+            ffi::GTK_CSS_PARSER_WARNING_UNIMPLEMENTED => Some(Self::Unimplemented),
+            value => Some(Self::__Unknown(value)),
         }
     }
 }


### PR DESCRIPTION
It should be used as an error domain for CssParserWarning
but as there's no annotation for that and it's mostly based on a convention that can't be respected for a Warning instead of an Error
do that manually here.