### PR TITLE
gtk: don't generate a builder for *Page objects

### DIFF
--- a/gtk4/Gir.toml
+++ b/gtk4/Gir.toml
@@ -208,7 +208,6 @@ generate = [
     "Gtk.SpinButtonUpdatePolicy",
     "Gtk.Spinner",
     "Gtk.SpinType",
-    "Gtk.StackPage",
     "Gtk.StackSidebar",
     "Gtk.StackSwitcher",
     "Gtk.StackTransitionType",
@@ -582,6 +581,7 @@ trust_return_value_nullability = false
 [[object]]
 name = "Gtk.AssistantPage"
 status = "generate"
+generate_builder = false
 trust_return_value_nullability = false
 
 [[object]]
@@ -1575,6 +1575,7 @@ trust_return_value_nullability = false
 [[object]]
 name = "Gtk.NotebookPage"
 status = "generate"
+generate_builder = false
 trust_return_value_nullability = false
 
 [[object]]
@@ -1895,6 +1896,11 @@ status = "generate"
     [[object.function]]
     name = "get_interpolate_size"
     rename = "interpolates_size"
+
+[[object]]
+name = "Gtk.StackPage"
+status = "generate"
+generate_builder = false
 
 [[object]]
 name = "Gtk.StringFilter"

--- a/gtk4/src/auto/assistant_page.rs
+++ b/gtk4/src/auto/assistant_page.rs
@@ -4,8 +4,6 @@
 
 use crate::AssistantPageType;
 use crate::Widget;
-use glib::object::Cast;
-use glib::object::IsA;
 use glib::object::ObjectType as ObjectType_;
 use glib::signal::connect_raw;
 use glib::signal::SignalHandlerId;
@@ -26,14 +24,6 @@ glib::wrapper! {
 }
 
 impl AssistantPage {
-    // rustdoc-stripper-ignore-next
-    /// Creates a new builder-style object to construct a [`AssistantPage`].
-    ///
-    /// This method returns an instance of [`AssistantPageBuilder`] which can be used to create a [`AssistantPage`].
-    pub fn builder() -> AssistantPageBuilder {
-        AssistantPageBuilder::default()
-    }
-
     #[doc(alias = "gtk_assistant_page_get_child")]
     #[doc(alias = "get_child")]
     pub fn child(&self) -> Option<Widget> {
@@ -182,64 +172,6 @@ impl AssistantPage {
                 Box_::into_raw(f),
             )
         }
-    }
-}
-
-#[derive(Clone, Default)]
-// rustdoc-stripper-ignore-next
-/// A builder for generating a [`AssistantPage`].
-pub struct AssistantPageBuilder {
-    child: Option<Widget>,
-    complete: Option<bool>,
-    page_type: Option<AssistantPageType>,
-    title: Option<String>,
-}
-
-impl AssistantPageBuilder {
-    // rustdoc-stripper-ignore-next
-    /// Create a new [`AssistantPageBuilder`].
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    // rustdoc-stripper-ignore-next
-    /// Build the [`AssistantPage`].
-    pub fn build(self) -> AssistantPage {
-        let mut properties: Vec<(&str, &dyn ToValue)> = vec![];
-        if let Some(ref child) = self.child {
-            properties.push(("child", child));
-        }
-        if let Some(ref complete) = self.complete {
-            properties.push(("complete", complete));
-        }
-        if let Some(ref page_type) = self.page_type {
-            properties.push(("page-type", page_type));
-        }
-        if let Some(ref title) = self.title {
-            properties.push(("title", title));
-        }
-        glib::Object::new::<AssistantPage>(&properties)
-            .expect("Failed to create an instance of AssistantPage")
-    }
-
-    pub fn child<P: IsA<Widget>>(mut self, child: &P) -> Self {
-        self.child = Some(child.clone().upcast());
-        self
-    }
-
-    pub fn complete(mut self, complete: bool) -> Self {
-        self.complete = Some(complete);
-        self
-    }
-
-    pub fn page_type(mut self, page_type: AssistantPageType) -> Self {
-        self.page_type = Some(page_type);
-        self
-    }
-
-    pub fn title(mut self, title: &str) -> Self {
-        self.title = Some(title.to_string());
-        self
     }
 }
 

--- a/gtk4/src/auto/mod.rs
+++ b/gtk4/src/auto/mod.rs
@@ -66,7 +66,6 @@ pub use self::assistant::AssistantBuilder;
 
 mod assistant_page;
 pub use self::assistant_page::AssistantPage;
-pub use self::assistant_page::AssistantPageBuilder;
 
 mod bin_layout;
 pub use self::bin_layout::BinLayout;
@@ -585,7 +584,6 @@ pub use self::notebook::NotebookBuilder;
 
 mod notebook_page;
 pub use self::notebook_page::NotebookPage;
