### PR TITLE
gtk: Export ParamSpec extenstion trait

### DIFF
--- a/gtk4/src/param_spec_expression.rs
+++ b/gtk4/src/param_spec_expression.rs
@@ -48,7 +48,7 @@ impl ParamSpecExpression {
 
 // rustdoc-stripper-ignore-next
 /// Register Expression's ParamSpec support
-trait GtkParamSpecExt {
+pub trait GtkParamSpecExt {
     fn new_expression(name: &str, nick: &str, blurb: &str, flags: glib::ParamFlags) -> Self;
 }
 

--- a/gtk4/src/prelude.rs
+++ b/gtk4/src/prelude.rs
@@ -22,6 +22,7 @@ pub use crate::font_chooser::FontChooserExtManual;
 pub use crate::im_context::IMContextExtManual;
 pub use crate::media_stream::MediaStreamExtManual;
 pub use crate::native_dialog::NativeDialogExtManual;
+pub use crate::param_spec_expression::GtkParamSpecExt;
 pub use crate::scale::ScaleExtManual;
 pub use crate::shortcut_trigger::ShortcutTriggerExtManual;
 pub use crate::text_buffer::TextBufferExtManual;


### PR DESCRIPTION
The `ParamSpec::new_extension` function is not available outside of gtk4-rs. This PR fixes that by exporting the necessary extension trait in the prelude.