### PR TITLE
gdk-wayland: add missing prelude

### DIFF
--- a/gdk4-wayland/src/lib.rs
+++ b/gdk4-wayland/src/lib.rs
@@ -8,6 +8,7 @@ pub use wayland_client;
 
 mod auto;
 
+pub mod prelude;
 pub use auto::*;
 
 mod wayland_device;

--- a/gdk4-wayland/src/prelude.rs
+++ b/gdk4-wayland/src/prelude.rs
@@ -1,0 +1,15 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+// rustdoc-stripper-ignore-next
+//! Traits intended for blanket imports.
+
+pub use crate::auto::traits::*;
+
+pub use crate::wayland_surface::WaylandSurfaceExtManual;
+
+#[doc(hidden)]
+pub use gdk::prelude::*;
+#[doc(hidden)]
+pub use gio::prelude::*;
+#[doc(hidden)]
+pub use glib::prelude::*;


### PR DESCRIPTION
for the WaylandSurfaceExtManual trait