### PR TITLE
gtk: disable GestureSingle builder

### DIFF
--- a/gtk4/Gir.toml
+++ b/gtk4/Gir.toml
@@ -109,7 +109,6 @@ generate = [
     "Gtk.GestureLongPress",
     "Gtk.GesturePan",
     "Gtk.GestureRotate",
-    "Gtk.GestureSingle",
     "Gtk.GestureSwipe",
     "Gtk.GestureZoom",
     "Gtk.Grid",
@@ -1206,6 +1205,11 @@ status = "generate"
         [[object.function.parameter]]
         name = "sequence"
         const = true
+
+[[object]]
+name = "Gtk.GestureSingle"
+status = "generate"
+generate_builder = false
 
 [[object]]
 name = "Gtk.GestureStylus"

--- a/gtk4/src/auto/gesture_single.rs
+++ b/gtk4/src/auto/gesture_single.rs
@@ -4,15 +4,11 @@
 
 use crate::EventController;
 use crate::Gesture;
-use crate::PropagationLimit;
-use crate::PropagationPhase;
 use glib::object::Cast;
 use glib::object::IsA;
 use glib::signal::connect_raw;
 use glib::signal::SignalHandlerId;
 use glib::translate::*;
-use glib::StaticType;
-use glib::ToValue;
 use std::boxed::Box as Box_;
 use std::fmt;
 use std::mem::transmute;
@@ -23,103 +19,6 @@ glib::wrapper! {
 
     match fn {
         type_ => || ffi::gtk_gesture_single_get_type(),
-    }
-}
-
-impl GestureSingle {
-    // rustdoc-stripper-ignore-next
-    /// Creates a new builder-pattern struct instance to construct [`GestureSingle`] objects.
-    ///
-    /// This method returns an instance of [`GestureSingleBuilder`] which can be used to create [`GestureSingle`] objects.
-    pub fn builder() -> GestureSingleBuilder {
-        GestureSingleBuilder::default()
-    }
-}
-
-#[derive(Clone, Default)]
-// rustdoc-stripper-ignore-next
-/// A [builder-pattern] type to construct [`GestureSingle`] objects.
-///
-/// [builder-pattern]: https://doc.rust-lang.org/1.0.0/style/ownership/builders.html
-pub struct GestureSingleBuilder {
-    button: Option<u32>,
-    exclusive: Option<bool>,
-    touch_only: Option<bool>,
-    n_points: Option<u32>,
-    name: Option<String>,
-    propagation_limit: Option<PropagationLimit>,
-    propagation_phase: Option<PropagationPhase>,
-}
-
-impl GestureSingleBuilder {
-    // rustdoc-stripper-ignore-next
-    /// Create a new [`GestureSingleBuilder`].
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    // rustdoc-stripper-ignore-next
-    /// Build the [`GestureSingle`].
-    pub fn build(self) -> GestureSingle {
-        let mut properties: Vec<(&str, &dyn ToValue)> = vec![];
-        if let Some(ref button) = self.button {
-            properties.push(("button", button));
-        }
-        if let Some(ref exclusive) = self.exclusive {
-            properties.push(("exclusive", exclusive));
-        }
-        if let Some(ref touch_only) = self.touch_only {
-            properties.push(("touch-only", touch_only));
-        }
-        if let Some(ref n_points) = self.n_points {
-            properties.push(("n-points", n_points));
-        }
-        if let Some(ref name) = self.name {
-            properties.push(("name", name));
-        }
-        if let Some(ref propagation_limit) = self.propagation_limit {
-            properties.push(("propagation-limit", propagation_limit));
-        }
-        if let Some(ref propagation_phase) = self.propagation_phase {
-            properties.push(("propagation-phase", propagation_phase));
-        }
-        glib::Object::new::<GestureSingle>(&properties)
-            .expect("Failed to create an instance of GestureSingle")
-    }
-
-    pub fn button(mut self, button: u32) -> Self {
-        self.button = Some(button);
-        self
-    }
-
-    pub fn exclusive(mut self, exclusive: bool) -> Self {
-        self.exclusive = Some(exclusive);
-        self
-    }
-
-    pub fn touch_only(mut self, touch_only: bool) -> Self {
-        self.touch_only = Some(touch_only);
-        self
-    }
-
-    pub fn n_points(mut self, n_points: u32) -> Self {
-        self.n_points = Some(n_points);
-        self
-    }
-
-    pub fn name(mut self, name: &str) -> Self {
-        self.name = Some(name.to_string());
-        self
-    }
-
-    pub fn propagation_limit(mut self, propagation_limit: PropagationLimit) -> Self {
-        self.propagation_limit = Some(propagation_limit);
-        self
-    }
-
-    pub fn propagation_phase(mut self, propagation_phase: PropagationPhase) -> Self {
-        self.propagation_phase = Some(propagation_phase);
-        self
     }
 }
 

--- a/gtk4/src/auto/mod.rs
+++ b/gtk4/src/auto/mod.rs
@@ -414,7 +414,6 @@ pub use self::gesture_rotate::GestureRotate;
 pub use self::gesture_rotate::GestureRotateBuilder;
 
 mod gesture_single;
-pub use self::gesture_single::GestureSingleBuilder;
 pub use self::gesture_single::{GestureSingle, NONE_GESTURE_SINGLE};
 
 mod gesture_stylus;


### PR DESCRIPTION
It's an abstract class that cannot be instantiated.

fixes #502