### PR TITLE
book: Fix broken link

### DIFF
--- a/book/src/gobject_subclassing.md
+++ b/book/src/gobject_subclassing.md
@@ -33,7 +33,7 @@ Next, we describe our custom GObject.
 # fn main() {}
 ```
 
-[`glib::wrapper!`](http://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/macro.glib_wrapper.html) does the most of the work of subclassing for us.
+[`glib::wrapper!`](http://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/macro.wrapper.html) does the most of the work of subclassing for us.
 We only have to point to the implementation struct and which ancestor GObjects we extend.
 Please note that the list of ancestor GObjects does not mention `glib::Object`.
 This is because `glib::Object` is *always* the base class in the object hierarchy and therefore already implied.


### PR DESCRIPTION
This PR fixes a broken link to the [`glib::wrapper!`](https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/macro.wrapper.html) macro's documentation.