-pub use self::notebook_page::NotebookPageBuilder;
 
 mod nothing_action;
 pub use self::nothing_action::NothingAction;
@@ -828,7 +826,6 @@ pub use self::stack::StackBuilder;
 
 mod stack_page;
 pub use self::stack_page::StackPage;
-pub use self::stack_page::StackPageBuilder;
 
 mod stack_sidebar;
 pub use self::stack_sidebar::StackSidebar;

--- a/gtk4/src/auto/notebook_page.rs
+++ b/gtk4/src/auto/notebook_page.rs
@@ -3,8 +3,6 @@
 // DO NOT EDIT
 
 use crate::Widget;
-use glib::object::Cast;
-use glib::object::IsA;
 use glib::object::ObjectType as ObjectType_;
 use glib::signal::connect_raw;
 use glib::signal::SignalHandlerId;
@@ -25,14 +23,6 @@ glib::wrapper! {
 }
 
 impl NotebookPage {
-    // rustdoc-stripper-ignore-next
-    /// Creates a new builder-style object to construct a [`NotebookPage`].
-    ///
-    /// This method returns an instance of [`NotebookPageBuilder`] which can be used to create a [`NotebookPage`].
-    pub fn builder() -> NotebookPageBuilder {
-        NotebookPageBuilder::default()
-    }
-
     #[doc(alias = "gtk_notebook_page_get_child")]
     #[doc(alias = "get_child")]
     pub fn child(&self) -> Option<Widget> {
@@ -400,118 +390,6 @@ impl NotebookPage {
                 Box_::into_raw(f),
             )
         }
-    }
-}
-
-#[derive(Clone, Default)]
-// rustdoc-stripper-ignore-next
-/// A builder for generating a [`NotebookPage`].
-pub struct NotebookPageBuilder {
-    child: Option<Widget>,
-    detachable: Option<bool>,
-    menu: Option<Widget>,
-    menu_label: Option<String>,
-    position: Option<i32>,
-    reorderable: Option<bool>,
-    tab: Option<Widget>,
-    tab_expand: Option<bool>,
-    tab_fill: Option<bool>,
-    tab_label: Option<String>,
-}
-
-impl NotebookPageBuilder {
-    // rustdoc-stripper-ignore-next
-    /// Create a new [`NotebookPageBuilder`].
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    // rustdoc-stripper-ignore-next
-    /// Build the [`NotebookPage`].
-    pub fn build(self) -> NotebookPage {
-        let mut properties: Vec<(&str, &dyn ToValue)> = vec![];
-        if let Some(ref child) = self.child {
-            properties.push(("child", child));
-        }
-        if let Some(ref detachable) = self.detachable {
-            properties.push(("detachable", detachable));
-        }
-        if let Some(ref menu) = self.menu {
-            properties.push(("menu", menu));
-        }
-        if let Some(ref menu_label) = self.menu_label {
-            properties.push(("menu-label", menu_label));
-        }
-        if let Some(ref position) = self.position {
-            properties.push(("position", position));
-        }
-        if let Some(ref reorderable) = self.reorderable {
-            properties.push(("reorderable", reorderable));
-        }
-        if let Some(ref tab) = self.tab {
-            properties.push(("tab", tab));
-        }
-        if let Some(ref tab_expand) = self.tab_expand {
-            properties.push(("tab-expand", tab_expand));
-        }
-        if let Some(ref tab_fill) = self.tab_fill {
-            properties.push(("tab-fill", tab_fill));
-        }
-        if let Some(ref tab_label) = self.tab_label {
-            properties.push(("tab-label", tab_label));
-        }
-        glib::Object::new::<NotebookPage>(&properties)
-            .expect("Failed to create an instance of NotebookPage")
-    }
-
-    pub fn child<P: IsA<Widget>>(mut self, child: &P) -> Self {
-        self.child = Some(child.clone().upcast());
-        self
-    }
-
-    pub fn detachable(mut self, detachable: bool) -> Self {
-        self.detachable = Some(detachable);
-        self
-    }
-
-    pub fn menu<P: IsA<Widget>>(mut self, menu: &P) -> Self {
-        self.menu = Some(menu.clone().upcast());
-        self
-    }
-
-    pub fn menu_label(mut self, menu_label: &str) -> Self {
-        self.menu_label = Some(menu_label.to_string());
-        self
-    }
-
-    pub fn position(mut self, position: i32) -> Self {
-        self.position = Some(position);
-        self
-    }
-
-    pub fn reorderable(mut self, reorderable: bool) -> Self {
-        self.reorderable = Some(reorderable);
-        self
-    }
-
-    pub fn tab<P: IsA<Widget>>(mut self, tab: &P) -> Self {
-        self.tab = Some(tab.clone().upcast());
-        self
-    }
-
-    pub fn tab_expand(mut self, tab_expand: bool) -> Self {
-        self.tab_expand = Some(tab_expand);
-        self
-    }
-
-    pub fn tab_fill(mut self, tab_fill: bool) -> Self {
-        self.tab_fill = Some(tab_fill);
-        self
-    }
-
-    pub fn tab_label(mut self, tab_label: &str) -> Self {
-        self.tab_label = Some(tab_label.to_string());
-        self
     }
 }
 

