### PR TITLE
use AsRef<RenderNode> instead of IsRenderNode

### DIFF
--- a/gdk4/src/event.rs
+++ b/gdk4/src/event.rs
@@ -236,6 +236,13 @@ impl fmt::Debug for Event {
     }
 }
 
+#[doc(hidden)]
+impl AsRef<Event> for Event {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
 pub unsafe trait EventKind:
     StaticType + FromGlibPtrFull<*mut ffi::GdkEvent> + 'static
 {

--- a/gsk4/src/blend_node.rs
+++ b/gsk4/src/blend_node.rs
@@ -1,6 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::{BlendMode, IsRenderNode, RenderNode, RenderNodeType};
+use crate::{BlendMode, RenderNode, RenderNodeType};
 use glib::translate::*;
 
 glib::wrapper! {
@@ -23,7 +23,7 @@ define_render_node!(
 
 impl BlendNode {
     #[doc(alias = "gsk_blend_node_new")]
-    pub fn new<P: IsRenderNode, Q: IsRenderNode>(
+    pub fn new<P: AsRef<RenderNode>, Q: AsRef<RenderNode>>(
         bottom: &P,
         top: &Q,
         blend_mode: BlendMode,

--- a/gsk4/src/blur_node.rs
+++ b/gsk4/src/blur_node.rs
@@ -1,6 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::{IsRenderNode, RenderNode, RenderNodeType};
+use crate::{RenderNode, RenderNodeType};
 use glib::translate::*;
 
 glib::wrapper! {
@@ -23,7 +23,7 @@ define_render_node!(
 
 impl BlurNode {
     #[doc(alias = "gsk_blur_node_new")]
-    pub fn new<P: IsRenderNode>(child: &P, radius: f32) -> Self {
+    pub fn new<P: AsRef<RenderNode>>(child: &P, radius: f32) -> Self {
         skip_assert_initialized!();
         unsafe {
             from_glib_full(ffi::gsk_blur_node_new(

--- a/gsk4/src/clip_node.rs
+++ b/gsk4/src/clip_node.rs
@@ -1,6 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::{IsRenderNode, RenderNode, RenderNodeType};
+use crate::{RenderNode, RenderNodeType};
 use glib::translate::*;
 
 glib::wrapper! {
@@ -23,7 +23,7 @@ define_render_node!(
 
 impl ClipNode {
     #[doc(alias = "gsk_clip_node_new")]
-    pub fn new<P: IsRenderNode>(child: &P, clip: &graphene::Rect) -> Self {
+    pub fn new<P: AsRef<RenderNode>>(child: &P, clip: &graphene::Rect) -> Self {
         skip_assert_initialized!();
         unsafe {
             from_glib_full(ffi::gsk_clip_node_new(

--- a/gsk4/src/color_matrix_node.rs
+++ b/gsk4/src/color_matrix_node.rs
@@ -1,6 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::{IsRenderNode, RenderNode, RenderNodeType};
+use crate::{RenderNode, RenderNodeType};
 use glib::translate::*;
 
 glib::wrapper! {
@@ -23,7 +23,7 @@ define_render_node!(
 
 impl ColorMatrixNode {
     #[doc(alias = "gsk_color_matrix_node_new")]
-    pub fn new<P: IsRenderNode>(
+    pub fn new<P: AsRef<RenderNode>>(
         child: &P,
         color_matrix: &graphene::Matrix,
         color_offset: &graphene::Vec4,

--- a/gsk4/src/cross_fade_node.rs
+++ b/gsk4/src/cross_fade_node.rs
@@ -1,6 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::{IsRenderNode, RenderNode, RenderNodeType};
+use crate::{RenderNode, RenderNodeType};
 use glib::translate::*;
 
 glib::wrapper! {
@@ -23,7 +23,11 @@ define_render_node!(
 
 impl CrossFadeNode {
     #[doc(alias = "gsk_cross_fade_node_new")]
-    pub fn new<P: IsRenderNode, Q: IsRenderNode>(start: &P, end: &Q, progress: f32) -> Self {
+    pub fn new<P: AsRef<RenderNode>, Q: AsRef<RenderNode>>(
+        start: &P,
+        end: &Q,
+        progress: f32,
+    ) -> Self {
         skip_assert_initialized!();
         unsafe {
             from_glib_full(ffi::gsk_cross_fade_node_new(

--- a/gsk4/src/debug_node.rs
+++ b/gsk4/src/debug_node.rs
@@ -1,6 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::{IsRenderNode, RenderNode, RenderNodeType};
+use crate::{RenderNode, RenderNodeType};
 use glib::translate::*;
 
 glib::wrapper! {
@@ -23,7 +23,7 @@ define_render_node!(
 
 impl DebugNode {
     #[doc(alias = "gsk_debug_node_new")]
-    pub fn new<P: IsRenderNode>(child: &P, message: &str) -> Self {
+    pub fn new<P: AsRef<RenderNode>>(child: &P, message: &str) -> Self {
         skip_assert_initialized!();
         unsafe {
             from_glib_full(ffi::gsk_debug_node_new(

--- a/gsk4/src/opacity_node.rs
+++ b/gsk4/src/opacity_node.rs
@@ -1,6 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::{IsRenderNode, RenderNode, RenderNodeType};
+use crate::{RenderNode, RenderNodeType};
 use glib::translate::*;
 
 glib::wrapper! {
@@ -23,7 +23,7 @@ define_render_node!(
 
 impl OpacityNode {
     #[doc(alias = "gsk_opacity_node_new")]
-    pub fn new<P: IsRenderNode>(child: &P, opacity: f32) -> Self {
+    pub fn new<P: AsRef<RenderNode>>(child: &P, opacity: f32) -> Self {
         skip_assert_initialized!();
         unsafe {
             from_glib_full(ffi::gsk_opacity_node_new(

--- a/gsk4/src/render_node.rs
+++ b/gsk4/src/render_node.rs
@@ -156,6 +156,13 @@ impl fmt::Display for RenderNode {
     }
 }
 
+#[doc(hidden)]
+impl AsRef<RenderNode> for RenderNode {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
 macro_rules! define_render_node {
     ($rust_type:ident, $ffi_type:path, $get_type:path, $node_type:path) => {
         impl ::glib::StaticType for $rust_type {

--- a/gsk4/src/renderer.rs
+++ b/gsk4/src/renderer.rs
@@ -1,15 +1,15 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::{IsRenderNode, Renderer};
+use crate::{RenderNode, Renderer};
 use glib::object::IsA;
 use glib::translate::*;
 
 pub trait RendererExtManual: 'static {
     #[doc(alias = "gsk_renderer_render")]
-    fn render<P: IsRenderNode>(&self, root: &P, region: Option<&cairo::Region>);
+    fn render<P: AsRef<RenderNode>>(&self, root: &P, region: Option<&cairo::Region>);
 
     #[doc(alias = "gsk_renderer_render_texture")]
-    fn render_texture<P: IsRenderNode>(
+    fn render_texture<P: AsRef<RenderNode>>(
         &self,
         root: &P,
         viewport: Option<&graphene::Rect>,
@@ -17,7 +17,7 @@ pub trait RendererExtManual: 'static {
 }
 
 impl<O: IsA<Renderer>> RendererExtManual for O {
-    fn render<P: IsRenderNode>(&self, root: &P, region: Option<&cairo::Region>) {
+    fn render<P: AsRef<RenderNode>>(&self, root: &P, region: Option<&cairo::Region>) {
         unsafe {
             ffi::gsk_renderer_render(
                 self.as_ref().to_glib_none().0,
@@ -27,7 +27,7 @@ impl<O: IsA<Renderer>> RendererExtManual for O {
         }
     }
 
-    fn render_texture<P: IsRenderNode>(
+    fn render_texture<P: AsRef<RenderNode>>(
         &self,
         root: &P,
         viewport: Option<&graphene::Rect>,

--- a/gsk4/src/repeat_node.rs
+++ b/gsk4/src/repeat_node.rs
@@ -1,6 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::{IsRenderNode, RenderNode, RenderNodeType};
+use crate::{RenderNode, RenderNodeType};
 use glib::translate::*;
 
 glib::wrapper! {
@@ -23,7 +23,7 @@ define_render_node!(
 
 impl RepeatNode {
     #[doc(alias = "gsk_repeat_node_new")]
-    pub fn new<P: IsRenderNode>(
+    pub fn new<P: AsRef<RenderNode>>(
         bounds: &graphene::Rect,
         child: &P,
         child_bounds: Option<&graphene::Rect>,

--- a/gsk4/src/rounded_clip_node.rs
+++ b/gsk4/src/rounded_clip_node.rs
@@ -1,6 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::{IsRenderNode, RenderNode, RenderNodeType, RoundedRect};
+use crate::{RenderNode, RenderNodeType, RoundedRect};
 use glib::translate::*;
 
 glib::wrapper! {
@@ -23,7 +23,7 @@ define_render_node!(
 
 impl RoundedClipNode {
     #[doc(alias = "gsk_rounded_clip_node_new")]
-    pub fn new<P: IsRenderNode>(child: &P, clip: &RoundedRect) -> Self {
+    pub fn new<P: AsRef<RenderNode>>(child: &P, clip: &RoundedRect) -> Self {
         skip_assert_initialized!();
         unsafe {
             from_glib_none(ffi::gsk_rounded_clip_node_new(

--- a/gsk4/src/shadow_node.rs
+++ b/gsk4/src/shadow_node.rs
@@ -1,6 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::{IsRenderNode, RenderNode, RenderNodeType, Shadow};
+use crate::{RenderNode, RenderNodeType, Shadow};
 use glib::translate::*;
 
 glib::wrapper! {
@@ -23,7 +23,7 @@ define_render_node!(
 
 impl ShadowNode {
     #[doc(alias = "gsk_shadow_node_new")]
-    pub fn new<P: IsRenderNode>(child: &P, shadows: &[Shadow]) -> Self {
+    pub fn new<P: AsRef<RenderNode>>(child: &P, shadows: &[Shadow]) -> Self {
         skip_assert_initialized!();
         let n_shadows = shadows.len() as usize;
         unsafe {

--- a/gsk4/src/transform_node.rs
+++ b/gsk4/src/transform_node.rs
@@ -1,6 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::{IsRenderNode, RenderNode, RenderNodeType, Transform};
+use crate::{RenderNode, RenderNodeType, Transform};
 use glib::translate::*;
 
 glib::wrapper! {
@@ -23,7 +23,7 @@ define_render_node!(
 
 impl TransformNode {
     #[doc(alias = "gsk_transform_node_new")]
-    pub fn new<P: IsRenderNode>(child: &P, transform: &Transform) -> Self {
+    pub fn new<P: AsRef<RenderNode>>(child: &P, transform: &Transform) -> Self {
         skip_assert_initialized!();
         unsafe {
             from_glib_full(ffi::gsk_transform_node_new(

--- a/gtk4/Gir.toml
+++ b/gtk4/Gir.toml
@@ -1885,7 +1885,7 @@ trust_return_value_nullability = false
     manual = true # ignore format args
     [[object.function]]
     name = "append_node"
-    # use IsRenderNode instead of IsA<RenderNode>
+    # use AsRef<RenderNode> instead of IsA<RenderNode>
     manual = true
 
 [[object]]

--- a/gtk4/src/snapshot.rs
+++ b/gtk4/src/snapshot.rs
@@ -148,12 +148,9 @@ impl Snapshot {
     }
 
     #[doc(alias = "gtk_snapshot_append_node")]
-    pub fn append_node<P: gsk::IsRenderNode>(&self, node: &P) {
+    pub fn append_node<P: AsRef<gsk::RenderNode>>(&self, node: &P) {
         unsafe {
-            ffi::gtk_snapshot_append_node(
-                self.to_glib_none().0,
-                node.upcast_ref().to_glib_none().0,
-            );
+            ffi::gtk_snapshot_append_node(self.to_glib_none().0, node.as_ref().to_glib_none().0);
         }
     }
 }


### PR DESCRIPTION
Would it be an api break to backport this to 0.1?