### PR TITLE
Implement gtk::Expression::bind() with two generic parameters

### DIFF
--- a/gtk4/src/expression.rs
+++ b/gtk4/src/expression.rs
@@ -80,11 +80,11 @@ impl Expression {
     }
 
     #[doc(alias = "gtk_expression_bind")]
-    pub fn bind<T: IsA<Object>>(
+    pub fn bind<T: IsA<Object>, U: IsA<Object>>(
         &self,
         target: &T,
         property_name: &str,
-        this: Option<&T>,
+        this: Option<&U>,
     ) -> ExpressionWatch {
         assert_initialized_main_thread!();
         unsafe {


### PR DESCRIPTION
It's unlikely that both objects are of the same type.

Fixes https://github.com/gtk-rs/gtk4-rs/issues/551