--- a/gtk4/src/auto/stack_page.rs
+++ b/gtk4/src/auto/stack_page.rs
@@ -3,16 +3,11 @@
 // DO NOT EDIT
 
 use crate::Accessible;
-use crate::AccessibleRole;
 use crate::Widget;
-use glib::object::Cast;
-use glib::object::IsA;
 use glib::object::ObjectType as ObjectType_;
 use glib::signal::connect_raw;
 use glib::signal::SignalHandlerId;
 use glib::translate::*;
-use glib::StaticType;
-use glib::ToValue;
 use std::boxed::Box as Box_;
 use std::fmt;
 use std::mem::transmute;
@@ -27,14 +22,6 @@ glib::wrapper! {
 }
 
 impl StackPage {
-    // rustdoc-stripper-ignore-next
-    /// Creates a new builder-style object to construct a [`StackPage`].
-    ///
-    /// This method returns an instance of [`StackPageBuilder`] which can be used to create a [`StackPage`].
-    pub fn builder() -> StackPageBuilder {
-        StackPageBuilder::default()
-    }
-
     #[doc(alias = "gtk_stack_page_get_child")]
     #[doc(alias = "get_child")]
     pub fn child(&self) -> Widget {
@@ -236,100 +223,6 @@ impl StackPage {
                 Box_::into_raw(f),
             )
         }
-    }
-}
-
-#[derive(Clone, Default)]
-// rustdoc-stripper-ignore-next
-/// A builder for generating a [`StackPage`].
-pub struct StackPageBuilder {
-    child: Option<Widget>,
-    icon_name: Option<String>,
-    name: Option<String>,
-    needs_attention: Option<bool>,
-    title: Option<String>,
-    use_underline: Option<bool>,
-    visible: Option<bool>,
-    accessible_role: Option<AccessibleRole>,
-}
-
-impl StackPageBuilder {
-    // rustdoc-stripper-ignore-next
-    /// Create a new [`StackPageBuilder`].
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    // rustdoc-stripper-ignore-next
-    /// Build the [`StackPage`].
-    pub fn build(self) -> StackPage {
-        let mut properties: Vec<(&str, &dyn ToValue)> = vec![];
-        if let Some(ref child) = self.child {
-            properties.push(("child", child));
-        }
-        if let Some(ref icon_name) = self.icon_name {
-            properties.push(("icon-name", icon_name));
-        }
-        if let Some(ref name) = self.name {
-            properties.push(("name", name));
-        }
-        if let Some(ref needs_attention) = self.needs_attention {
-            properties.push(("needs-attention", needs_attention));
-        }
-        if let Some(ref title) = self.title {
-            properties.push(("title", title));
-        }
-        if let Some(ref use_underline) = self.use_underline {
-            properties.push(("use-underline", use_underline));
-        }
-        if let Some(ref visible) = self.visible {
-            properties.push(("visible", visible));
-        }
-        if let Some(ref accessible_role) = self.accessible_role {
-            properties.push(("accessible-role", accessible_role));
-        }
-        glib::Object::new::<StackPage>(&properties)
-            .expect("Failed to create an instance of StackPage")
-    }
-
-    pub fn child<P: IsA<Widget>>(mut self, child: &P) -> Self {
-        self.child = Some(child.clone().upcast());
-        self
-    }
-
-    pub fn icon_name(mut self, icon_name: &str) -> Self {
-        self.icon_name = Some(icon_name.to_string());
-        self
-    }
-
-    pub fn name(mut self, name: &str) -> Self {
-        self.name = Some(name.to_string());
-        self
-    }
-
-    pub fn needs_attention(mut self, needs_attention: bool) -> Self {
-        self.needs_attention = Some(needs_attention);
-        self
-    }
-
-    pub fn title(mut self, title: &str) -> Self {
-        self.title = Some(title.to_string());
-        self
-    }
-
-    pub fn use_underline(mut self, use_underline: bool) -> Self {
-        self.use_underline = Some(use_underline);
-        self
-    }
-
-    pub fn visible(mut self, visible: bool) -> Self {
-        self.visible = Some(visible);
-        self
-    }
-
-    pub fn accessible_role(mut self, accessible_role: AccessibleRole) -> Self {
-        self.accessible_role = Some(accessible_role);
-        self
     }
 }
 


### PR DESCRIPTION
the user is not expected to be able to instantiate them.
They are instead created by Stack/Notebook/Assistant types