### PR TITLE
Fixed the description of the clock under gtk4-rs/examples/clock/

### DIFF
--- a/examples/clock/README.md
+++ b/examples/clock/README.md
@@ -1,5 +1,5 @@
 # Clock
 
-This example shows how to use the [builder pattern](https://doc.rust-lang.org/1.0.0/style/ownership/builders.html) with GObjects.
+A simple clock that displays the current system time. 
 
 ![Screenshot](screenshot.png)


### PR DESCRIPTION
Before, the description was the same as the description for gtk4-rs/examples/builder_pattern, now it has been updated to "A simple clock that displays the current system time." which is more accurate for the example.