### PR TITLE
Wait for tests in the worker thread to finish

### DIFF
--- a/gtk4/src/bitset_iter.rs
+++ b/gtk4/src/bitset_iter.rs
@@ -139,28 +139,26 @@ impl<'a> ToGlibPtr<'a, *const ffi::GtkBitsetIter> for BitsetIter<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::TEST_THREAD_WORKER;
+    use crate::test_synced;
 
     #[test]
     fn test_bitset_iter() {
-        TEST_THREAD_WORKER
-            .push(move || {
-                let set = Bitset::new_range(0, 20);
-                let (mut iter, init_value) = BitsetIter::init_first(&set).unwrap();
-                assert_eq!(init_value, 0);
-                assert_eq!(iter.next(), Some(1));
-                assert_eq!(iter.previous(), Some(0));
+        test_synced(move || {
+            let set = Bitset::new_range(0, 20);
+            let (mut iter, init_value) = BitsetIter::init_first(&set).unwrap();
+            assert_eq!(init_value, 0);
+            assert_eq!(iter.next(), Some(1));
+            assert_eq!(iter.previous(), Some(0));
 
-                let set2 = Bitset::new_range(0, 3);
-                let (mut iter, init_val) = BitsetIter::init_last(&set2).unwrap();
-                assert_eq!(init_val, 2);
-                assert_eq!(iter.previous(), Some(1));
-                assert_eq!(iter.previous(), Some(0));
-                assert_eq!(iter.previous(), None);
-                assert!(!iter.is_valid());
-                assert_eq!(iter.next(), Some(1));
-                assert!(iter.is_valid());
-            })
-            .expect("Failed to schedule a test call");
+            let set2 = Bitset::new_range(0, 3);
+            let (mut iter, init_val) = BitsetIter::init_last(&set2).unwrap();
+            assert_eq!(init_val, 2);
+            assert_eq!(iter.previous(), Some(1));
+            assert_eq!(iter.previous(), Some(0));
+            assert_eq!(iter.previous(), None);
+            assert!(!iter.is_valid());
+            assert_eq!(iter.next(), Some(1));
+            assert!(iter.is_valid());
+        });
     }
 }

--- a/gtk4/src/constant_expression.rs
+++ b/gtk4/src/constant_expression.rs
@@ -57,21 +57,19 @@ impl ConstantExpression {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::TEST_THREAD_WORKER;
+    use crate::test_synced;
 
     #[test]
     fn test_expressions() {
-        TEST_THREAD_WORKER
-            .push(move || {
-                let expr1 = ConstantExpression::new(&23);
-                assert_eq!(expr1.value().get::<i32>().unwrap(), 23);
-                let expr2 = ConstantExpression::for_value(&"hello".to_value());
-                assert_eq!(expr2.value().get::<String>().unwrap(), "hello");
-                let expr1 = ConstantExpression::new(&23);
-                assert_eq!(expr1.value().get::<i32>().unwrap(), 23);
-                let expr2 = ConstantExpression::for_value(&"hello".to_value());
-                assert_eq!(expr2.value().get::<String>().unwrap(), "hello");
-            })
-            .expect("Failed to schedule a test call");
+        test_synced(move || {
+            let expr1 = ConstantExpression::new(&23);
+            assert_eq!(expr1.value().get::<i32>().unwrap(), 23);
+            let expr2 = ConstantExpression::for_value(&"hello".to_value());
+            assert_eq!(expr2.value().get::<String>().unwrap(), "hello");
+            let expr1 = ConstantExpression::new(&23);
+            assert_eq!(expr1.value().get::<i32>().unwrap(), 23);
+            let expr2 = ConstantExpression::for_value(&"hello".to_value());
+            assert_eq!(expr2.value().get::<String>().unwrap(), "hello");
+        });
     }
 }

--- a/gtk4/src/object_expression.rs
+++ b/gtk4/src/object_expression.rs
@@ -42,16 +42,14 @@ impl ObjectExpression {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::TEST_THREAD_WORKER;
+    use crate::test_synced;
 
     #[test]
     fn test_object_expression() {
-        TEST_THREAD_WORKER
-            .push(move || {
-                let obj = crate::IconTheme::new();
-                let expr = ObjectExpression::new(&obj);
-                assert_eq!(expr.object().unwrap(), obj);
-            })
-            .expect("Failed to schedule a test call");
+        test_synced(move || {
+            let obj = crate::IconTheme::new();
+            let expr = ObjectExpression::new(&obj);
+            assert_eq!(expr.object().unwrap(), obj);
+        });
     }
 }

--- a/gtk4/src/param_spec_expression.rs
+++ b/gtk4/src/param_spec_expression.rs
@@ -70,22 +70,20 @@ impl GtkParamSpecExt for ParamSpec {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::TEST_THREAD_WORKER;
+    use crate::test_synced;
 
     #[test]
     fn test_paramspec_expression() {
-        TEST_THREAD_WORKER
-            .push(move || {
-                let pspec = ParamSpec::new_expression(
-                    "expression",
-                    "Expression",
-                    "Some Expression",
-                    glib::ParamFlags::CONSTRUCT_ONLY | glib::ParamFlags::READABLE,
-                );
+        test_synced(move || {
+            let pspec = ParamSpec::new_expression(
+                "expression",
+                "Expression",
+                "Some Expression",
+                glib::ParamFlags::CONSTRUCT_ONLY | glib::ParamFlags::READABLE,
+            );
 
-                let expr_pspec = pspec.downcast::<ParamSpecExpression>();
-                assert!(expr_pspec.is_ok());
-            })
-            .expect("Failed to schedule a test call");
+            let expr_pspec = pspec.downcast::<ParamSpecExpression>();
+            assert!(expr_pspec.is_ok());
+        });
     }
 }

--- a/gtk4/src/property_expression.rs
+++ b/gtk4/src/property_expression.rs
@@ -76,19 +76,17 @@ impl PropertyExpression {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{NONE_EXPRESSION, TEST_THREAD_WORKER};
+    use crate::{test_synced, NONE_EXPRESSION};
     use glib::StaticType;
 
     #[test]
     fn test_property_expression() {
-        TEST_THREAD_WORKER
-            .push(move || {
-                let _prop_expr = PropertyExpression::new(
-                    crate::StringObject::static_type(),
-                    NONE_EXPRESSION,
-                    "string",
-                );
-            })
-            .expect("Failed to schedule a test call");
+        test_synced(move || {
+            let _prop_expr = PropertyExpression::new(
+                crate::StringObject::static_type(),
+                NONE_EXPRESSION,
+                "string",
+            );
+        });
     }
 }

--- a/gtk4/src/rt.rs
+++ b/gtk4/src/rt.rs
@@ -124,15 +124,13 @@ pub fn init() -> Result<(), glib::BoolError> {
 
 #[cfg(test)]
 mod tests {
-    use crate::TEST_THREAD_WORKER;
+    use crate::test_synced;
 
     #[test]
     fn init_should_acquire_default_main_context() {
-        TEST_THREAD_WORKER
-            .push(move || {
-                let context = glib::MainContext::ref_thread_default();
-                assert!(context.is_owner());
-            })
-            .expect("Failed to schedule a test call");
+        test_synced(move || {
+            let context = glib::MainContext::ref_thread_default();
+            assert!(context.is_owner());
+        });
     }
 }


### PR DESCRIPTION
This is a followup of https://github.com/gtk-rs/gtk3-rs/issues/616#issuecomment-892921651, where I noticed the synchronized tests in gtk4-rs may actually not run, because we didn't wait for the worker thread to finish its tasks. This commit also deduplicates the way the synchronization primitive was used.