### PR TITLE
Fix examples/basics.

### DIFF
--- a/examples/basics/main.rs
+++ b/examples/basics/main.rs
@@ -1,19 +1,21 @@
-use gtk::prelude::*;
+use gtk4::prelude::*;
 
 fn main() {
-    let application =
-        gtk::Application::new(Some("com.github.gtk-rs.examples.basic"), Default::default());
+    let application = gtk4::Application::new(
+        Some("com.github.gtk4-rs.examples.basic"),
+        Default::default(),
+    );
     application.connect_activate(build_ui);
     application.run();
 }
 
-fn build_ui(application: &gtk::Application) {
-    let window = gtk::ApplicationWindow::new(application);
+fn build_ui(application: &gtk4::Application) {
+    let window = gtk4::ApplicationWindow::new(application);
 
-    window.set_title(Some("First GTK Program"));
+    window.set_title(Some("First GTK4 Program"));
     window.set_default_size(350, 70);
 
-    let button = gtk::Button::with_label("Click me!");
+    let button = gtk4::Button::with_label("Click me!");
 
     window.set_child(Some(&button));
 


### PR DESCRIPTION
This patch corrects the name space from gtk to gtk4.