### PR TITLE
gdk: mark some types as non final

### DIFF
--- a/gdk4/Gir.toml
+++ b/gdk4/Gir.toml
@@ -18,7 +18,6 @@ generate = [
     "Gdk.DevicePad",
     "Gdk.DevicePadFeature",
     "Gdk.DeviceToolType",
-    "Gdk.Drag",
     "Gdk.DragAction",
     "Gdk.DragCancelReason",
     "Gdk.DragSurface",
@@ -28,7 +27,6 @@ generate = [
     "Gdk.FrameClockPhase",
     "Gdk.FrameTimings",
     "Gdk.FullscreenMode",
-    "Gdk.GLContext",
     "Gdk.GLError",
     "Gdk.Gravity",
     "Gdk.InputSource",
@@ -41,7 +39,6 @@ generate = [
     "Gdk.PaintableFlags",
     "Gdk.Popup",
     "Gdk.ScrollDirection",
-    "Gdk.Seat",
     "Gdk.SeatCapabilities",
     "Gdk.Snapshot",
     "Gdk.SubpixelLayout",
@@ -172,6 +169,7 @@ status = "generate"
 name = "Gdk.AppLaunchContext"
 status = "generate"
 generate_builder = false
+final_type = false
 
 [[object]]
 name = "Gdk.Clipboard"
@@ -330,6 +328,7 @@ generate_builder = true
 [[object]]
 name = "Gdk.Device"
 status = "generate"
+final_type = false
     [[object.function]]
     name = "get_caps_lock_state"
     rename = "is_caps_locked"
@@ -348,6 +347,8 @@ generate_builder = true
 [[object]]
 name = "Gdk.Display"
 status = "generate"
+final_type = false
+manual_traits = ["DisplayExtManual"]
     [[object.function]]
     name = "get_setting"
     # Actually retrieves the setting in the provided argument
@@ -400,6 +401,11 @@ status = "generate"
 generate_builder = false
 
 [[object]]
+name = "Gdk.Drag"
+status = "generate"
+final_type = false
+
+[[object]]
 name = "Gdk.DrawContext"
 status = "generate"
 manual_traits = ["DrawContextExtManual"]
@@ -421,6 +427,11 @@ status = "manual" # fundemental type
 final_type = true # avoids the usage of EventExt trait
 
 [[object]]
+name = "Gdk.GLContext"
+status = "generate"
+final_type = false
+
+[[object]]
 name = "Gdk.GLTexture"
 status = "generate"
     [[object.function]]
@@ -430,6 +441,7 @@ status = "generate"
 [[object]]
 name = "Gdk.Monitor"
 status = "generate"
+final_type = false
 generate_builder = false
 
 [[object]]
@@ -440,8 +452,14 @@ status = "generate"
     manual = true # invalid mutability
 
 [[object]]
+name = "Gdk.Seat"
+status = "generate"
+final_type = false
+
+[[object]]
 name = "Gdk.Surface"
 status = "generate"
+final_type = false
 manual_traits = ["SurfaceExtManual"]
     [[object.function]]
     name = "create_similar_surface"

--- a/gdk4/src/auto/app_launch_context.rs
+++ b/gdk4/src/auto/app_launch_context.rs
@@ -15,48 +15,62 @@ glib::wrapper! {
     }
 }
 
-impl AppLaunchContext {
+pub const NONE_APP_LAUNCH_CONTEXT: Option<&AppLaunchContext> = None;
+
+pub trait AppLaunchContextExt: 'static {
     #[doc(alias = "gdk_app_launch_context_get_display")]
     #[doc(alias = "get_display")]
-    pub fn display(&self) -> Option<Display> {
+    fn display(&self) -> Option<Display>;
+
+    #[doc(alias = "gdk_app_launch_context_set_desktop")]
+    fn set_desktop(&self, desktop: i32);
+
+    #[doc(alias = "gdk_app_launch_context_set_icon")]
+    fn set_icon<P: IsA<gio::Icon>>(&self, icon: Option<&P>);
+
+    #[doc(alias = "gdk_app_launch_context_set_icon_name")]
+    fn set_icon_name(&self, icon_name: Option<&str>);
+
+    #[doc(alias = "gdk_app_launch_context_set_timestamp")]
+    fn set_timestamp(&self, timestamp: u32);
+}
+
+impl<O: IsA<AppLaunchContext>> AppLaunchContextExt for O {
+    fn display(&self) -> Option<Display> {
         unsafe {
             from_glib_none(ffi::gdk_app_launch_context_get_display(
-                self.to_glib_none().0,
+                self.as_ref().to_glib_none().0,
             ))
         }
     }
 
-    #[doc(alias = "gdk_app_launch_context_set_desktop")]
-    pub fn set_desktop(&self, desktop: i32) {
+    fn set_desktop(&self, desktop: i32) {
         unsafe {
-            ffi::gdk_app_launch_context_set_desktop(self.to_glib_none().0, desktop);
+            ffi::gdk_app_launch_context_set_desktop(self.as_ref().to_glib_none().0, desktop);
         }
     }
 
-    #[doc(alias = "gdk_app_launch_context_set_icon")]
-    pub fn set_icon<P: IsA<gio::Icon>>(&self, icon: Option<&P>) {
+    fn set_icon<P: IsA<gio::Icon>>(&self, icon: Option<&P>) {
         unsafe {
             ffi::gdk_app_launch_context_set_icon(
-                self.to_glib_none().0,
+                self.as_ref().to_glib_none().0,
                 icon.map(|p| p.as_ref()).to_glib_none().0,
             );
         }
     }
 
-    #[doc(alias = "gdk_app_launch_context_set_icon_name")]
-    pub fn set_icon_name(&self, icon_name: Option<&str>) {
+    fn set_icon_name(&self, icon_name: Option<&str>) {
         unsafe {
             ffi::gdk_app_launch_context_set_icon_name(
-                self.to_glib_none().0,
+                self.as_ref().to_glib_none().0,
                 icon_name.to_glib_none().0,
             );
         }
     }
 
-    #[doc(alias = "gdk_app_launch_context_set_timestamp")]
-    pub fn set_timestamp(&self, timestamp: u32) {
+    fn set_timestamp(&self, timestamp: u32) {
         unsafe {
-            ffi::gdk_app_launch_context_set_timestamp(self.to_glib_none().0, timestamp);
+            ffi::gdk_app_launch_context_set_timestamp(self.as_ref().to_glib_none().0, timestamp);
         }
     }
 }

--- a/gdk4/src/auto/clipboard.rs
+++ b/gdk4/src/auto/clipboard.rs
@@ -207,8 +207,8 @@ impl ClipboardBuilder {
             .expect("Failed to create an instance of Clipboard")
     }
 
-    pub fn display(mut self, display: &Display) -> Self {
-        self.display = Some(display.clone());
+    pub fn display<P: IsA<Display>>(mut self, display: &P) -> Self {
+        self.display = Some(display.clone().upcast());
         self
     }
 }

--- a/gdk4/src/auto/device.rs
+++ b/gdk4/src/auto/device.rs
@@ -8,7 +8,8 @@ use crate::InputSource;
 use crate::ModifierType;
 use crate::Seat;
 use crate::Surface;
-use glib::object::ObjectType as ObjectType_;
+use glib::object::Cast;
+use glib::object::IsA;
 use glib::signal::connect_raw;
 use glib::signal::SignalHandlerId;
 use glib::translate::*;
@@ -27,93 +28,204 @@ glib::wrapper! {
     }
 }
 
-impl Device {
+pub const NONE_DEVICE: Option<&Device> = None;
+
+pub trait DeviceExt: 'static {
     #[doc(alias = "gdk_device_get_caps_lock_state")]
     #[doc(alias = "get_caps_lock_state")]
-    pub fn is_caps_locked(&self) -> bool {
-        unsafe { from_glib(ffi::gdk_device_get_caps_lock_state(self.to_glib_none().0)) }
-    }
+    fn is_caps_locked(&self) -> bool;
 
     #[doc(alias = "gdk_device_get_device_tool")]
     #[doc(alias = "get_device_tool")]
-    pub fn device_tool(&self) -> Option<DeviceTool> {
-        unsafe { from_glib_none(ffi::gdk_device_get_device_tool(self.to_glib_none().0)) }
-    }
+    fn device_tool(&self) -> Option<DeviceTool>;
 
     #[doc(alias = "gdk_device_get_direction")]
     #[doc(alias = "get_direction")]
-    pub fn direction(&self) -> pango::Direction {
-        unsafe { from_glib(ffi::gdk_device_get_direction(self.to_glib_none().0)) }
-    }
+    fn direction(&self) -> pango::Direction;
 
     #[doc(alias = "gdk_device_get_display")]
     #[doc(alias = "get_display")]
-    pub fn display(&self) -> Option<Display> {
-        unsafe { from_glib_none(ffi::gdk_device_get_display(self.to_glib_none().0)) }
-    }
+    fn display(&self) -> Option<Display>;
 
     #[doc(alias = "gdk_device_get_has_cursor")]
     #[doc(alias = "get_has_cursor")]
-    pub fn has_cursor(&self) -> bool {
-        unsafe { from_glib(ffi::gdk_device_get_has_cursor(self.to_glib_none().0)) }
-    }
+    fn has_cursor(&self) -> bool;
 
     #[doc(alias = "gdk_device_get_modifier_state")]
     #[doc(alias = "get_modifier_state")]
-    pub fn modifier_state(&self) -> ModifierType {
-        unsafe { from_glib(ffi::gdk_device_get_modifier_state(self.to_glib_none().0)) }
-    }
+    fn modifier_state(&self) -> ModifierType;
 
     #[doc(alias = "gdk_device_get_name")]
     #[doc(alias = "get_name")]
-    pub fn name(&self) -> Option<glib::GString> {
-        unsafe { from_glib_none(ffi::gdk_device_get_name(self.to_glib_none().0)) }
-    }
+    fn name(&self) -> Option<glib::GString>;
 
     #[doc(alias = "gdk_device_get_num_lock_state")]
     #[doc(alias = "get_num_lock_state")]
-    pub fn is_num_locked(&self) -> bool {
-        unsafe { from_glib(ffi::gdk_device_get_num_lock_state(self.to_glib_none().0)) }
-    }
+    fn is_num_locked(&self) -> bool;
 
     #[doc(alias = "gdk_device_get_num_touches")]
     #[doc(alias = "get_num_touches")]
-    pub fn num_touches(&self) -> u32 {
-        unsafe { ffi::gdk_device_get_num_touches(self.to_glib_none().0) }
-    }
+    fn num_touches(&self) -> u32;
 
     #[doc(alias = "gdk_device_get_product_id")]
     #[doc(alias = "get_product_id")]
-    pub fn product_id(&self) -> Option<glib::GString> {
-        unsafe { from_glib_none(ffi::gdk_device_get_product_id(self.to_glib_none().0)) }
-    }
+    fn product_id(&self) -> Option<glib::GString>;
 
     #[doc(alias = "gdk_device_get_scroll_lock_state")]
     #[doc(alias = "get_scroll_lock_state")]
-    pub fn is_scroll_locked(&self) -> bool {
-        unsafe { from_glib(ffi::gdk_device_get_scroll_lock_state(self.to_glib_none().0)) }
-    }
+    fn is_scroll_locked(&self) -> bool;
 
     #[doc(alias = "gdk_device_get_seat")]
     #[doc(alias = "get_seat")]
-    pub fn seat(&self) -> Option<Seat> {
-        unsafe { from_glib_none(ffi::gdk_device_get_seat(self.to_glib_none().0)) }
-    }
+    fn seat(&self) -> Option<Seat>;
 
     #[doc(alias = "gdk_device_get_source")]
     #[doc(alias = "get_source")]
-    pub fn source(&self) -> InputSource {
-        unsafe { from_glib(ffi::gdk_device_get_source(self.to_glib_none().0)) }
-    }
+    fn source(&self) -> InputSource;
 
     #[doc(alias = "gdk_device_get_surface_at_position")]
     #[doc(alias = "get_surface_at_position")]
-    pub fn surface_at_position(&self) -> (Option<Surface>, f64, f64) {
+    fn surface_at_position(&self) -> (Option<Surface>, f64, f64);
+
+    #[doc(alias = "gdk_device_get_vendor_id")]
+    #[doc(alias = "get_vendor_id")]
+    fn vendor_id(&self) -> Option<glib::GString>;
+
+    #[doc(alias = "gdk_device_has_bidi_layouts")]
+    fn has_bidi_layouts(&self) -> bool;
+
+    #[doc(alias = "n-axes")]
+    fn n_axes(&self) -> u32;
+
+    fn set_seat<P: IsA<Seat>>(&self, seat: Option<&P>);
+
+    fn tool(&self) -> Option<DeviceTool>;
+
+    #[doc(alias = "changed")]
+    fn connect_changed<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "tool-changed")]
+    fn connect_tool_changed<F: Fn(&Self, &DeviceTool) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "caps-lock-state")]
+    fn connect_caps_lock_state_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "direction")]
+    fn connect_direction_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "has-bidi-layouts")]
+    fn connect_has_bidi_layouts_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "modifier-state")]
+    fn connect_modifier_state_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "n-axes")]
+    fn connect_n_axes_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "num-lock-state")]
+    fn connect_num_lock_state_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "scroll-lock-state")]
+    fn connect_scroll_lock_state_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "seat")]
+    fn connect_seat_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "tool")]
+    fn connect_tool_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+}
+
+impl<O: IsA<Device>> DeviceExt for O {
+    fn is_caps_locked(&self) -> bool {
+        unsafe {
+            from_glib(ffi::gdk_device_get_caps_lock_state(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
+    }
+
+    fn device_tool(&self) -> Option<DeviceTool> {
+        unsafe {
+            from_glib_none(ffi::gdk_device_get_device_tool(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
+    }
+
+    fn direction(&self) -> pango::Direction {
+        unsafe {
+            from_glib(ffi::gdk_device_get_direction(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
+    }
+
+    fn display(&self) -> Option<Display> {
+        unsafe { from_glib_none(ffi::gdk_device_get_display(self.as_ref().to_glib_none().0)) }
+    }
+
+    fn has_cursor(&self) -> bool {
+        unsafe {
+            from_glib(ffi::gdk_device_get_has_cursor(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
+    }
+
+    fn modifier_state(&self) -> ModifierType {
+        unsafe {
+            from_glib(ffi::gdk_device_get_modifier_state(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
+    }
+
+    fn name(&self) -> Option<glib::GString> {
+        unsafe { from_glib_none(ffi::gdk_device_get_name(self.as_ref().to_glib_none().0)) }
+    }
+
+    fn is_num_locked(&self) -> bool {
+        unsafe {
+            from_glib(ffi::gdk_device_get_num_lock_state(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
+    }
+
+    fn num_touches(&self) -> u32 {
+        unsafe { ffi::gdk_device_get_num_touches(self.as_ref().to_glib_none().0) }
+    }
+
+    fn product_id(&self) -> Option<glib::GString> {
+        unsafe {
+            from_glib_none(ffi::gdk_device_get_product_id(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
+    }
+
+    fn is_scroll_locked(&self) -> bool {
+        unsafe {
+            from_glib(ffi::gdk_device_get_scroll_lock_state(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
+    }
+
+    fn seat(&self) -> Option<Seat> {
+        unsafe { from_glib_none(ffi::gdk_device_get_seat(self.as_ref().to_glib_none().0)) }
+    }
+
+    fn source(&self) -> InputSource {
+        unsafe { from_glib(ffi::gdk_device_get_source(self.as_ref().to_glib_none().0)) }
+    }
+
+    fn surface_at_position(&self) -> (Option<Surface>, f64, f64) {
         unsafe {
             let mut win_x = mem::MaybeUninit::uninit();
             let mut win_y = mem::MaybeUninit::uninit();
             let ret = from_glib_none(ffi::gdk_device_get_surface_at_position(
-                self.to_glib_none().0,
+                self.as_ref().to_glib_none().0,
                 win_x.as_mut_ptr(),
                 win_y.as_mut_ptr(),
             ));
@@ -123,23 +235,27 @@ impl Device {
         }
     }
 
-    #[doc(alias = "gdk_device_get_vendor_id")]
-    #[doc(alias = "get_vendor_id")]
-    pub fn vendor_id(&self) -> Option<glib::GString> {
-        unsafe { from_glib_none(ffi::gdk_device_get_vendor_id(self.to_glib_none().0)) }
+    fn vendor_id(&self) -> Option<glib::GString> {
+        unsafe {
+            from_glib_none(ffi::gdk_device_get_vendor_id(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
     }
 
-    #[doc(alias = "gdk_device_has_bidi_layouts")]
-    pub fn has_bidi_layouts(&self) -> bool {
-        unsafe { from_glib(ffi::gdk_device_has_bidi_layouts(self.to_glib_none().0)) }
+    fn has_bidi_layouts(&self) -> bool {
+        unsafe {
+            from_glib(ffi::gdk_device_has_bidi_layouts(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
     }
 
-    #[doc(alias = "n-axes")]
-    pub fn n_axes(&self) -> u32 {
+    fn n_axes(&self) -> u32 {
         unsafe {
             let mut value = glib::Value::from_type(<u32 as StaticType>::static_type());
             glib::gobject_ffi::g_object_get_property(
-                self.as_ptr() as *mut glib::gobject_ffi::GObject,
+                self.to_glib_none().0 as *mut glib::gobject_ffi::GObject,
                 b"n-axes\0".as_ptr() as *const _,
                 value.to_glib_none_mut().0,
             );
@@ -149,21 +265,21 @@ impl Device {
         }
     }
 
-    pub fn set_seat(&self, seat: Option<&Seat>) {
+    fn set_seat<P: IsA<Seat>>(&self, seat: Option<&P>) {
         unsafe {
             glib::gobject_ffi::g_object_set_property(
-                self.as_ptr() as *mut glib::gobject_ffi::GObject,
+                self.to_glib_none().0 as *mut glib::gobject_ffi::GObject,
                 b"seat\0".as_ptr() as *const _,
                 seat.to_value().to_glib_none().0,
             );
         }
     }
 
-    pub fn tool(&self) -> Option<DeviceTool> {
+    fn tool(&self) -> Option<DeviceTool> {
         unsafe {
             let mut value = glib::Value::from_type(<DeviceTool as StaticType>::static_type());
             glib::gobject_ffi::g_object_get_property(
-                self.as_ptr() as *mut glib::gobject_ffi::GObject,
+                self.to_glib_none().0 as *mut glib::gobject_ffi::GObject,
                 b"tool\0".as_ptr() as *const _,
                 value.to_glib_none_mut().0,
             );
@@ -174,13 +290,13 @@ impl Device {
     }
 
     #[doc(alias = "changed")]
-    pub fn connect_changed<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn changed_trampoline<F: Fn(&Device) + 'static>(
+    fn connect_changed<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn changed_trampoline<P: IsA<Device>, F: Fn(&P) + 'static>(
             this: *mut ffi::GdkDevice,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Device::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -188,7 +304,7 @@ impl Device {
                 self.as_ptr() as *mut _,
                 b"changed\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    changed_trampoline::<F> as *const (),
+                    changed_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -196,17 +312,20 @@ impl Device {
     }
 
     #[doc(alias = "tool-changed")]
-    pub fn connect_tool_changed<F: Fn(&Self, &DeviceTool) + 'static>(
-        &self,
-        f: F,
-    ) -> SignalHandlerId {
-        unsafe extern "C" fn tool_changed_trampoline<F: Fn(&Device, &DeviceTool) + 'static>(
+    fn connect_tool_changed<F: Fn(&Self, &DeviceTool) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn tool_changed_trampoline<
+            P: IsA<Device>,
+            F: Fn(&P, &DeviceTool) + 'static,
+        >(
             this: *mut ffi::GdkDevice,
             tool: *mut ffi::GdkDeviceTool,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this), &from_glib_borrow(tool))
+            f(
+                &Device::from_glib_borrow(this).unsafe_cast_ref(),
+                &from_glib_borrow(tool),
+            )
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -214,7 +333,7 @@ impl Device {
                 self.as_ptr() as *mut _,
                 b"tool-changed\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    tool_changed_trampoline::<F> as *const (),
+                    tool_changed_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -222,14 +341,17 @@ impl Device {
     }
 
     #[doc(alias = "caps-lock-state")]
-    pub fn connect_caps_lock_state_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn notify_caps_lock_state_trampoline<F: Fn(&Device) + 'static>(
+    fn connect_caps_lock_state_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn notify_caps_lock_state_trampoline<
+            P: IsA<Device>,
+            F: Fn(&P) + 'static,
+        >(
             this: *mut ffi::GdkDevice,
             _param_spec: glib::ffi::gpointer,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Device::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -237,7 +359,7 @@ impl Device {
                 self.as_ptr() as *mut _,
                 b"notify::caps-lock-state\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    notify_caps_lock_state_trampoline::<F> as *const (),
+                    notify_caps_lock_state_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -245,14 +367,14 @@ impl Device {
     }
 
     #[doc(alias = "direction")]
-    pub fn connect_direction_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn notify_direction_trampoline<F: Fn(&Device) + 'static>(
+    fn connect_direction_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn notify_direction_trampoline<P: IsA<Device>, F: Fn(&P) + 'static>(
             this: *mut ffi::GdkDevice,
             _param_spec: glib::ffi::gpointer,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Device::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -260,7 +382,7 @@ impl Device {
                 self.as_ptr() as *mut _,
                 b"notify::direction\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    notify_direction_trampoline::<F> as *const (),
+                    notify_direction_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -268,14 +390,17 @@ impl Device {
     }
 
     #[doc(alias = "has-bidi-layouts")]
-    pub fn connect_has_bidi_layouts_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn notify_has_bidi_layouts_trampoline<F: Fn(&Device) + 'static>(
+    fn connect_has_bidi_layouts_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn notify_has_bidi_layouts_trampoline<
+            P: IsA<Device>,
+            F: Fn(&P) + 'static,
+        >(
             this: *mut ffi::GdkDevice,
             _param_spec: glib::ffi::gpointer,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Device::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -283,7 +408,7 @@ impl Device {
                 self.as_ptr() as *mut _,
                 b"notify::has-bidi-layouts\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    notify_has_bidi_layouts_trampoline::<F> as *const (),
+                    notify_has_bidi_layouts_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -291,14 +416,17 @@ impl Device {
     }
 
     #[doc(alias = "modifier-state")]
-    pub fn connect_modifier_state_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn notify_modifier_state_trampoline<F: Fn(&Device) + 'static>(
+    fn connect_modifier_state_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn notify_modifier_state_trampoline<
+            P: IsA<Device>,
+            F: Fn(&P) + 'static,
+        >(
             this: *mut ffi::GdkDevice,
             _param_spec: glib::ffi::gpointer,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Device::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -306,7 +434,7 @@ impl Device {
                 self.as_ptr() as *mut _,
                 b"notify::modifier-state\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    notify_modifier_state_trampoline::<F> as *const (),
+                    notify_modifier_state_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -314,14 +442,14 @@ impl Device {
     }
 
     #[doc(alias = "n-axes")]
-    pub fn connect_n_axes_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn notify_n_axes_trampoline<F: Fn(&Device) + 'static>(
+    fn connect_n_axes_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn notify_n_axes_trampoline<P: IsA<Device>, F: Fn(&P) + 'static>(
             this: *mut ffi::GdkDevice,
             _param_spec: glib::ffi::gpointer,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Device::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -329,7 +457,7 @@ impl Device {
                 self.as_ptr() as *mut _,
                 b"notify::n-axes\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    notify_n_axes_trampoline::<F> as *const (),
+                    notify_n_axes_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -337,14 +465,17 @@ impl Device {
     }
 
     #[doc(alias = "num-lock-state")]
-    pub fn connect_num_lock_state_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn notify_num_lock_state_trampoline<F: Fn(&Device) + 'static>(
+    fn connect_num_lock_state_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn notify_num_lock_state_trampoline<
+            P: IsA<Device>,
+            F: Fn(&P) + 'static,
+        >(
             this: *mut ffi::GdkDevice,
             _param_spec: glib::ffi::gpointer,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Device::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -352,7 +483,7 @@ impl Device {
                 self.as_ptr() as *mut _,
                 b"notify::num-lock-state\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    notify_num_lock_state_trampoline::<F> as *const (),
+                    notify_num_lock_state_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -360,17 +491,17 @@ impl Device {
     }
 
     #[doc(alias = "scroll-lock-state")]
-    pub fn connect_scroll_lock_state_notify<F: Fn(&Self) + 'static>(
-        &self,
-        f: F,
-    ) -> SignalHandlerId {
-        unsafe extern "C" fn notify_scroll_lock_state_trampoline<F: Fn(&Device) + 'static>(
+    fn connect_scroll_lock_state_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn notify_scroll_lock_state_trampoline<
+            P: IsA<Device>,
+            F: Fn(&P) + 'static,
+        >(
             this: *mut ffi::GdkDevice,
             _param_spec: glib::ffi::gpointer,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Device::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -378,7 +509,7 @@ impl Device {
                 self.as_ptr() as *mut _,
                 b"notify::scroll-lock-state\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    notify_scroll_lock_state_trampoline::<F> as *const (),
+                    notify_scroll_lock_state_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -386,14 +517,14 @@ impl Device {
     }
 
     #[doc(alias = "seat")]
-    pub fn connect_seat_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn notify_seat_trampoline<F: Fn(&Device) + 'static>(
+    fn connect_seat_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn notify_seat_trampoline<P: IsA<Device>, F: Fn(&P) + 'static>(
             this: *mut ffi::GdkDevice,
             _param_spec: glib::ffi::gpointer,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Device::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -401,7 +532,7 @@ impl Device {
                 self.as_ptr() as *mut _,
                 b"notify::seat\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    notify_seat_trampoline::<F> as *const (),
+                    notify_seat_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -409,14 +540,14 @@ impl Device {
     }
 
     #[doc(alias = "tool")]
-    pub fn connect_tool_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn notify_tool_trampoline<F: Fn(&Device) + 'static>(
+    fn connect_tool_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn notify_tool_trampoline<P: IsA<Device>, F: Fn(&P) + 'static>(
             this: *mut ffi::GdkDevice,
             _param_spec: glib::ffi::gpointer,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Device::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -424,7 +555,7 @@ impl Device {
                 self.as_ptr() as *mut _,
                 b"notify::tool\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    notify_tool_trampoline::<F> as *const (),
+                    notify_tool_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )

--- a/gdk4/src/auto/display.rs
+++ b/gdk4/src/auto/display.rs
@@ -8,7 +8,8 @@ use crate::Device;
 use crate::Monitor;
 use crate::Seat;
 use crate::Surface;
-use glib::object::ObjectType as ObjectType_;
+use glib::object::Cast;
+use glib::object::IsA;
 use glib::signal::connect_raw;
 use glib::signal::SignalHandlerId;
 use glib::translate::*;
@@ -26,178 +27,6 @@ glib::wrapper! {
 }
 
 impl Display {
-    #[doc(alias = "gdk_display_beep")]
-    pub fn beep(&self) {
-        unsafe {
-            ffi::gdk_display_beep(self.to_glib_none().0);
-        }
-    }
-
-    #[doc(alias = "gdk_display_close")]
-    pub fn close(&self) {
-        unsafe {
-            ffi::gdk_display_close(self.to_glib_none().0);
-        }
-    }
-
-    #[doc(alias = "gdk_display_device_is_grabbed")]
-    pub fn device_is_grabbed(&self, device: &Device) -> bool {
-        unsafe {
-            from_glib(ffi::gdk_display_device_is_grabbed(
-                self.to_glib_none().0,
-                device.to_glib_none().0,
-            ))
-        }
-    }
-
-    #[doc(alias = "gdk_display_flush")]
-    pub fn flush(&self) {
-        unsafe {
-            ffi::gdk_display_flush(self.to_glib_none().0);
-        }
-    }
-
-    #[doc(alias = "gdk_display_get_app_launch_context")]
-    #[doc(alias = "get_app_launch_context")]
-    pub fn app_launch_context(&self) -> AppLaunchContext {
-        unsafe {
-            from_glib_full(ffi::gdk_display_get_app_launch_context(
-                self.to_glib_none().0,
-            ))
-        }
-    }
-
-    #[doc(alias = "gdk_display_get_clipboard")]
-    #[doc(alias = "get_clipboard")]
-    pub fn clipboard(&self) -> Clipboard {
-        unsafe { from_glib_none(ffi::gdk_display_get_clipboard(self.to_glib_none().0)) }
-    }
-
-    #[doc(alias = "gdk_display_get_default_seat")]
-    #[doc(alias = "get_default_seat")]
-    pub fn default_seat(&self) -> Seat {
-        unsafe { from_glib_none(ffi::gdk_display_get_default_seat(self.to_glib_none().0)) }
-    }
-
-    #[doc(alias = "gdk_display_get_monitor_at_surface")]
-    #[doc(alias = "get_monitor_at_surface")]
-    pub fn monitor_at_surface(&self, surface: &Surface) -> Option<Monitor> {
-        unsafe {
-            from_glib_none(ffi::gdk_display_get_monitor_at_surface(
-                self.to_glib_none().0,
-                surface.to_glib_none().0,
-            ))
-        }
-    }
-
-    #[doc(alias = "gdk_display_get_monitors")]
-    #[doc(alias = "get_monitors")]
-    pub fn monitors(&self) -> Option<gio::ListModel> {
-        unsafe { from_glib_none(ffi::gdk_display_get_monitors(self.to_glib_none().0)) }
-    }
-
-    #[doc(alias = "gdk_display_get_name")]
-    #[doc(alias = "get_name")]
-    pub fn name(&self) -> glib::GString {
-        unsafe { from_glib_none(ffi::gdk_display_get_name(self.to_glib_none().0)) }
-    }
-
-    #[doc(alias = "gdk_display_get_primary_clipboard")]
-    #[doc(alias = "get_primary_clipboard")]
-    pub fn primary_clipboard(&self) -> Clipboard {
-        unsafe {
-            from_glib_none(ffi::gdk_display_get_primary_clipboard(
-                self.to_glib_none().0,
-            ))
-        }
-    }
-
-    #[doc(alias = "gdk_display_get_setting")]
-    pub fn get_setting(&self, name: &str, value: &mut glib::Value) -> bool {
-        unsafe {
-            from_glib(ffi::gdk_display_get_setting(
-                self.to_glib_none().0,
-                name.to_glib_none().0,
-                value.to_glib_none_mut().0,
-            ))
-        }
-    }
-
-    #[doc(alias = "gdk_display_get_startup_notification_id")]
-    #[doc(alias = "get_startup_notification_id")]
-    pub fn startup_notification_id(&self) -> Option<glib::GString> {
-        unsafe {
-            from_glib_none(ffi::gdk_display_get_startup_notification_id(
-                self.to_glib_none().0,
-            ))
-        }
-    }
-
-    #[doc(alias = "gdk_display_is_closed")]
-    pub fn is_closed(&self) -> bool {
-        unsafe { from_glib(ffi::gdk_display_is_closed(self.to_glib_none().0)) }
-    }
-
-    #[doc(alias = "gdk_display_is_composited")]
-    pub fn is_composited(&self) -> bool {
-        unsafe { from_glib(ffi::gdk_display_is_composited(self.to_glib_none().0)) }
-    }
-
-    #[doc(alias = "gdk_display_is_rgba")]
-    pub fn is_rgba(&self) -> bool {
-        unsafe { from_glib(ffi::gdk_display_is_rgba(self.to_glib_none().0)) }
-    }
-
-    #[doc(alias = "gdk_display_list_seats")]
-    pub fn list_seats(&self) -> Vec<Seat> {
-        unsafe {
-            FromGlibPtrContainer::from_glib_container(ffi::gdk_display_list_seats(
-                self.to_glib_none().0,
-            ))
-        }
-    }
-
-    #[doc(alias = "gdk_display_notify_startup_complete")]
-    pub fn notify_startup_complete(&self, startup_id: &str) {
-        unsafe {
-            ffi::gdk_display_notify_startup_complete(
-                self.to_glib_none().0,
-                startup_id.to_glib_none().0,
-            );
-        }
-    }
-
-    #[doc(alias = "gdk_display_supports_input_shapes")]
-    pub fn supports_input_shapes(&self) -> bool {
-        unsafe {
-            from_glib(ffi::gdk_display_supports_input_shapes(
-                self.to_glib_none().0,
-            ))
-        }
-    }
-
-    #[doc(alias = "gdk_display_sync")]
-    pub fn sync(&self) {
-        unsafe {
-            ffi::gdk_display_sync(self.to_glib_none().0);
-        }
-    }
-
-    #[doc(alias = "input-shapes")]
-    pub fn is_input_shapes(&self) -> bool {
-        unsafe {
-            let mut value = glib::Value::from_type(<bool as StaticType>::static_type());
-            glib::gobject_ffi::g_object_get_property(
-                self.as_ptr() as *mut glib::gobject_ffi::GObject,
-                b"input-shapes\0".as_ptr() as *const _,
-                value.to_glib_none_mut().0,
-            );
-            value
-                .get()
-                .expect("Return Value for property `input-shapes` getter")
-        }
-    }
-
     #[doc(alias = "gdk_display_get_default")]
     #[doc(alias = "get_default")]
     pub fn default() -> Option<Display> {
@@ -210,16 +39,286 @@ impl Display {
         assert_initialized_main_thread!();
         unsafe { from_glib_none(ffi::gdk_display_open(display_name.to_glib_none().0)) }
     }
+}
+
+impl fmt::Display for Display {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&DisplayExt::name(self))
+    }
+}
+
+pub const NONE_DISPLAY: Option<&Display> = None;
+
+pub trait DisplayExt: 'static {
+    #[doc(alias = "gdk_display_beep")]
+    fn beep(&self);
+
+    #[doc(alias = "gdk_display_close")]
+    fn close(&self);
+
+    #[doc(alias = "gdk_display_device_is_grabbed")]
+    fn device_is_grabbed<P: IsA<Device>>(&self, device: &P) -> bool;
+
+    #[doc(alias = "gdk_display_flush")]
+    fn flush(&self);
+
+    #[doc(alias = "gdk_display_get_app_launch_context")]
+    #[doc(alias = "get_app_launch_context")]
+    fn app_launch_context(&self) -> AppLaunchContext;
+
+    #[doc(alias = "gdk_display_get_clipboard")]
+    #[doc(alias = "get_clipboard")]
+    fn clipboard(&self) -> Clipboard;
+
+    #[doc(alias = "gdk_display_get_default_seat")]
+    #[doc(alias = "get_default_seat")]
+    fn default_seat(&self) -> Seat;
+
+    #[doc(alias = "gdk_display_get_monitor_at_surface")]
+    #[doc(alias = "get_monitor_at_surface")]
+    fn monitor_at_surface<P: IsA<Surface>>(&self, surface: &P) -> Option<Monitor>;
+
+    #[doc(alias = "gdk_display_get_monitors")]
+    #[doc(alias = "get_monitors")]
+    fn monitors(&self) -> Option<gio::ListModel>;
+
+    #[doc(alias = "gdk_display_get_name")]
+    #[doc(alias = "get_name")]
+    fn name(&self) -> glib::GString;
+
+    #[doc(alias = "gdk_display_get_primary_clipboard")]
+    #[doc(alias = "get_primary_clipboard")]
+    fn primary_clipboard(&self) -> Clipboard;
+
+    #[doc(alias = "gdk_display_get_setting")]
+    fn get_setting(&self, name: &str, value: &mut glib::Value) -> bool;
+
+    #[doc(alias = "gdk_display_get_startup_notification_id")]
+    #[doc(alias = "get_startup_notification_id")]
+    fn startup_notification_id(&self) -> Option<glib::GString>;
+
+    #[doc(alias = "gdk_display_is_closed")]
+    fn is_closed(&self) -> bool;
+
+    #[doc(alias = "gdk_display_is_composited")]
+    fn is_composited(&self) -> bool;
+
+    #[doc(alias = "gdk_display_is_rgba")]
+    fn is_rgba(&self) -> bool;
+
+    #[doc(alias = "gdk_display_list_seats")]
+    fn list_seats(&self) -> Vec<Seat>;
+
+    #[doc(alias = "gdk_display_notify_startup_complete")]
+    fn notify_startup_complete(&self, startup_id: &str);
+
+    #[doc(alias = "gdk_display_supports_input_shapes")]
+    fn supports_input_shapes(&self) -> bool;
+
+    #[doc(alias = "gdk_display_sync")]
+    fn sync(&self);
+
+    #[doc(alias = "input-shapes")]
+    fn is_input_shapes(&self) -> bool;
 
     #[doc(alias = "closed")]
-    pub fn connect_closed<F: Fn(&Self, bool) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn closed_trampoline<F: Fn(&Display, bool) + 'static>(
+    fn connect_closed<F: Fn(&Self, bool) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "opened")]
+    fn connect_opened<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "seat-added")]
+    fn connect_seat_added<F: Fn(&Self, &Seat) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "seat-removed")]
+    fn connect_seat_removed<F: Fn(&Self, &Seat) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "setting-changed")]
+    fn connect_setting_changed<F: Fn(&Self, &str) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "composited")]
+    fn connect_composited_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "input-shapes")]
+    fn connect_input_shapes_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "rgba")]
+    fn connect_rgba_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+}
+
+impl<O: IsA<Display>> DisplayExt for O {
+    fn beep(&self) {
+        unsafe {
+            ffi::gdk_display_beep(self.as_ref().to_glib_none().0);
+        }
+    }
+
+    fn close(&self) {
+        unsafe {
+            ffi::gdk_display_close(self.as_ref().to_glib_none().0);
+        }
+    }
+
+    fn device_is_grabbed<P: IsA<Device>>(&self, device: &P) -> bool {
+        unsafe {
+            from_glib(ffi::gdk_display_device_is_grabbed(
+                self.as_ref().to_glib_none().0,
+                device.as_ref().to_glib_none().0,
+            ))
+        }
+    }
+
+    fn flush(&self) {
+        unsafe {
+            ffi::gdk_display_flush(self.as_ref().to_glib_none().0);
+        }
+    }
+
+    fn app_launch_context(&self) -> AppLaunchContext {
+        unsafe {
+            from_glib_full(ffi::gdk_display_get_app_launch_context(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
+    }
+
+    fn clipboard(&self) -> Clipboard {
+        unsafe {
+            from_glib_none(ffi::gdk_display_get_clipboard(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
+    }
+
+    fn default_seat(&self) -> Seat {
+        unsafe {
+            from_glib_none(ffi::gdk_display_get_default_seat(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
+    }
+
+    fn monitor_at_surface<P: IsA<Surface>>(&self, surface: &P) -> Option<Monitor> {
+        unsafe {
+            from_glib_none(ffi::gdk_display_get_monitor_at_surface(
+                self.as_ref().to_glib_none().0,
+                surface.as_ref().to_glib_none().0,
+            ))
+        }
+    }
+
+    fn monitors(&self) -> Option<gio::ListModel> {
+        unsafe {
+            from_glib_none(ffi::gdk_display_get_monitors(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
+    }
+
+    fn name(&self) -> glib::GString {
+        unsafe { from_glib_none(ffi::gdk_display_get_name(self.as_ref().to_glib_none().0)) }
+    }
+
+    fn primary_clipboard(&self) -> Clipboard {
+        unsafe {
+            from_glib_none(ffi::gdk_display_get_primary_clipboard(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
+    }
+
+    fn get_setting(&self, name: &str, value: &mut glib::Value) -> bool {
+        unsafe {
+            from_glib(ffi::gdk_display_get_setting(
+                self.as_ref().to_glib_none().0,
+                name.to_glib_none().0,
+                value.to_glib_none_mut().0,
+            ))
+        }
+    }
+
+    fn startup_notification_id(&self) -> Option<glib::GString> {
+        unsafe {
+            from_glib_none(ffi::gdk_display_get_startup_notification_id(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
+    }
+
+    fn is_closed(&self) -> bool {
+        unsafe { from_glib(ffi::gdk_display_is_closed(self.as_ref().to_glib_none().0)) }
+    }
+
+    fn is_composited(&self) -> bool {
+        unsafe {
+            from_glib(ffi::gdk_display_is_composited(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
+    }
+
+    fn is_rgba(&self) -> bool {
+        unsafe { from_glib(ffi::gdk_display_is_rgba(self.as_ref().to_glib_none().0)) }
+    }
+
+    fn list_seats(&self) -> Vec<Seat> {
+        unsafe {
+            FromGlibPtrContainer::from_glib_container(ffi::gdk_display_list_seats(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
+    }
+
+    fn notify_startup_complete(&self, startup_id: &str) {
+        unsafe {
+            ffi::gdk_display_notify_startup_complete(
+                self.as_ref().to_glib_none().0,
+                startup_id.to_glib_none().0,
+            );
+        }
+    }
+
+    fn supports_input_shapes(&self) -> bool {
+        unsafe {
+            from_glib(ffi::gdk_display_supports_input_shapes(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
+    }
+
+    fn sync(&self) {
+        unsafe {
+            ffi::gdk_display_sync(self.as_ref().to_glib_none().0);
+        }
+    }
+
+    fn is_input_shapes(&self) -> bool {
+        unsafe {
+            let mut value = glib::Value::from_type(<bool as StaticType>::static_type());
+            glib::gobject_ffi::g_object_get_property(
+                self.to_glib_none().0 as *mut glib::gobject_ffi::GObject,
+                b"input-shapes\0".as_ptr() as *const _,
+                value.to_glib_none_mut().0,
+            );
+            value
+                .get()
+                .expect("Return Value for property `input-shapes` getter")
+        }
+    }
+
+    #[doc(alias = "closed")]
+    fn connect_closed<F: Fn(&Self, bool) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn closed_trampoline<P: IsA<Display>, F: Fn(&P, bool) + 'static>(
             this: *mut ffi::GdkDisplay,
             is_error: glib::ffi::gboolean,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this), from_glib(is_error))
+            f(
+                &Display::from_glib_borrow(this).unsafe_cast_ref(),
+                from_glib(is_error),
+            )
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -227,7 +326,7 @@ impl Display {
                 self.as_ptr() as *mut _,
                 b"closed\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    closed_trampoline::<F> as *const (),
+                    closed_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -235,13 +334,13 @@ impl Display {
     }
 
     #[doc(alias = "opened")]
-    pub fn connect_opened<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn opened_trampoline<F: Fn(&Display) + 'static>(
+    fn connect_opened<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn opened_trampoline<P: IsA<Display>, F: Fn(&P) + 'static>(
             this: *mut ffi::GdkDisplay,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Display::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -249,7 +348,7 @@ impl Display {
                 self.as_ptr() as *mut _,
                 b"opened\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    opened_trampoline::<F> as *const (),
+                    opened_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -257,14 +356,17 @@ impl Display {
     }
 
     #[doc(alias = "seat-added")]
-    pub fn connect_seat_added<F: Fn(&Self, &Seat) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn seat_added_trampoline<F: Fn(&Display, &Seat) + 'static>(
+    fn connect_seat_added<F: Fn(&Self, &Seat) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn seat_added_trampoline<P: IsA<Display>, F: Fn(&P, &Seat) + 'static>(
             this: *mut ffi::GdkDisplay,
             seat: *mut ffi::GdkSeat,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this), &from_glib_borrow(seat))
+            f(
+                &Display::from_glib_borrow(this).unsafe_cast_ref(),
+                &from_glib_borrow(seat),
+            )
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -272,7 +374,7 @@ impl Display {
                 self.as_ptr() as *mut _,
                 b"seat-added\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    seat_added_trampoline::<F> as *const (),
+                    seat_added_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -280,14 +382,20 @@ impl Display {
     }
 
     #[doc(alias = "seat-removed")]
-    pub fn connect_seat_removed<F: Fn(&Self, &Seat) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn seat_removed_trampoline<F: Fn(&Display, &Seat) + 'static>(
+    fn connect_seat_removed<F: Fn(&Self, &Seat) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn seat_removed_trampoline<
+            P: IsA<Display>,
+            F: Fn(&P, &Seat) + 'static,
+        >(
             this: *mut ffi::GdkDisplay,
             seat: *mut ffi::GdkSeat,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this), &from_glib_borrow(seat))
+            f(
+                &Display::from_glib_borrow(this).unsafe_cast_ref(),
+                &from_glib_borrow(seat),
+            )
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -295,7 +403,7 @@ impl Display {
                 self.as_ptr() as *mut _,
                 b"seat-removed\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    seat_removed_trampoline::<F> as *const (),
+                    seat_removed_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -303,15 +411,18 @@ impl Display {
     }
 
     #[doc(alias = "setting-changed")]
-    pub fn connect_setting_changed<F: Fn(&Self, &str) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn setting_changed_trampoline<F: Fn(&Display, &str) + 'static>(
+    fn connect_setting_changed<F: Fn(&Self, &str) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn setting_changed_trampoline<
+            P: IsA<Display>,
+            F: Fn(&P, &str) + 'static,
+        >(
             this: *mut ffi::GdkDisplay,
             setting: *mut libc::c_char,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
             f(
-                &from_glib_borrow(this),
+                &Display::from_glib_borrow(this).unsafe_cast_ref(),
                 &glib::GString::from_glib_borrow(setting),
             )
         }
@@ -321,7 +432,7 @@ impl Display {
                 self.as_ptr() as *mut _,
                 b"setting-changed\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    setting_changed_trampoline::<F> as *const (),
+                    setting_changed_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -329,14 +440,14 @@ impl Display {
     }
 
     #[doc(alias = "composited")]
-    pub fn connect_composited_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn notify_composited_trampoline<F: Fn(&Display) + 'static>(
+    fn connect_composited_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn notify_composited_trampoline<P: IsA<Display>, F: Fn(&P) + 'static>(
             this: *mut ffi::GdkDisplay,
             _param_spec: glib::ffi::gpointer,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Display::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -344,7 +455,7 @@ impl Display {
                 self.as_ptr() as *mut _,
                 b"notify::composited\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    notify_composited_trampoline::<F> as *const (),
+                    notify_composited_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -352,14 +463,17 @@ impl Display {
     }
 
     #[doc(alias = "input-shapes")]
-    pub fn connect_input_shapes_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn notify_input_shapes_trampoline<F: Fn(&Display) + 'static>(
+    fn connect_input_shapes_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn notify_input_shapes_trampoline<
+            P: IsA<Display>,
+            F: Fn(&P) + 'static,
+        >(
             this: *mut ffi::GdkDisplay,
             _param_spec: glib::ffi::gpointer,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Display::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -367,7 +481,7 @@ impl Display {
                 self.as_ptr() as *mut _,
                 b"notify::input-shapes\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    notify_input_shapes_trampoline::<F> as *const (),
+                    notify_input_shapes_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -375,14 +489,14 @@ impl Display {
     }
 
     #[doc(alias = "rgba")]
-    pub fn connect_rgba_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn notify_rgba_trampoline<F: Fn(&Display) + 'static>(
+    fn connect_rgba_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn notify_rgba_trampoline<P: IsA<Display>, F: Fn(&P) + 'static>(
             this: *mut ffi::GdkDisplay,
             _param_spec: glib::ffi::gpointer,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Display::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -390,17 +504,10 @@ impl Display {
                 self.as_ptr() as *mut _,
                 b"notify::rgba\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    notify_rgba_trampoline::<F> as *const (),
+                    notify_rgba_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
         }
-    }
-}
-
-impl fmt::Display for Display {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(&self.name())
     }
 }

--- a/gdk4/src/auto/display_manager.rs
+++ b/gdk4/src/auto/display_manager.rs
@@ -3,6 +3,7 @@
 // DO NOT EDIT
 
 use crate::Display;
+use glib::object::IsA;
 use glib::object::ObjectType as ObjectType_;
 use glib::signal::connect_raw;
 use glib::signal::SignalHandlerId;
@@ -50,11 +51,11 @@ impl DisplayManager {
     }
 
     #[doc(alias = "gdk_display_manager_set_default_display")]
-    pub fn set_default_display(&self, display: &Display) {
+    pub fn set_default_display<P: IsA<Display>>(&self, display: &P) {
         unsafe {
             ffi::gdk_display_manager_set_default_display(
                 self.to_glib_none().0,
-                display.to_glib_none().0,
+                display.as_ref().to_glib_none().0,
             );
         }
     }

--- a/gdk4/src/auto/drag.rs
+++ b/gdk4/src/auto/drag.rs
@@ -9,8 +9,8 @@ use crate::Display;
 use crate::DragAction;
 use crate::DragCancelReason;
 use crate::Surface;
+use glib::object::Cast;
 use glib::object::IsA;
-use glib::object::ObjectType as ObjectType_;
 use glib::signal::connect_raw;
 use glib::signal::SignalHandlerId;
 use glib::translate::*;
@@ -28,94 +28,11 @@ glib::wrapper! {
 }
 
 impl Drag {
-    #[doc(alias = "gdk_drag_drop_done")]
-    pub fn drop_done(&self, success: bool) {
-        unsafe {
-            ffi::gdk_drag_drop_done(self.to_glib_none().0, success.into_glib());
-        }
-    }
-
-    #[doc(alias = "gdk_drag_get_actions")]
-    #[doc(alias = "get_actions")]
-    pub fn actions(&self) -> DragAction {
-        unsafe { from_glib(ffi::gdk_drag_get_actions(self.to_glib_none().0)) }
-    }
-
-    #[doc(alias = "gdk_drag_get_content")]
-    #[doc(alias = "get_content")]
-    pub fn content(&self) -> Option<ContentProvider> {
-        unsafe { from_glib_none(ffi::gdk_drag_get_content(self.to_glib_none().0)) }
-    }
-
-    #[doc(alias = "gdk_drag_get_device")]
-    #[doc(alias = "get_device")]
-    pub fn device(&self) -> Option<Device> {
-        unsafe { from_glib_none(ffi::gdk_drag_get_device(self.to_glib_none().0)) }
-    }
-
-    #[doc(alias = "gdk_drag_get_display")]
-    #[doc(alias = "get_display")]
-    pub fn display(&self) -> Option<Display> {
-        unsafe { from_glib_none(ffi::gdk_drag_get_display(self.to_glib_none().0)) }
-    }
-
-    #[doc(alias = "gdk_drag_get_drag_surface")]
-    #[doc(alias = "get_drag_surface")]
-    pub fn drag_surface(&self) -> Option<Surface> {
-        unsafe { from_glib_none(ffi::gdk_drag_get_drag_surface(self.to_glib_none().0)) }
-    }
-
-    #[doc(alias = "gdk_drag_get_formats")]
-    #[doc(alias = "get_formats")]
-    pub fn formats(&self) -> Option<ContentFormats> {
-        unsafe { from_glib_none(ffi::gdk_drag_get_formats(self.to_glib_none().0)) }
-    }
-
-    #[doc(alias = "gdk_drag_get_selected_action")]
-    #[doc(alias = "get_selected_action")]
-    pub fn selected_action(&self) -> DragAction {
-        unsafe { from_glib(ffi::gdk_drag_get_selected_action(self.to_glib_none().0)) }
-    }
-
-    #[doc(alias = "gdk_drag_get_surface")]
-    #[doc(alias = "get_surface")]
-    pub fn surface(&self) -> Option<Surface> {
-        unsafe { from_glib_none(ffi::gdk_drag_get_surface(self.to_glib_none().0)) }
-    }
-
-    #[doc(alias = "gdk_drag_set_hotspot")]
-    pub fn set_hotspot(&self, hot_x: i32, hot_y: i32) {
-        unsafe {
-            ffi::gdk_drag_set_hotspot(self.to_glib_none().0, hot_x, hot_y);
-        }
-    }
-
-    pub fn set_actions(&self, actions: DragAction) {
-        unsafe {
-            glib::gobject_ffi::g_object_set_property(
-                self.as_ptr() as *mut glib::gobject_ffi::GObject,
-                b"actions\0".as_ptr() as *const _,
-                actions.to_value().to_glib_none().0,
-            );
-        }
-    }
-
-    #[doc(alias = "selected-action")]
-    pub fn set_selected_action(&self, selected_action: DragAction) {
-        unsafe {
-            glib::gobject_ffi::g_object_set_property(
-                self.as_ptr() as *mut glib::gobject_ffi::GObject,
-                b"selected-action\0".as_ptr() as *const _,
-                selected_action.to_value().to_glib_none().0,
-            );
-        }
-    }
-
     #[doc(alias = "gdk_drag_begin")]
-    pub fn begin<P: IsA<ContentProvider>>(
-        surface: &Surface,
-        device: &Device,
-        content: &P,
+    pub fn begin<P: IsA<Surface>, Q: IsA<Device>, R: IsA<ContentProvider>>(
+        surface: &P,
+        device: &Q,
+        content: &R,
         actions: DragAction,
         dx: f64,
         dy: f64,
@@ -123,8 +40,8 @@ impl Drag {
         skip_assert_initialized!();
         unsafe {
             from_glib_full(ffi::gdk_drag_begin(
-                surface.to_glib_none().0,
-                device.to_glib_none().0,
+                surface.as_ref().to_glib_none().0,
+                device.as_ref().to_glib_none().0,
                 content.as_ref().to_glib_none().0,
                 actions.into_glib(),
                 dx,
@@ -132,19 +49,161 @@ impl Drag {
             ))
         }
     }
+}
+
+pub const NONE_DRAG: Option<&Drag> = None;
+
+pub trait DragExt: 'static {
+    #[doc(alias = "gdk_drag_drop_done")]
+    fn drop_done(&self, success: bool);
+
+    #[doc(alias = "gdk_drag_get_actions")]
+    #[doc(alias = "get_actions")]
+    fn actions(&self) -> DragAction;
+
+    #[doc(alias = "gdk_drag_get_content")]
+    #[doc(alias = "get_content")]
+    fn content(&self) -> Option<ContentProvider>;
+
+    #[doc(alias = "gdk_drag_get_device")]
+    #[doc(alias = "get_device")]
+    fn device(&self) -> Option<Device>;
+
+    #[doc(alias = "gdk_drag_get_display")]
+    #[doc(alias = "get_display")]
+    fn display(&self) -> Option<Display>;
+
+    #[doc(alias = "gdk_drag_get_drag_surface")]
+    #[doc(alias = "get_drag_surface")]
+    fn drag_surface(&self) -> Option<Surface>;
+
+    #[doc(alias = "gdk_drag_get_formats")]
+    #[doc(alias = "get_formats")]
+    fn formats(&self) -> Option<ContentFormats>;
+
+    #[doc(alias = "gdk_drag_get_selected_action")]
+    #[doc(alias = "get_selected_action")]
+    fn selected_action(&self) -> DragAction;
+
+    #[doc(alias = "gdk_drag_get_surface")]
+    #[doc(alias = "get_surface")]
+    fn surface(&self) -> Option<Surface>;
+
+    #[doc(alias = "gdk_drag_set_hotspot")]
+    fn set_hotspot(&self, hot_x: i32, hot_y: i32);
+
+    fn set_actions(&self, actions: DragAction);
+
+    #[doc(alias = "selected-action")]
+    fn set_selected_action(&self, selected_action: DragAction);
 
     #[doc(alias = "cancel")]
-    pub fn connect_cancel<F: Fn(&Self, DragCancelReason) + 'static>(
-        &self,
-        f: F,
-    ) -> SignalHandlerId {
-        unsafe extern "C" fn cancel_trampoline<F: Fn(&Drag, DragCancelReason) + 'static>(
+    fn connect_cancel<F: Fn(&Self, DragCancelReason) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "dnd-finished")]
+    fn connect_dnd_finished<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "drop-performed")]
+    fn connect_drop_performed<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "actions")]
+    fn connect_actions_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "display")]
+    fn connect_display_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "selected-action")]
+    fn connect_selected_action_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+}
+
+impl<O: IsA<Drag>> DragExt for O {
+    fn drop_done(&self, success: bool) {
+        unsafe {
+            ffi::gdk_drag_drop_done(self.as_ref().to_glib_none().0, success.into_glib());
+        }
+    }
+
+    fn actions(&self) -> DragAction {
+        unsafe { from_glib(ffi::gdk_drag_get_actions(self.as_ref().to_glib_none().0)) }
+    }
+
+    fn content(&self) -> Option<ContentProvider> {
+        unsafe { from_glib_none(ffi::gdk_drag_get_content(self.as_ref().to_glib_none().0)) }
+    }
+
+    fn device(&self) -> Option<Device> {
+        unsafe { from_glib_none(ffi::gdk_drag_get_device(self.as_ref().to_glib_none().0)) }
+    }
+
+    fn display(&self) -> Option<Display> {
+        unsafe { from_glib_none(ffi::gdk_drag_get_display(self.as_ref().to_glib_none().0)) }
+    }
+
+    fn drag_surface(&self) -> Option<Surface> {
+        unsafe {
+            from_glib_none(ffi::gdk_drag_get_drag_surface(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
+    }
+
+    fn formats(&self) -> Option<ContentFormats> {
+        unsafe { from_glib_none(ffi::gdk_drag_get_formats(self.as_ref().to_glib_none().0)) }
+    }
+
+    fn selected_action(&self) -> DragAction {
+        unsafe {
+            from_glib(ffi::gdk_drag_get_selected_action(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
+    }
+
+    fn surface(&self) -> Option<Surface> {
+        unsafe { from_glib_none(ffi::gdk_drag_get_surface(self.as_ref().to_glib_none().0)) }
+    }
+
+    fn set_hotspot(&self, hot_x: i32, hot_y: i32) {
+        unsafe {
+            ffi::gdk_drag_set_hotspot(self.as_ref().to_glib_none().0, hot_x, hot_y);
+        }
+    }
+
+    fn set_actions(&self, actions: DragAction) {
+        unsafe {
+            glib::gobject_ffi::g_object_set_property(
+                self.to_glib_none().0 as *mut glib::gobject_ffi::GObject,
+                b"actions\0".as_ptr() as *const _,
+                actions.to_value().to_glib_none().0,
+            );
+        }
+    }
+
+    fn set_selected_action(&self, selected_action: DragAction) {
+        unsafe {
+            glib::gobject_ffi::g_object_set_property(
+                self.to_glib_none().0 as *mut glib::gobject_ffi::GObject,
+                b"selected-action\0".as_ptr() as *const _,
+                selected_action.to_value().to_glib_none().0,
+            );
+        }
+    }
+
+    #[doc(alias = "cancel")]
+    fn connect_cancel<F: Fn(&Self, DragCancelReason) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn cancel_trampoline<
+            P: IsA<Drag>,
+            F: Fn(&P, DragCancelReason) + 'static,
+        >(
             this: *mut ffi::GdkDrag,
             reason: ffi::GdkDragCancelReason,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this), from_glib(reason))
+            f(
+                &Drag::from_glib_borrow(this).unsafe_cast_ref(),
+                from_glib(reason),
+            )
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -152,7 +211,7 @@ impl Drag {
                 self.as_ptr() as *mut _,
                 b"cancel\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    cancel_trampoline::<F> as *const (),
+                    cancel_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -160,13 +219,13 @@ impl Drag {
     }
 
     #[doc(alias = "dnd-finished")]
-    pub fn connect_dnd_finished<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn dnd_finished_trampoline<F: Fn(&Drag) + 'static>(
+    fn connect_dnd_finished<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn dnd_finished_trampoline<P: IsA<Drag>, F: Fn(&P) + 'static>(
             this: *mut ffi::GdkDrag,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Drag::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -174,7 +233,7 @@ impl Drag {
                 self.as_ptr() as *mut _,
                 b"dnd-finished\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    dnd_finished_trampoline::<F> as *const (),
+                    dnd_finished_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -182,13 +241,13 @@ impl Drag {
     }
 
     #[doc(alias = "drop-performed")]
-    pub fn connect_drop_performed<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn drop_performed_trampoline<F: Fn(&Drag) + 'static>(
+    fn connect_drop_performed<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn drop_performed_trampoline<P: IsA<Drag>, F: Fn(&P) + 'static>(
             this: *mut ffi::GdkDrag,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Drag::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -196,7 +255,7 @@ impl Drag {
                 self.as_ptr() as *mut _,
                 b"drop-performed\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    drop_performed_trampoline::<F> as *const (),
+                    drop_performed_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -204,14 +263,14 @@ impl Drag {
     }
 
     #[doc(alias = "actions")]
-    pub fn connect_actions_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn notify_actions_trampoline<F: Fn(&Drag) + 'static>(
+    fn connect_actions_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn notify_actions_trampoline<P: IsA<Drag>, F: Fn(&P) + 'static>(
             this: *mut ffi::GdkDrag,
             _param_spec: glib::ffi::gpointer,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Drag::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -219,7 +278,7 @@ impl Drag {
                 self.as_ptr() as *mut _,
                 b"notify::actions\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    notify_actions_trampoline::<F> as *const (),
+                    notify_actions_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -227,14 +286,14 @@ impl Drag {
     }
 
     #[doc(alias = "display")]
-    pub fn connect_display_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn notify_display_trampoline<F: Fn(&Drag) + 'static>(
+    fn connect_display_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn notify_display_trampoline<P: IsA<Drag>, F: Fn(&P) + 'static>(
             this: *mut ffi::GdkDrag,
             _param_spec: glib::ffi::gpointer,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Drag::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -242,7 +301,7 @@ impl Drag {
                 self.as_ptr() as *mut _,
                 b"notify::display\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    notify_display_trampoline::<F> as *const (),
+                    notify_display_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -250,14 +309,17 @@ impl Drag {
     }
 
     #[doc(alias = "selected-action")]
-    pub fn connect_selected_action_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn notify_selected_action_trampoline<F: Fn(&Drag) + 'static>(
+    fn connect_selected_action_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn notify_selected_action_trampoline<
+            P: IsA<Drag>,
+            F: Fn(&P) + 'static,
+        >(
             this: *mut ffi::GdkDrag,
             _param_spec: glib::ffi::gpointer,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Drag::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -265,7 +327,7 @@ impl Drag {
                 self.as_ptr() as *mut _,
                 b"notify::selected-action\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    notify_selected_action_trampoline::<F> as *const (),
+                    notify_selected_action_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )

--- a/gdk4/src/auto/gl_context.rs
+++ b/gdk4/src/auto/gl_context.rs
@@ -3,6 +3,7 @@
 // DO NOT EDIT
 
 use crate::DrawContext;
+use glib::object::IsA;
 use glib::translate::*;
 use std::fmt;
 use std::mem;
@@ -17,128 +18,6 @@ glib::wrapper! {
 }
 
 impl GLContext {
-    #[doc(alias = "gdk_gl_context_get_debug_enabled")]
-    #[doc(alias = "get_debug_enabled")]
-    pub fn is_debug_enabled(&self) -> bool {
-        unsafe { from_glib(ffi::gdk_gl_context_get_debug_enabled(self.to_glib_none().0)) }
-    }
-
-    #[doc(alias = "gdk_gl_context_get_forward_compatible")]
-    #[doc(alias = "get_forward_compatible")]
-    pub fn is_forward_compatible(&self) -> bool {
-        unsafe {
-            from_glib(ffi::gdk_gl_context_get_forward_compatible(
-                self.to_glib_none().0,
-            ))
-        }
-    }
-
-    #[doc(alias = "gdk_gl_context_get_required_version")]
-    #[doc(alias = "get_required_version")]
-    pub fn required_version(&self) -> (i32, i32) {
-        unsafe {
-            let mut major = mem::MaybeUninit::uninit();
-            let mut minor = mem::MaybeUninit::uninit();
-            ffi::gdk_gl_context_get_required_version(
-                self.to_glib_none().0,
-                major.as_mut_ptr(),
-                minor.as_mut_ptr(),
-            );
-            let major = major.assume_init();
-            let minor = minor.assume_init();
-            (major, minor)
-        }
-    }
-
-    #[doc(alias = "gdk_gl_context_get_shared_context")]
-    #[doc(alias = "get_shared_context")]
-    pub fn shared_context(&self) -> Option<GLContext> {
-        unsafe {
-            from_glib_none(ffi::gdk_gl_context_get_shared_context(
-                self.to_glib_none().0,
-            ))
-        }
-    }
-
-    #[doc(alias = "gdk_gl_context_get_use_es")]
-    #[doc(alias = "get_use_es")]
-    pub fn uses_es(&self) -> bool {
-        unsafe { from_glib(ffi::gdk_gl_context_get_use_es(self.to_glib_none().0)) }
-    }
-
-    #[doc(alias = "gdk_gl_context_get_version")]
-    #[doc(alias = "get_version")]
-    pub fn version(&self) -> (i32, i32) {
-        unsafe {
-            let mut major = mem::MaybeUninit::uninit();
-            let mut minor = mem::MaybeUninit::uninit();
-            ffi::gdk_gl_context_get_version(
-                self.to_glib_none().0,
-                major.as_mut_ptr(),
-                minor.as_mut_ptr(),
-            );
-            let major = major.assume_init();
-            let minor = minor.assume_init();
-            (major, minor)
-        }
-    }
-
-    #[doc(alias = "gdk_gl_context_is_legacy")]
-    pub fn is_legacy(&self) -> bool {
-        unsafe { from_glib(ffi::gdk_gl_context_is_legacy(self.to_glib_none().0)) }
-    }
-
-    #[doc(alias = "gdk_gl_context_make_current")]
-    pub fn make_current(&self) {
-        unsafe {
-            ffi::gdk_gl_context_make_current(self.to_glib_none().0);
-        }
-    }
-
-    #[doc(alias = "gdk_gl_context_realize")]
-    pub fn realize(&self) -> Result<(), glib::Error> {
-        unsafe {
-            let mut error = ptr::null_mut();
-            let _ = ffi::gdk_gl_context_realize(self.to_glib_none().0, &mut error);
-            if error.is_null() {
-                Ok(())
-            } else {
-                Err(from_glib_full(error))
-            }
-        }
-    }
-
-    #[doc(alias = "gdk_gl_context_set_debug_enabled")]
-    pub fn set_debug_enabled(&self, enabled: bool) {
-        unsafe {
-            ffi::gdk_gl_context_set_debug_enabled(self.to_glib_none().0, enabled.into_glib());
-        }
-    }
-
-    #[doc(alias = "gdk_gl_context_set_forward_compatible")]
-    pub fn set_forward_compatible(&self, compatible: bool) {
-        unsafe {
-            ffi::gdk_gl_context_set_forward_compatible(
-                self.to_glib_none().0,
-                compatible.into_glib(),
-            );
-        }
-    }
-
-    #[doc(alias = "gdk_gl_context_set_required_version")]
-    pub fn set_required_version(&self, major: i32, minor: i32) {
-        unsafe {
-            ffi::gdk_gl_context_set_required_version(self.to_glib_none().0, major, minor);
-        }
-    }
-
-    #[doc(alias = "gdk_gl_context_set_use_es")]
-    pub fn set_use_es(&self, use_es: i32) {
-        unsafe {
-            ffi::gdk_gl_context_set_use_es(self.to_glib_none().0, use_es);
-        }
-    }
-
     #[doc(alias = "gdk_gl_context_clear_current")]
     pub fn clear_current() {
         assert_initialized_main_thread!();
@@ -152,6 +31,175 @@ impl GLContext {
     pub fn current() -> Option<GLContext> {
         assert_initialized_main_thread!();
         unsafe { from_glib_none(ffi::gdk_gl_context_get_current()) }
+    }
+}
+
+pub const NONE_GL_CONTEXT: Option<&GLContext> = None;
+
+pub trait GLContextExt: 'static {
+    #[doc(alias = "gdk_gl_context_get_debug_enabled")]
+    #[doc(alias = "get_debug_enabled")]
+    fn is_debug_enabled(&self) -> bool;
+
+    #[doc(alias = "gdk_gl_context_get_forward_compatible")]
+    #[doc(alias = "get_forward_compatible")]
+    fn is_forward_compatible(&self) -> bool;
+
+    #[doc(alias = "gdk_gl_context_get_required_version")]
+    #[doc(alias = "get_required_version")]
+    fn required_version(&self) -> (i32, i32);
+
+    #[doc(alias = "gdk_gl_context_get_shared_context")]
+    #[doc(alias = "get_shared_context")]
+    fn shared_context(&self) -> Option<GLContext>;
+
+    #[doc(alias = "gdk_gl_context_get_use_es")]
+    #[doc(alias = "get_use_es")]
+    fn uses_es(&self) -> bool;
+
+    #[doc(alias = "gdk_gl_context_get_version")]
+    #[doc(alias = "get_version")]
+    fn version(&self) -> (i32, i32);
+
+    #[doc(alias = "gdk_gl_context_is_legacy")]
+    fn is_legacy(&self) -> bool;
+
+    #[doc(alias = "gdk_gl_context_make_current")]
+    fn make_current(&self);
+
+    #[doc(alias = "gdk_gl_context_realize")]
+    fn realize(&self) -> Result<(), glib::Error>;
+
+    #[doc(alias = "gdk_gl_context_set_debug_enabled")]
+    fn set_debug_enabled(&self, enabled: bool);
+
+    #[doc(alias = "gdk_gl_context_set_forward_compatible")]
+    fn set_forward_compatible(&self, compatible: bool);
+
+    #[doc(alias = "gdk_gl_context_set_required_version")]
+    fn set_required_version(&self, major: i32, minor: i32);
+
+    #[doc(alias = "gdk_gl_context_set_use_es")]
+    fn set_use_es(&self, use_es: i32);
+}
+
+impl<O: IsA<GLContext>> GLContextExt for O {
+    fn is_debug_enabled(&self) -> bool {
+        unsafe {
+            from_glib(ffi::gdk_gl_context_get_debug_enabled(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
+    }
+
+    fn is_forward_compatible(&self) -> bool {
+        unsafe {
+            from_glib(ffi::gdk_gl_context_get_forward_compatible(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
+    }
+
+    fn required_version(&self) -> (i32, i32) {
+        unsafe {
+            let mut major = mem::MaybeUninit::uninit();
+            let mut minor = mem::MaybeUninit::uninit();
+            ffi::gdk_gl_context_get_required_version(
+                self.as_ref().to_glib_none().0,
+                major.as_mut_ptr(),
+                minor.as_mut_ptr(),
+            );
+            let major = major.assume_init();
+            let minor = minor.assume_init();
+            (major, minor)
+        }
+    }
+
+    fn shared_context(&self) -> Option<GLContext> {
+        unsafe {
+            from_glib_none(ffi::gdk_gl_context_get_shared_context(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
+    }
+
+    fn uses_es(&self) -> bool {
+        unsafe {
+            from_glib(ffi::gdk_gl_context_get_use_es(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
+    }
+
+    fn version(&self) -> (i32, i32) {
+        unsafe {
+            let mut major = mem::MaybeUninit::uninit();
+            let mut minor = mem::MaybeUninit::uninit();
+            ffi::gdk_gl_context_get_version(
+                self.as_ref().to_glib_none().0,
+                major.as_mut_ptr(),
+                minor.as_mut_ptr(),
+            );
+            let major = major.assume_init();
+            let minor = minor.assume_init();
+            (major, minor)
+        }
+    }
+
+    fn is_legacy(&self) -> bool {
+        unsafe {
+            from_glib(ffi::gdk_gl_context_is_legacy(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
+    }
+
+    fn make_current(&self) {
+        unsafe {
+            ffi::gdk_gl_context_make_current(self.as_ref().to_glib_none().0);
+        }
+    }
+
+    fn realize(&self) -> Result<(), glib::Error> {
+        unsafe {
+            let mut error = ptr::null_mut();
+            let _ = ffi::gdk_gl_context_realize(self.as_ref().to_glib_none().0, &mut error);
+            if error.is_null() {
+                Ok(())
+            } else {
+                Err(from_glib_full(error))
+            }
+        }
+    }
+
+    fn set_debug_enabled(&self, enabled: bool) {
+        unsafe {
+            ffi::gdk_gl_context_set_debug_enabled(
+                self.as_ref().to_glib_none().0,
+                enabled.into_glib(),
+            );
+        }
+    }
+
+    fn set_forward_compatible(&self, compatible: bool) {
+        unsafe {
+            ffi::gdk_gl_context_set_forward_compatible(
+                self.as_ref().to_glib_none().0,
+                compatible.into_glib(),
+            );
+        }
+    }
+
+    fn set_required_version(&self, major: i32, minor: i32) {
+        unsafe {
+            ffi::gdk_gl_context_set_required_version(self.as_ref().to_glib_none().0, major, minor);
+        }
+    }
+
+    fn set_use_es(&self, use_es: i32) {
+        unsafe {
+            ffi::gdk_gl_context_set_use_es(self.as_ref().to_glib_none().0, use_es);
+        }
     }
 }
 

--- a/gdk4/src/auto/mod.rs
+++ b/gdk4/src/auto/mod.rs
@@ -3,7 +3,7 @@
 // DO NOT EDIT
 
 mod app_launch_context;
-pub use self::app_launch_context::AppLaunchContext;
+pub use self::app_launch_context::{AppLaunchContext, NONE_APP_LAUNCH_CONTEXT};
 
 mod cairo_context;
 pub use self::cairo_context::CairoContext;
@@ -26,7 +26,7 @@ pub use self::cursor::Cursor;
 pub use self::cursor::CursorBuilder;
 
 mod device;
-pub use self::device::Device;
+pub use self::device::{Device, NONE_DEVICE};
 
 mod device_pad;
 pub use self::device_pad::{DevicePad, NONE_DEVICE_PAD};
@@ -36,13 +36,13 @@ pub use self::device_tool::DeviceTool;
 pub use self::device_tool::DeviceToolBuilder;
 
 mod display;
-pub use self::display::Display;
+pub use self::display::{Display, NONE_DISPLAY};
 
 mod display_manager;
 pub use self::display_manager::DisplayManager;
 
 mod drag;
-pub use self::drag::Drag;
+pub use self::drag::{Drag, NONE_DRAG};
 
 mod drag_surface;
 pub use self::drag_surface::{DragSurface, NONE_DRAG_SURFACE};
@@ -57,7 +57,7 @@ mod frame_clock;
 pub use self::frame_clock::FrameClock;
 
 mod gl_context;
-pub use self::gl_context::GLContext;
+pub use self::gl_context::{GLContext, NONE_GL_CONTEXT};
 
 mod gl_texture;
 pub use self::gl_texture::GLTexture;
@@ -66,7 +66,7 @@ mod memory_texture;
 pub use self::memory_texture::MemoryTexture;
 
 mod monitor;
-pub use self::monitor::Monitor;
+pub use self::monitor::{Monitor, NONE_MONITOR};
 
 mod paintable;
 pub use self::paintable::{Paintable, NONE_PAINTABLE};
@@ -75,13 +75,13 @@ mod popup;
 pub use self::popup::{Popup, NONE_POPUP};
 
 mod seat;
-pub use self::seat::Seat;
+pub use self::seat::{Seat, NONE_SEAT};
 
 mod snapshot;
 pub use self::snapshot::Snapshot;
 
 mod surface;
-pub use self::surface::Surface;
+pub use self::surface::{Surface, NONE_SURFACE};
 
 mod texture;
 pub use self::texture::{Texture, NONE_TEXTURE};
@@ -144,12 +144,20 @@ pub mod functions;
 
 #[doc(hidden)]
 pub mod traits {
+    pub use super::app_launch_context::AppLaunchContextExt;
     pub use super::content_provider::ContentProviderExt;
+    pub use super::device::DeviceExt;
     pub use super::device_pad::DevicePadExt;
+    pub use super::display::DisplayExt;
+    pub use super::drag::DragExt;
     pub use super::drag_surface::DragSurfaceExt;
     pub use super::draw_context::DrawContextExt;
+    pub use super::gl_context::GLContextExt;
+    pub use super::monitor::MonitorExt;
     pub use super::paintable::PaintableExt;
     pub use super::popup::PopupExt;
+    pub use super::seat::SeatExt;
+    pub use super::surface::SurfaceExt;
     pub use super::texture::TextureExt;
     pub use super::toplevel::ToplevelExt;
 }

--- a/gdk4/src/auto/monitor.rs
+++ b/gdk4/src/auto/monitor.rs
@@ -5,7 +5,8 @@
 use crate::Display;
 use crate::Rectangle;
 use crate::SubpixelLayout;
-use glib::object::ObjectType as ObjectType_;
+use glib::object::Cast;
+use glib::object::IsA;
 use glib::signal::connect_raw;
 use glib::signal::SignalHandlerId;
 use glib::translate::*;
@@ -21,84 +22,158 @@ glib::wrapper! {
     }
 }
 
-impl Monitor {
+pub const NONE_MONITOR: Option<&Monitor> = None;
+
+pub trait MonitorExt: 'static {
     #[doc(alias = "gdk_monitor_get_connector")]
     #[doc(alias = "get_connector")]
-    pub fn connector(&self) -> Option<glib::GString> {
-        unsafe { from_glib_none(ffi::gdk_monitor_get_connector(self.to_glib_none().0)) }
-    }
+    fn connector(&self) -> Option<glib::GString>;
 
     #[doc(alias = "gdk_monitor_get_display")]
     #[doc(alias = "get_display")]
-    pub fn display(&self) -> Option<Display> {
-        unsafe { from_glib_none(ffi::gdk_monitor_get_display(self.to_glib_none().0)) }
-    }
+    fn display(&self) -> Option<Display>;
 
     #[doc(alias = "gdk_monitor_get_geometry")]
     #[doc(alias = "get_geometry")]
-    pub fn geometry(&self) -> Rectangle {
+    fn geometry(&self) -> Rectangle;
+
+    #[doc(alias = "gdk_monitor_get_height_mm")]
+    #[doc(alias = "get_height_mm")]
+    fn height_mm(&self) -> i32;
+
+    #[doc(alias = "gdk_monitor_get_manufacturer")]
+    #[doc(alias = "get_manufacturer")]
+    fn manufacturer(&self) -> Option<glib::GString>;
+
+    #[doc(alias = "gdk_monitor_get_model")]
+    #[doc(alias = "get_model")]
+    fn model(&self) -> Option<glib::GString>;
+
+    #[doc(alias = "gdk_monitor_get_refresh_rate")]
+    #[doc(alias = "get_refresh_rate")]
+    fn refresh_rate(&self) -> i32;
+
+    #[doc(alias = "gdk_monitor_get_scale_factor")]
+    #[doc(alias = "get_scale_factor")]
+    fn scale_factor(&self) -> i32;
+
+    #[doc(alias = "gdk_monitor_get_subpixel_layout")]
+    #[doc(alias = "get_subpixel_layout")]
+    fn subpixel_layout(&self) -> SubpixelLayout;
+
+    #[doc(alias = "gdk_monitor_get_width_mm")]
+    #[doc(alias = "get_width_mm")]
+    fn width_mm(&self) -> i32;
+
+    #[doc(alias = "gdk_monitor_is_valid")]
+    fn is_valid(&self) -> bool;
+
+    #[doc(alias = "invalidate")]
+    fn connect_invalidate<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "connector")]
+    fn connect_connector_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "geometry")]
+    fn connect_geometry_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "height-mm")]
+    fn connect_height_mm_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "manufacturer")]
+    fn connect_manufacturer_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "model")]
+    fn connect_model_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "refresh-rate")]
+    fn connect_refresh_rate_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "scale-factor")]
+    fn connect_scale_factor_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "subpixel-layout")]
+    fn connect_subpixel_layout_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "valid")]
+    fn connect_valid_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "width-mm")]
+    fn connect_width_mm_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+}
+
+impl<O: IsA<Monitor>> MonitorExt for O {
+    fn connector(&self) -> Option<glib::GString> {
+        unsafe {
+            from_glib_none(ffi::gdk_monitor_get_connector(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
+    }
+
+    fn display(&self) -> Option<Display> {
+        unsafe { from_glib_none(ffi::gdk_monitor_get_display(self.as_ref().to_glib_none().0)) }
+    }
+
+    fn geometry(&self) -> Rectangle {
         unsafe {
             let mut geometry = Rectangle::uninitialized();
-            ffi::gdk_monitor_get_geometry(self.to_glib_none().0, geometry.to_glib_none_mut().0);
+            ffi::gdk_monitor_get_geometry(
+                self.as_ref().to_glib_none().0,
+                geometry.to_glib_none_mut().0,
+            );
             geometry
         }
     }
 
-    #[doc(alias = "gdk_monitor_get_height_mm")]
-    #[doc(alias = "get_height_mm")]
-    pub fn height_mm(&self) -> i32 {
-        unsafe { ffi::gdk_monitor_get_height_mm(self.to_glib_none().0) }
+    fn height_mm(&self) -> i32 {
+        unsafe { ffi::gdk_monitor_get_height_mm(self.as_ref().to_glib_none().0) }
     }
 
-    #[doc(alias = "gdk_monitor_get_manufacturer")]
-    #[doc(alias = "get_manufacturer")]
-    pub fn manufacturer(&self) -> Option<glib::GString> {
-        unsafe { from_glib_none(ffi::gdk_monitor_get_manufacturer(self.to_glib_none().0)) }
+    fn manufacturer(&self) -> Option<glib::GString> {
+        unsafe {
+            from_glib_none(ffi::gdk_monitor_get_manufacturer(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
     }
 
-    #[doc(alias = "gdk_monitor_get_model")]
-    #[doc(alias = "get_model")]
-    pub fn model(&self) -> Option<glib::GString> {
-        unsafe { from_glib_none(ffi::gdk_monitor_get_model(self.to_glib_none().0)) }
+    fn model(&self) -> Option<glib::GString> {
+        unsafe { from_glib_none(ffi::gdk_monitor_get_model(self.as_ref().to_glib_none().0)) }
     }
 
-    #[doc(alias = "gdk_monitor_get_refresh_rate")]
-    #[doc(alias = "get_refresh_rate")]
-    pub fn refresh_rate(&self) -> i32 {
-        unsafe { ffi::gdk_monitor_get_refresh_rate(self.to_glib_none().0) }
+    fn refresh_rate(&self) -> i32 {
+        unsafe { ffi::gdk_monitor_get_refresh_rate(self.as_ref().to_glib_none().0) }
     }
 
-    #[doc(alias = "gdk_monitor_get_scale_factor")]
-    #[doc(alias = "get_scale_factor")]
-    pub fn scale_factor(&self) -> i32 {
-        unsafe { ffi::gdk_monitor_get_scale_factor(self.to_glib_none().0) }
+    fn scale_factor(&self) -> i32 {
+        unsafe { ffi::gdk_monitor_get_scale_factor(self.as_ref().to_glib_none().0) }
     }
 
-    #[doc(alias = "gdk_monitor_get_subpixel_layout")]
-    #[doc(alias = "get_subpixel_layout")]
-    pub fn subpixel_layout(&self) -> SubpixelLayout {
-        unsafe { from_glib(ffi::gdk_monitor_get_subpixel_layout(self.to_glib_none().0)) }
+    fn subpixel_layout(&self) -> SubpixelLayout {
+        unsafe {
+            from_glib(ffi::gdk_monitor_get_subpixel_layout(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
     }
 
-    #[doc(alias = "gdk_monitor_get_width_mm")]
-    #[doc(alias = "get_width_mm")]
-    pub fn width_mm(&self) -> i32 {
-        unsafe { ffi::gdk_monitor_get_width_mm(self.to_glib_none().0) }
+    fn width_mm(&self) -> i32 {
+        unsafe { ffi::gdk_monitor_get_width_mm(self.as_ref().to_glib_none().0) }
     }
 
-    #[doc(alias = "gdk_monitor_is_valid")]
-    pub fn is_valid(&self) -> bool {
-        unsafe { from_glib(ffi::gdk_monitor_is_valid(self.to_glib_none().0)) }
+    fn is_valid(&self) -> bool {
+        unsafe { from_glib(ffi::gdk_monitor_is_valid(self.as_ref().to_glib_none().0)) }
     }
 
     #[doc(alias = "invalidate")]
-    pub fn connect_invalidate<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn invalidate_trampoline<F: Fn(&Monitor) + 'static>(
+    fn connect_invalidate<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn invalidate_trampoline<P: IsA<Monitor>, F: Fn(&P) + 'static>(
             this: *mut ffi::GdkMonitor,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Monitor::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -106,7 +181,7 @@ impl Monitor {
                 self.as_ptr() as *mut _,
                 b"invalidate\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    invalidate_trampoline::<F> as *const (),
+                    invalidate_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -114,14 +189,14 @@ impl Monitor {
     }
 
     #[doc(alias = "connector")]
-    pub fn connect_connector_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn notify_connector_trampoline<F: Fn(&Monitor) + 'static>(
+    fn connect_connector_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn notify_connector_trampoline<P: IsA<Monitor>, F: Fn(&P) + 'static>(
             this: *mut ffi::GdkMonitor,
             _param_spec: glib::ffi::gpointer,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Monitor::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -129,7 +204,7 @@ impl Monitor {
                 self.as_ptr() as *mut _,
                 b"notify::connector\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    notify_connector_trampoline::<F> as *const (),
+                    notify_connector_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -137,14 +212,14 @@ impl Monitor {
     }
 
     #[doc(alias = "geometry")]
-    pub fn connect_geometry_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn notify_geometry_trampoline<F: Fn(&Monitor) + 'static>(
+    fn connect_geometry_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn notify_geometry_trampoline<P: IsA<Monitor>, F: Fn(&P) + 'static>(
             this: *mut ffi::GdkMonitor,
             _param_spec: glib::ffi::gpointer,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Monitor::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -152,7 +227,7 @@ impl Monitor {
                 self.as_ptr() as *mut _,
                 b"notify::geometry\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    notify_geometry_trampoline::<F> as *const (),
+                    notify_geometry_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -160,14 +235,14 @@ impl Monitor {
     }
 
     #[doc(alias = "height-mm")]
-    pub fn connect_height_mm_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn notify_height_mm_trampoline<F: Fn(&Monitor) + 'static>(
+    fn connect_height_mm_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn notify_height_mm_trampoline<P: IsA<Monitor>, F: Fn(&P) + 'static>(
             this: *mut ffi::GdkMonitor,
             _param_spec: glib::ffi::gpointer,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Monitor::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -175,7 +250,7 @@ impl Monitor {
                 self.as_ptr() as *mut _,
                 b"notify::height-mm\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    notify_height_mm_trampoline::<F> as *const (),
+                    notify_height_mm_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -183,14 +258,17 @@ impl Monitor {
     }
 
     #[doc(alias = "manufacturer")]
-    pub fn connect_manufacturer_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn notify_manufacturer_trampoline<F: Fn(&Monitor) + 'static>(
+    fn connect_manufacturer_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn notify_manufacturer_trampoline<
+            P: IsA<Monitor>,
+            F: Fn(&P) + 'static,
+        >(
             this: *mut ffi::GdkMonitor,
             _param_spec: glib::ffi::gpointer,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Monitor::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -198,7 +276,7 @@ impl Monitor {
                 self.as_ptr() as *mut _,
                 b"notify::manufacturer\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    notify_manufacturer_trampoline::<F> as *const (),
+                    notify_manufacturer_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -206,14 +284,14 @@ impl Monitor {
     }
 
     #[doc(alias = "model")]
-    pub fn connect_model_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn notify_model_trampoline<F: Fn(&Monitor) + 'static>(
+    fn connect_model_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn notify_model_trampoline<P: IsA<Monitor>, F: Fn(&P) + 'static>(
             this: *mut ffi::GdkMonitor,
             _param_spec: glib::ffi::gpointer,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Monitor::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -221,7 +299,7 @@ impl Monitor {
                 self.as_ptr() as *mut _,
                 b"notify::model\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    notify_model_trampoline::<F> as *const (),
+                    notify_model_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -229,14 +307,17 @@ impl Monitor {
     }
 
     #[doc(alias = "refresh-rate")]
-    pub fn connect_refresh_rate_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn notify_refresh_rate_trampoline<F: Fn(&Monitor) + 'static>(
+    fn connect_refresh_rate_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn notify_refresh_rate_trampoline<
+            P: IsA<Monitor>,
+            F: Fn(&P) + 'static,
+        >(
             this: *mut ffi::GdkMonitor,
             _param_spec: glib::ffi::gpointer,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Monitor::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -244,7 +325,7 @@ impl Monitor {
                 self.as_ptr() as *mut _,
                 b"notify::refresh-rate\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    notify_refresh_rate_trampoline::<F> as *const (),
+                    notify_refresh_rate_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -252,14 +333,17 @@ impl Monitor {
     }
 
     #[doc(alias = "scale-factor")]
-    pub fn connect_scale_factor_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn notify_scale_factor_trampoline<F: Fn(&Monitor) + 'static>(
+    fn connect_scale_factor_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn notify_scale_factor_trampoline<
+            P: IsA<Monitor>,
+            F: Fn(&P) + 'static,
+        >(
             this: *mut ffi::GdkMonitor,
             _param_spec: glib::ffi::gpointer,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Monitor::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -267,7 +351,7 @@ impl Monitor {
                 self.as_ptr() as *mut _,
                 b"notify::scale-factor\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    notify_scale_factor_trampoline::<F> as *const (),
+                    notify_scale_factor_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -275,14 +359,17 @@ impl Monitor {
     }
 
     #[doc(alias = "subpixel-layout")]
-    pub fn connect_subpixel_layout_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn notify_subpixel_layout_trampoline<F: Fn(&Monitor) + 'static>(
+    fn connect_subpixel_layout_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn notify_subpixel_layout_trampoline<
+            P: IsA<Monitor>,
+            F: Fn(&P) + 'static,
+        >(
             this: *mut ffi::GdkMonitor,
             _param_spec: glib::ffi::gpointer,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Monitor::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -290,7 +377,7 @@ impl Monitor {
                 self.as_ptr() as *mut _,
                 b"notify::subpixel-layout\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    notify_subpixel_layout_trampoline::<F> as *const (),
+                    notify_subpixel_layout_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -298,14 +385,14 @@ impl Monitor {
     }
 
     #[doc(alias = "valid")]
-    pub fn connect_valid_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn notify_valid_trampoline<F: Fn(&Monitor) + 'static>(
+    fn connect_valid_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn notify_valid_trampoline<P: IsA<Monitor>, F: Fn(&P) + 'static>(
             this: *mut ffi::GdkMonitor,
             _param_spec: glib::ffi::gpointer,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Monitor::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -313,7 +400,7 @@ impl Monitor {
                 self.as_ptr() as *mut _,
                 b"notify::valid\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    notify_valid_trampoline::<F> as *const (),
+                    notify_valid_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -321,14 +408,14 @@ impl Monitor {
     }
 
     #[doc(alias = "width-mm")]
-    pub fn connect_width_mm_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn notify_width_mm_trampoline<F: Fn(&Monitor) + 'static>(
+    fn connect_width_mm_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn notify_width_mm_trampoline<P: IsA<Monitor>, F: Fn(&P) + 'static>(
             this: *mut ffi::GdkMonitor,
             _param_spec: glib::ffi::gpointer,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Monitor::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -336,7 +423,7 @@ impl Monitor {
                 self.as_ptr() as *mut _,
                 b"notify::width-mm\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    notify_width_mm_trampoline::<F> as *const (),
+                    notify_width_mm_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )

--- a/gdk4/src/auto/surface.rs
+++ b/gdk4/src/auto/surface.rs
@@ -12,7 +12,8 @@ use crate::GLContext;
 use crate::ModifierType;
 use crate::Monitor;
 use crate::VulkanContext;
-use glib::object::ObjectType as ObjectType_;
+use glib::object::Cast;
+use glib::object::IsA;
 use glib::signal::connect_raw;
 use glib::signal::SignalHandlerId;
 use glib::translate::*;
@@ -32,94 +33,207 @@ glib::wrapper! {
 
 impl Surface {
     #[doc(alias = "gdk_surface_new_popup")]
-    pub fn new_popup(parent: &Surface, autohide: bool) -> Surface {
+    pub fn new_popup<P: IsA<Surface>>(parent: &P, autohide: bool) -> Surface {
         skip_assert_initialized!();
         unsafe {
             from_glib_full(ffi::gdk_surface_new_popup(
-                parent.to_glib_none().0,
+                parent.as_ref().to_glib_none().0,
                 autohide.into_glib(),
             ))
         }
     }
 
     #[doc(alias = "gdk_surface_new_toplevel")]
-    pub fn new_toplevel(display: &Display) -> Surface {
+    pub fn new_toplevel<P: IsA<Display>>(display: &P) -> Surface {
         skip_assert_initialized!();
-        unsafe { from_glib_full(ffi::gdk_surface_new_toplevel(display.to_glib_none().0)) }
-    }
-
-    #[doc(alias = "gdk_surface_beep")]
-    pub fn beep(&self) {
         unsafe {
-            ffi::gdk_surface_beep(self.to_glib_none().0);
+            from_glib_full(ffi::gdk_surface_new_toplevel(
+                display.as_ref().to_glib_none().0,
+            ))
         }
     }
+}
+
+pub const NONE_SURFACE: Option<&Surface> = None;
+
+pub trait SurfaceExt: 'static {
+    #[doc(alias = "gdk_surface_beep")]
+    fn beep(&self);
 
     #[doc(alias = "gdk_surface_create_cairo_context")]
-    pub fn create_cairo_context(&self) -> Option<CairoContext> {
-        unsafe { from_glib_full(ffi::gdk_surface_create_cairo_context(self.to_glib_none().0)) }
-    }
+    fn create_cairo_context(&self) -> Option<CairoContext>;
 
     #[doc(alias = "gdk_surface_create_gl_context")]
-    pub fn create_gl_context(&self) -> Result<GLContext, glib::Error> {
-        unsafe {
-            let mut error = ptr::null_mut();
-            let ret = ffi::gdk_surface_create_gl_context(self.to_glib_none().0, &mut error);
-            if error.is_null() {
-                Ok(from_glib_full(ret))
-            } else {
-                Err(from_glib_full(error))
-            }
-        }
-    }
+    fn create_gl_context(&self) -> Result<GLContext, glib::Error>;
 
     #[doc(alias = "gdk_surface_create_vulkan_context")]
-    pub fn create_vulkan_context(&self) -> Result<VulkanContext, glib::Error> {
-        unsafe {
-            let mut error = ptr::null_mut();
-            let ret = ffi::gdk_surface_create_vulkan_context(self.to_glib_none().0, &mut error);
-            if error.is_null() {
-                Ok(from_glib_full(ret))
-            } else {
-                Err(from_glib_full(error))
-            }
-        }
-    }
+    fn create_vulkan_context(&self) -> Result<VulkanContext, glib::Error>;
 
     #[doc(alias = "gdk_surface_destroy")]
-    pub fn destroy(&self) {
-        unsafe {
-            ffi::gdk_surface_destroy(self.to_glib_none().0);
-        }
-    }
+    fn destroy(&self);
 
     #[doc(alias = "gdk_surface_get_cursor")]
     #[doc(alias = "get_cursor")]
-    pub fn cursor(&self) -> Option<Cursor> {
-        unsafe { from_glib_none(ffi::gdk_surface_get_cursor(self.to_glib_none().0)) }
-    }
+    fn cursor(&self) -> Option<Cursor>;
 
     #[doc(alias = "gdk_surface_get_device_cursor")]
     #[doc(alias = "get_device_cursor")]
-    pub fn device_cursor(&self, device: &Device) -> Option<Cursor> {
+    fn device_cursor<P: IsA<Device>>(&self, device: &P) -> Option<Cursor>;
+
+    #[doc(alias = "gdk_surface_get_device_position")]
+    #[doc(alias = "get_device_position")]
+    fn device_position<P: IsA<Device>>(&self, device: &P) -> Option<(f64, f64, ModifierType)>;
+
+    #[doc(alias = "gdk_surface_get_display")]
+    #[doc(alias = "get_display")]
+    fn display(&self) -> Option<Display>;
+
+    #[doc(alias = "gdk_surface_get_frame_clock")]
+    #[doc(alias = "get_frame_clock")]
+    fn frame_clock(&self) -> Option<FrameClock>;
+
+    #[doc(alias = "gdk_surface_get_height")]
+    #[doc(alias = "get_height")]
+    fn height(&self) -> i32;
+
+    #[doc(alias = "gdk_surface_get_mapped")]
+    #[doc(alias = "get_mapped")]
+    fn is_mapped(&self) -> bool;
+
+    #[doc(alias = "gdk_surface_get_scale_factor")]
+    #[doc(alias = "get_scale_factor")]
+    fn scale_factor(&self) -> i32;
+
+    #[doc(alias = "gdk_surface_get_width")]
+    #[doc(alias = "get_width")]
+    fn width(&self) -> i32;
+
+    #[doc(alias = "gdk_surface_hide")]
+    fn hide(&self);
+
+    #[doc(alias = "gdk_surface_is_destroyed")]
+    fn is_destroyed(&self) -> bool;
+
+    #[doc(alias = "gdk_surface_queue_render")]
+    fn queue_render(&self);
+
+    #[doc(alias = "gdk_surface_request_layout")]
+    fn request_layout(&self);
+
+    #[doc(alias = "gdk_surface_set_cursor")]
+    fn set_cursor(&self, cursor: Option<&Cursor>);
+
+    #[doc(alias = "gdk_surface_set_device_cursor")]
+    fn set_device_cursor<P: IsA<Device>>(&self, device: &P, cursor: &Cursor);
+
+    #[doc(alias = "gdk_surface_set_input_region")]
+    fn set_input_region(&self, region: &mut cairo::Region);
+
+    #[doc(alias = "gdk_surface_set_opaque_region")]
+    fn set_opaque_region(&self, region: Option<&cairo::Region>);
+
+    #[doc(alias = "enter-monitor")]
+    fn connect_enter_monitor<F: Fn(&Self, &Monitor) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "event")]
+    fn connect_event<F: Fn(&Self, &Event) -> bool + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "layout")]
+    fn connect_layout<F: Fn(&Self, i32, i32) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "leave-monitor")]
+    fn connect_leave_monitor<F: Fn(&Self, &Monitor) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "render")]
+    fn connect_render<F: Fn(&Self, &cairo::Region) -> bool + 'static>(
+        &self,
+        f: F,
+    ) -> SignalHandlerId;
+
+    #[doc(alias = "cursor")]
+    fn connect_cursor_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "height")]
+    fn connect_height_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "mapped")]
+    fn connect_mapped_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "scale-factor")]
+    fn connect_scale_factor_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+
+    #[doc(alias = "width")]
+    fn connect_width_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
+}
+
+impl<O: IsA<Surface>> SurfaceExt for O {
+    fn beep(&self) {
         unsafe {
-            from_glib_none(ffi::gdk_surface_get_device_cursor(
-                self.to_glib_none().0,
-                device.to_glib_none().0,
+            ffi::gdk_surface_beep(self.as_ref().to_glib_none().0);
+        }
+    }
+
+    fn create_cairo_context(&self) -> Option<CairoContext> {
+        unsafe {
+            from_glib_full(ffi::gdk_surface_create_cairo_context(
+                self.as_ref().to_glib_none().0,
             ))
         }
     }
 
-    #[doc(alias = "gdk_surface_get_device_position")]
-    #[doc(alias = "get_device_position")]
-    pub fn device_position(&self, device: &Device) -> Option<(f64, f64, ModifierType)> {
+    fn create_gl_context(&self) -> Result<GLContext, glib::Error> {
+        unsafe {
+            let mut error = ptr::null_mut();
+            let ret =
+                ffi::gdk_surface_create_gl_context(self.as_ref().to_glib_none().0, &mut error);
+            if error.is_null() {
+                Ok(from_glib_full(ret))
+            } else {
+                Err(from_glib_full(error))
+            }
+        }
+    }
+
+    fn create_vulkan_context(&self) -> Result<VulkanContext, glib::Error> {
+        unsafe {
+            let mut error = ptr::null_mut();
+            let ret =
+                ffi::gdk_surface_create_vulkan_context(self.as_ref().to_glib_none().0, &mut error);
+            if error.is_null() {
+                Ok(from_glib_full(ret))
+            } else {
+                Err(from_glib_full(error))
+            }
+        }
+    }
+
+    fn destroy(&self) {
+        unsafe {
+            ffi::gdk_surface_destroy(self.as_ref().to_glib_none().0);
+        }
+    }
+
+    fn cursor(&self) -> Option<Cursor> {
+        unsafe { from_glib_none(ffi::gdk_surface_get_cursor(self.as_ref().to_glib_none().0)) }
+    }
+
+    fn device_cursor<P: IsA<Device>>(&self, device: &P) -> Option<Cursor> {
+        unsafe {
+            from_glib_none(ffi::gdk_surface_get_device_cursor(
+                self.as_ref().to_glib_none().0,
+                device.as_ref().to_glib_none().0,
+            ))
+        }
+    }
+
+    fn device_position<P: IsA<Device>>(&self, device: &P) -> Option<(f64, f64, ModifierType)> {
         unsafe {
             let mut x = mem::MaybeUninit::uninit();
             let mut y = mem::MaybeUninit::uninit();
             let mut mask = mem::MaybeUninit::uninit();
             let ret = from_glib(ffi::gdk_surface_get_device_position(
-                self.to_glib_none().0,
-                device.to_glib_none().0,
+                self.as_ref().to_glib_none().0,
+                device.as_ref().to_glib_none().0,
                 x.as_mut_ptr(),
                 y.as_mut_ptr(),
                 mask.as_mut_ptr(),
@@ -135,112 +249,109 @@ impl Surface {
         }
     }
 
-    #[doc(alias = "gdk_surface_get_display")]
-    #[doc(alias = "get_display")]
-    pub fn display(&self) -> Option<Display> {
-        unsafe { from_glib_none(ffi::gdk_surface_get_display(self.to_glib_none().0)) }
+    fn display(&self) -> Option<Display> {
+        unsafe { from_glib_none(ffi::gdk_surface_get_display(self.as_ref().to_glib_none().0)) }
     }
 
-    #[doc(alias = "gdk_surface_get_frame_clock")]
-    #[doc(alias = "get_frame_clock")]
-    pub fn frame_clock(&self) -> Option<FrameClock> {
-        unsafe { from_glib_none(ffi::gdk_surface_get_frame_clock(self.to_glib_none().0)) }
-    }
-
-    #[doc(alias = "gdk_surface_get_height")]
-    #[doc(alias = "get_height")]
-    pub fn height(&self) -> i32 {
-        unsafe { ffi::gdk_surface_get_height(self.to_glib_none().0) }
-    }
-
-    #[doc(alias = "gdk_surface_get_mapped")]
-    #[doc(alias = "get_mapped")]
-    pub fn is_mapped(&self) -> bool {
-        unsafe { from_glib(ffi::gdk_surface_get_mapped(self.to_glib_none().0)) }
-    }
-
-    #[doc(alias = "gdk_surface_get_scale_factor")]
-    #[doc(alias = "get_scale_factor")]
-    pub fn scale_factor(&self) -> i32 {
-        unsafe { ffi::gdk_surface_get_scale_factor(self.to_glib_none().0) }
-    }
-
-    #[doc(alias = "gdk_surface_get_width")]
-    #[doc(alias = "get_width")]
-    pub fn width(&self) -> i32 {
-        unsafe { ffi::gdk_surface_get_width(self.to_glib_none().0) }
-    }
-
-    #[doc(alias = "gdk_surface_hide")]
-    pub fn hide(&self) {
+    fn frame_clock(&self) -> Option<FrameClock> {
         unsafe {
-            ffi::gdk_surface_hide(self.to_glib_none().0);
+            from_glib_none(ffi::gdk_surface_get_frame_clock(
+                self.as_ref().to_glib_none().0,
+            ))
         }
     }
 
-    #[doc(alias = "gdk_surface_is_destroyed")]
-    pub fn is_destroyed(&self) -> bool {
-        unsafe { from_glib(ffi::gdk_surface_is_destroyed(self.to_glib_none().0)) }
+    fn height(&self) -> i32 {
+        unsafe { ffi::gdk_surface_get_height(self.as_ref().to_glib_none().0) }
     }
 
-    #[doc(alias = "gdk_surface_queue_render")]
-    pub fn queue_render(&self) {
+    fn is_mapped(&self) -> bool {
+        unsafe { from_glib(ffi::gdk_surface_get_mapped(self.as_ref().to_glib_none().0)) }
+    }
+
+    fn scale_factor(&self) -> i32 {
+        unsafe { ffi::gdk_surface_get_scale_factor(self.as_ref().to_glib_none().0) }
+    }
+
+    fn width(&self) -> i32 {
+        unsafe { ffi::gdk_surface_get_width(self.as_ref().to_glib_none().0) }
+    }
+
+    fn hide(&self) {
         unsafe {
-            ffi::gdk_surface_queue_render(self.to_glib_none().0);
+            ffi::gdk_surface_hide(self.as_ref().to_glib_none().0);
         }
     }
 
-    #[doc(alias = "gdk_surface_request_layout")]
-    pub fn request_layout(&self) {
+    fn is_destroyed(&self) -> bool {
         unsafe {
-            ffi::gdk_surface_request_layout(self.to_glib_none().0);
+            from_glib(ffi::gdk_surface_is_destroyed(
+                self.as_ref().to_glib_none().0,
+            ))
         }
     }
 
-    #[doc(alias = "gdk_surface_set_cursor")]
-    pub fn set_cursor(&self, cursor: Option<&Cursor>) {
+    fn queue_render(&self) {
         unsafe {
-            ffi::gdk_surface_set_cursor(self.to_glib_none().0, cursor.to_glib_none().0);
+            ffi::gdk_surface_queue_render(self.as_ref().to_glib_none().0);
         }
     }
 
-    #[doc(alias = "gdk_surface_set_device_cursor")]
-    pub fn set_device_cursor(&self, device: &Device, cursor: &Cursor) {
+    fn request_layout(&self) {
+        unsafe {
+            ffi::gdk_surface_request_layout(self.as_ref().to_glib_none().0);
+        }
+    }
+
+    fn set_cursor(&self, cursor: Option<&Cursor>) {
+        unsafe {
+            ffi::gdk_surface_set_cursor(self.as_ref().to_glib_none().0, cursor.to_glib_none().0);
+        }
+    }
+
+    fn set_device_cursor<P: IsA<Device>>(&self, device: &P, cursor: &Cursor) {
         unsafe {
             ffi::gdk_surface_set_device_cursor(
-                self.to_glib_none().0,
-                device.to_glib_none().0,
+                self.as_ref().to_glib_none().0,
+                device.as_ref().to_glib_none().0,
                 cursor.to_glib_none().0,
             );
         }
     }
 
-    #[doc(alias = "gdk_surface_set_input_region")]
-    pub fn set_input_region(&self, region: &mut cairo::Region) {
+    fn set_input_region(&self, region: &mut cairo::Region) {
         unsafe {
-            ffi::gdk_surface_set_input_region(self.to_glib_none().0, region.to_glib_none_mut().0);
+            ffi::gdk_surface_set_input_region(
+                self.as_ref().to_glib_none().0,
+                region.to_glib_none_mut().0,
+            );
         }
     }
 
-    #[doc(alias = "gdk_surface_set_opaque_region")]
-    pub fn set_opaque_region(&self, region: Option<&cairo::Region>) {
+    fn set_opaque_region(&self, region: Option<&cairo::Region>) {
         unsafe {
             ffi::gdk_surface_set_opaque_region(
-                self.to_glib_none().0,
+                self.as_ref().to_glib_none().0,
                 mut_override(region.to_glib_none().0),
             );
         }
     }
 
     #[doc(alias = "enter-monitor")]
-    pub fn connect_enter_monitor<F: Fn(&Self, &Monitor) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn enter_monitor_trampoline<F: Fn(&Surface, &Monitor) + 'static>(
+    fn connect_enter_monitor<F: Fn(&Self, &Monitor) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn enter_monitor_trampoline<
+            P: IsA<Surface>,
+            F: Fn(&P, &Monitor) + 'static,
+        >(
             this: *mut ffi::GdkSurface,
             monitor: *mut ffi::GdkMonitor,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this), &from_glib_borrow(monitor))
+            f(
+                &Surface::from_glib_borrow(this).unsafe_cast_ref(),
+                &from_glib_borrow(monitor),
+            )
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -248,7 +359,7 @@ impl Surface {
                 self.as_ptr() as *mut _,
                 b"enter-monitor\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    enter_monitor_trampoline::<F> as *const (),
+                    enter_monitor_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -256,14 +367,21 @@ impl Surface {
     }
 
     #[doc(alias = "event")]
-    pub fn connect_event<F: Fn(&Self, &Event) -> bool + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn event_trampoline<F: Fn(&Surface, &Event) -> bool + 'static>(
+    fn connect_event<F: Fn(&Self, &Event) -> bool + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn event_trampoline<
+            P: IsA<Surface>,
+            F: Fn(&P, &Event) -> bool + 'static,
+        >(
             this: *mut ffi::GdkSurface,
             event: *mut ffi::GdkEvent,
             f: glib::ffi::gpointer,
         ) -> glib::ffi::gboolean {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this), &from_glib_borrow(event)).into_glib()
+            f(
+                &Surface::from_glib_borrow(this).unsafe_cast_ref(),
+                &from_glib_borrow(event),
+            )
+            .into_glib()
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -271,7 +389,7 @@ impl Surface {
                 self.as_ptr() as *mut _,
                 b"event\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    event_trampoline::<F> as *const (),
+                    event_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -279,15 +397,19 @@ impl Surface {
     }
 
     #[doc(alias = "layout")]
-    pub fn connect_layout<F: Fn(&Self, i32, i32) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn layout_trampoline<F: Fn(&Surface, i32, i32) + 'static>(
+    fn connect_layout<F: Fn(&Self, i32, i32) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn layout_trampoline<P: IsA<Surface>, F: Fn(&P, i32, i32) + 'static>(
             this: *mut ffi::GdkSurface,
             width: libc::c_int,
             height: libc::c_int,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this), width, height)
+            f(
+                &Surface::from_glib_borrow(this).unsafe_cast_ref(),
+                width,
+                height,
+            )
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -295,7 +417,7 @@ impl Surface {
                 self.as_ptr() as *mut _,
                 b"layout\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    layout_trampoline::<F> as *const (),
+                    layout_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -303,14 +425,20 @@ impl Surface {
     }
 
     #[doc(alias = "leave-monitor")]
-    pub fn connect_leave_monitor<F: Fn(&Self, &Monitor) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn leave_monitor_trampoline<F: Fn(&Surface, &Monitor) + 'static>(
+    fn connect_leave_monitor<F: Fn(&Self, &Monitor) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn leave_monitor_trampoline<
+            P: IsA<Surface>,
+            F: Fn(&P, &Monitor) + 'static,
+        >(
             this: *mut ffi::GdkSurface,
             monitor: *mut ffi::GdkMonitor,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this), &from_glib_borrow(monitor))
+            f(
+                &Surface::from_glib_borrow(this).unsafe_cast_ref(),
+                &from_glib_borrow(monitor),
+            )
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -318,7 +446,7 @@ impl Surface {
                 self.as_ptr() as *mut _,
                 b"leave-monitor\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    leave_monitor_trampoline::<F> as *const (),
+                    leave_monitor_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -326,19 +454,24 @@ impl Surface {
     }
 
     #[doc(alias = "render")]
-    pub fn connect_render<F: Fn(&Self, &cairo::Region) -> bool + 'static>(
+    fn connect_render<F: Fn(&Self, &cairo::Region) -> bool + 'static>(
         &self,
         f: F,
     ) -> SignalHandlerId {
         unsafe extern "C" fn render_trampoline<
-            F: Fn(&Surface, &cairo::Region) -> bool + 'static,
+            P: IsA<Surface>,
+            F: Fn(&P, &cairo::Region) -> bool + 'static,
         >(
             this: *mut ffi::GdkSurface,
             region: *mut cairo::ffi::cairo_region_t,
             f: glib::ffi::gpointer,
         ) -> glib::ffi::gboolean {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this), &from_glib_borrow(region)).into_glib()
+            f(
+                &Surface::from_glib_borrow(this).unsafe_cast_ref(),
+                &from_glib_borrow(region),
+            )
+            .into_glib()
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -346,7 +479,7 @@ impl Surface {
                 self.as_ptr() as *mut _,
                 b"render\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    render_trampoline::<F> as *const (),
+                    render_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -354,14 +487,14 @@ impl Surface {
     }
 
     #[doc(alias = "cursor")]
-    pub fn connect_cursor_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn notify_cursor_trampoline<F: Fn(&Surface) + 'static>(
+    fn connect_cursor_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn notify_cursor_trampoline<P: IsA<Surface>, F: Fn(&P) + 'static>(
             this: *mut ffi::GdkSurface,
             _param_spec: glib::ffi::gpointer,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Surface::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -369,7 +502,7 @@ impl Surface {
                 self.as_ptr() as *mut _,
                 b"notify::cursor\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    notify_cursor_trampoline::<F> as *const (),
+                    notify_cursor_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -377,14 +510,14 @@ impl Surface {
     }
 
     #[doc(alias = "height")]
-    pub fn connect_height_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn notify_height_trampoline<F: Fn(&Surface) + 'static>(
+    fn connect_height_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn notify_height_trampoline<P: IsA<Surface>, F: Fn(&P) + 'static>(
             this: *mut ffi::GdkSurface,
             _param_spec: glib::ffi::gpointer,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Surface::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -392,7 +525,7 @@ impl Surface {
                 self.as_ptr() as *mut _,
                 b"notify::height\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    notify_height_trampoline::<F> as *const (),
+                    notify_height_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -400,14 +533,14 @@ impl Surface {
     }
 
     #[doc(alias = "mapped")]
-    pub fn connect_mapped_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn notify_mapped_trampoline<F: Fn(&Surface) + 'static>(
+    fn connect_mapped_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn notify_mapped_trampoline<P: IsA<Surface>, F: Fn(&P) + 'static>(
             this: *mut ffi::GdkSurface,
             _param_spec: glib::ffi::gpointer,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Surface::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -415,7 +548,7 @@ impl Surface {
                 self.as_ptr() as *mut _,
                 b"notify::mapped\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    notify_mapped_trampoline::<F> as *const (),
+                    notify_mapped_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -423,14 +556,17 @@ impl Surface {
     }
 
     #[doc(alias = "scale-factor")]
-    pub fn connect_scale_factor_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn notify_scale_factor_trampoline<F: Fn(&Surface) + 'static>(
+    fn connect_scale_factor_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn notify_scale_factor_trampoline<
+            P: IsA<Surface>,
+            F: Fn(&P) + 'static,
+        >(
             this: *mut ffi::GdkSurface,
             _param_spec: glib::ffi::gpointer,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Surface::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -438,7 +574,7 @@ impl Surface {
                 self.as_ptr() as *mut _,
                 b"notify::scale-factor\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    notify_scale_factor_trampoline::<F> as *const (),
+                    notify_scale_factor_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )
@@ -446,14 +582,14 @@ impl Surface {
     }
 
     #[doc(alias = "width")]
-    pub fn connect_width_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
-        unsafe extern "C" fn notify_width_trampoline<F: Fn(&Surface) + 'static>(
+    fn connect_width_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
+        unsafe extern "C" fn notify_width_trampoline<P: IsA<Surface>, F: Fn(&P) + 'static>(
             this: *mut ffi::GdkSurface,
             _param_spec: glib::ffi::gpointer,
             f: glib::ffi::gpointer,
         ) {
             let f: &F = &*(f as *const F);
-            f(&from_glib_borrow(this))
+            f(&Surface::from_glib_borrow(this).unsafe_cast_ref())
         }
         unsafe {
             let f: Box_<F> = Box_::new(f);
@@ -461,7 +597,7 @@ impl Surface {
                 self.as_ptr() as *mut _,
                 b"notify::width\0".as_ptr() as *const _,
                 Some(transmute::<_, unsafe extern "C" fn()>(
-                    notify_width_trampoline::<F> as *const (),
+                    notify_width_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )

--- a/gdk4/src/auto/toplevel.rs
+++ b/gdk4/src/auto/toplevel.rs
@@ -32,13 +32,13 @@ pub const NONE_TOPLEVEL: Option<&Toplevel> = None;
 
 pub trait ToplevelExt: 'static {
     #[doc(alias = "gdk_toplevel_begin_move")]
-    fn begin_move(&self, device: &Device, button: i32, x: f64, y: f64, timestamp: u32);
+    fn begin_move<P: IsA<Device>>(&self, device: &P, button: i32, x: f64, y: f64, timestamp: u32);
 
     #[doc(alias = "gdk_toplevel_begin_resize")]
-    fn begin_resize(
+    fn begin_resize<P: IsA<Device>>(
         &self,
         edge: SurfaceEdge,
-        device: Option<&Device>,
+        device: Option<&P>,
         button: i32,
         x: f64,
         y: f64,
@@ -83,7 +83,7 @@ pub trait ToplevelExt: 'static {
     fn set_title(&self, title: &str);
 
     #[doc(alias = "gdk_toplevel_set_transient_for")]
-    fn set_transient_for(&self, parent: &Surface);
+    fn set_transient_for<P: IsA<Surface>>(&self, parent: &P);
 
     #[doc(alias = "gdk_toplevel_supports_edge_constraints")]
     fn supports_edge_constraints(&self) -> bool;
@@ -146,11 +146,11 @@ pub trait ToplevelExt: 'static {
 }
 
 impl<O: IsA<Toplevel>> ToplevelExt for O {
-    fn begin_move(&self, device: &Device, button: i32, x: f64, y: f64, timestamp: u32) {
+    fn begin_move<P: IsA<Device>>(&self, device: &P, button: i32, x: f64, y: f64, timestamp: u32) {
         unsafe {
             ffi::gdk_toplevel_begin_move(
                 self.as_ref().to_glib_none().0,
-                device.to_glib_none().0,
+                device.as_ref().to_glib_none().0,
                 button,
                 x,
                 y,
@@ -159,10 +159,10 @@ impl<O: IsA<Toplevel>> ToplevelExt for O {
         }
     }
 
-    fn begin_resize(
+    fn begin_resize<P: IsA<Device>>(
         &self,
         edge: SurfaceEdge,
-        device: Option<&Device>,
+        device: Option<&P>,
         button: i32,
         x: f64,
         y: f64,
@@ -172,7 +172,7 @@ impl<O: IsA<Toplevel>> ToplevelExt for O {
             ffi::gdk_toplevel_begin_resize(
                 self.as_ref().to_glib_none().0,
                 edge.into_glib(),
-                device.to_glib_none().0,
+                device.map(|p| p.as_ref()).to_glib_none().0,
                 button,
                 x,
                 y,
@@ -253,11 +253,11 @@ impl<O: IsA<Toplevel>> ToplevelExt for O {
         }
     }
 
-    fn set_transient_for(&self, parent: &Surface) {
+    fn set_transient_for<P: IsA<Surface>>(&self, parent: &P) {
         unsafe {
             ffi::gdk_toplevel_set_transient_for(
                 self.as_ref().to_glib_none().0,
-                parent.to_glib_none().0,
+                parent.as_ref().to_glib_none().0,
             );
         }
     }

--- a/gdk4/src/auto/toplevel_layout.rs
+++ b/gdk4/src/auto/toplevel_layout.rs
@@ -3,6 +3,7 @@
 // DO NOT EDIT
 
 use crate::Monitor;
+use glib::object::IsA;
 use glib::translate::*;
 use std::mem;
 
@@ -96,12 +97,12 @@ impl ToplevelLayout {
     }
 
     #[doc(alias = "gdk_toplevel_layout_set_fullscreen")]
-    pub fn set_fullscreen(&self, fullscreen: bool, monitor: Option<&Monitor>) {
+    pub fn set_fullscreen<P: IsA<Monitor>>(&self, fullscreen: bool, monitor: Option<&P>) {
         unsafe {
             ffi::gdk_toplevel_layout_set_fullscreen(
                 self.to_glib_none().0,
                 fullscreen.into_glib(),
-                monitor.to_glib_none().0,
+                monitor.map(|p| p.as_ref()).to_glib_none().0,
             );
         }
     }

--- a/gdk4/src/prelude.rs
+++ b/gdk4/src/prelude.rs
@@ -7,6 +7,7 @@ pub use crate::auto::traits::*;
 
 pub use crate::cairo_interaction::{GdkCairoContextExt, GdkCairoSurfaceExt};
 pub use crate::content_provider::ContentProviderExtManual;
+pub use crate::display::DisplayExtManual;
 pub use crate::draw_context::DrawContextExtManual;
 pub use crate::surface::SurfaceExtManual;
 pub use crate::texture::TextureExtManual;


### PR DESCRIPTION
they are parents of gdk-x11/gdk-wayland specific types
and so their methods should be usable on those types without any special casting

this also fixes docs for those as Ext traits are used but gir detects them as final