### PR TITLE
book: Improve snippets by removing `main` hack

### DIFF
--- a/book/src/gobject_memory_management.md
+++ b/book/src/gobject_memory_management.md
@@ -111,7 +111,7 @@ we can use the [`Cell`](https://doc.rust-lang.org/std/cell/struct.Cell.html) typ
 
 <span class="filename">Filename: listings/gobject_memory_management/1/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/gobject_memory_management/1/main.rs:callback}}
 ```
 
@@ -120,7 +120,7 @@ We can improve that by using the `glib::clone!` macro.
 
 <span class="filename">Filename: listings/gobject_memory_management/2/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/gobject_memory_management/2/main.rs:callback}}
 ```
 
@@ -129,7 +129,7 @@ Therefore, we can pass the buttons the same way to the closure as we did with `n
 
 <span class="filename">Filename: listings/gobject_memory_management/3/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/gobject_memory_management/3/main.rs:callback}}
 ```
 If we now click on one button, the other button's label gets changed.
@@ -145,7 +145,7 @@ Since we want our apps to free unneeded memory, we should use weak references fo
 
 <span class="filename">Filename: listings/gobject_memory_management/4/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/gobject_memory_management/4/main.rs:callback}}
 ```
 
@@ -163,7 +163,7 @@ Who then keeps the buttons alive?
 
 <span class="filename">Filename: listings/gobject_memory_management/4/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/gobject_memory_management/4/main.rs:box_append}}
 ```
 
@@ -171,7 +171,7 @@ When we append the buttons to the `gtk_box`, `gtk_box` keeps a strong reference 
 
 <span class="filename">Filename: listings/gobject_memory_management/4/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/gobject_memory_management/4/main.rs:set_child}}
 ```
 
@@ -179,7 +179,7 @@ When we set `gtk_box` as child of `window`, `window` keeps a strong reference to
 
 <span class="filename">Filename: listings/gobject_memory_management/4/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/gobject_memory_management/4/main.rs:window}}
 ```
 

--- a/book/src/gobject_properties.md
+++ b/book/src/gobject_properties.md
@@ -9,7 +9,7 @@ That is why `gtk-rs` provides corresponding [`state`](../docs/gtk4/struct.Switch
 
 <span class="filename">Filename: listings/gobject_properties/1/main.rs</span>
 
-```rust ,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/gobject_properties/1/main.rs:switch}}
 ```
 Alternatively, we can use the general [`property`](http://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/object/trait.ObjectExt.html#tymethod.property) and [`set_property`](http://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/object/trait.ObjectExt.html#tymethod.set_property) methods.
@@ -17,7 +17,7 @@ Because they can be used for properties of different types, they operate with `g
 
 <span class="filename">Filename: listings/gobject_properties/2/main.rs</span>
 
-```rust ,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/gobject_properties/2/main.rs:switch}}
 ```
 
@@ -29,7 +29,7 @@ Let us see how that would look like for two `Switch` instances.
 
 <span class="filename">Filename: listings/gobject_properties/3/main.rs</span>
 
-```rust ,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/gobject_properties/3/main.rs:switches}}
 ```
 
@@ -38,7 +38,7 @@ We also want the binding to be bidirectional, so we specify this with the [`Bind
 
 <span class="filename">Filename: listings/gobject_properties/3/main.rs</span>
 
-```rust ,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/gobject_properties/3/main.rs:bind_state}}
 ```
 
@@ -71,11 +71,8 @@ The formerly private `number` is now accessible via the `property` and `set_prop
 
 <span class="filename">Filename: listings/gobject_properties/4/custom_button/imp.rs</span>
 
-```rust
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/gobject_properties/4/custom_button/imp.rs:object_impl}}
-# // Please ignore this line
-# // It is only there to make mdbook happy
-# fn main() {}
 ```
 
 We can immediately take advantage of this new property by binding the "label" property to it.
@@ -86,7 +83,7 @@ Let us see what we can do with this by creating two custom buttons.
 
 <span class="filename">Filename: listings/gobject_properties/4/main.rs</span>
 
-```rust ,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/gobject_properties/4/main.rs:buttons}}
 ```
 
@@ -95,7 +92,7 @@ By leveraging [`transform_to`](http://gtk-rs.org/gtk-rs-core/stable/latest/docs/
 
 <span class="filename">Filename: listings/gobject_properties/4/main.rs</span>
 
-```rust ,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/gobject_properties/4/main.rs:bind_numbers}}
 ```
 Now if we click on one button, the "number" and "label" properties of the other button change as well.
@@ -107,7 +104,7 @@ We can do this like this:
 
 <span class="filename">Filename: listings/gobject_properties/4/main.rs</span>
 
-```rust ,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/gobject_properties/4/main.rs:connect_notify}}
 ```
 

--- a/book/src/gobject_signals.md
+++ b/book/src/gobject_signals.md
@@ -9,7 +9,7 @@ In our "Hello World" example we [connected](../docs/gtk4/prelude/trait.ButtonExt
 
 <span class="filename">Filename: listings/gobject_signals/1/main.rs</span>
 
-```rust ,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/gobject_signals/1/main.rs:callback}}
 ```
 
@@ -18,7 +18,7 @@ connected to it with the generic [`connect_local`](http://gtk-rs.org/gtk-rs-core
 
 <span class="filename">Filename: listings/gobject_signals/2/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/gobject_signals/2/main.rs:callback}}
 ```
 
@@ -30,12 +30,9 @@ First we override the necessary methods in `ObjectImpl`.
 
 <span class="filename">Filename: listings/gobject_signals/3/custom_button/imp.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/gobject_signals/3/custom_button/imp.rs:object_impl}}
 
-# // Please ignore this line
-# // It is only there to make mdbook happy
-# fn main() {}
 ```
 
 The `signals` method is responsible for defining a set of signals.
@@ -49,12 +46,9 @@ After we did that, we set `number` back to 0.
 
 <span class="filename">Filename: listings/gobject_signals/3/custom_button/imp.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/gobject_signals/3/custom_button/imp.rs:button_impl}}
 
-# // Please ignore this line
-# // It is only there to make mdbook happy
-# fn main() {}
 ```
 
 If we now press on the button, the number of its label increases until it reaches `MAX_NUMBER`.
@@ -63,7 +57,7 @@ Whenever we now receive the "max-number-reached" signal, the accompanying number
 
 <span class="filename">Filename: listings/gobject_signals/3/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/gobject_signals/3/main.rs:signal_handling}}
 ```
 

--- a/book/src/gobject_subclassing.md
+++ b/book/src/gobject_subclassing.md
@@ -10,11 +10,8 @@ It therefore corresponds to the private section of objects in languages like Jav
 
 <span class="filename">Filename: listings/gobject_subclassing/1/custom_button/imp.rs</span>
 
-```rust ,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/gobject_subclassing/1/custom_button/imp.rs}}
-# // Please ignore this line
-# // It is only there to make mdbook happy
-# fn main() {}
 ```
 The description of the subclassing is in `ObjectSubclass`.
 - `NAME` should consist of crate-name, module-path and object-name in order to avoid name collisions. Use [PascalCase](https://wiki.c2.com/?PascalCase) here.
@@ -28,11 +25,8 @@ Next, we describe our custom GObject.
 
 <span class="filename">Filename: listings/gobject_subclassing/1/custom_button/mod.rs</span>
 
-```rust ,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/gobject_subclassing/1/custom_button/mod.rs:mod}}
-# // Please ignore this line
-# // It is only there to make mdbook happy
-# fn main() {}
 ```
 
 [`glib::wrapper!`](http://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/macro.wrapper.html) does the most of the work of subclassing for us.
@@ -44,7 +38,7 @@ After these steps, nothing is stopping us anymore from replacing `gtk::Button` w
 
 <span class="filename">Filename: listings/gobject_subclassing/1/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/gobject_subclassing/1/main.rs}}
 ```
 We are able to use `CustomButton` as a drop-in replacement for `gtk::Button`.
@@ -56,18 +50,15 @@ So let us make it a bit more interesting!
 
 <span class="filename">Filename: listings/gobject_subclassing/2/custom_button/imp.rs</span>
 
-```rust ,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/gobject_subclassing/2/custom_button/imp.rs}}
-# // Please ignore this line
-# // It is only there to make mdbook happy
-# fn main() {}
 ```
 We override `constructed` in `ObjectImpl` so that the label of the button initializes with `number`.
 We also override `clicked` in `ButtonImpl` so that every click increases `number` and updates the label.
 
 <span class="filename">Filename: listings/gobject_subclassing/2/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/gobject_subclassing/2/main.rs:activate}}
 ```
 

--- a/book/src/gobject_values.md
+++ b/book/src/gobject_values.md
@@ -4,7 +4,7 @@ Some GObject-related functions rely on generic values for their arguments or ret
 Enums in C are not as powerful as the one in Rust, which is why [`glib::Value`](http://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/value/struct.Value.html) is used for this.
 Conceptually though, there are similar to a Rust enum defined like this:
 
-```rust
+```rust, no_run,noplayground
 enum Value <T> {
     bool(bool),
     i8(i8),
@@ -24,7 +24,7 @@ For example, this is how you would use a `Value` representing an `i32`.
 
 <span class="filename">Filename: listings/gobject_values/1/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/gobject_values/1/main.rs:i32}}
 ```
 
@@ -35,13 +35,13 @@ You can still access it the same way as with the `i32` above.
 
 <span class="filename">Filename: listings/gobject_values/1/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/gobject_values/1/main.rs:string}}
 ```
 
 If you want to differentiate between specifying the wrong type and a `Value` representing `None`, just call `get::<Option<T>>` instead.
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/gobject_values/1/main.rs:string_none}}
 ```
 

--- a/book/src/hello_world.md
+++ b/book/src/hello_world.md
@@ -7,7 +7,7 @@ For that we use the [builder pattern](https://rust-unofficial.github.io/patterns
 
 <span class="filename">Filename: listings/hello_world/1/main.rs</span>
 
-```rust ,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/hello_world/1/main.rs}}
 ```
 
@@ -17,7 +17,7 @@ So let us create a window there.
 
 <span class="filename">Filename: listings/hello_world/2/main.rs</span>
 
-```rust ,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/hello_world/2/main.rs}}
 ```
 That is better!
@@ -29,7 +29,7 @@ Also, the name of the chapter suggests that the phrase "Hello World!" will be in
 
 <span class="filename">Filename: listings/hello_world/3/main.rs</span>
 
-```rust ,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/hello_world/3/main.rs:build_ui}}
 ```
 There is now a button and if we click on it, its label becomes "Hello World!".

--- a/book/src/interface_builder.md
+++ b/book/src/interface_builder.md
@@ -6,7 +6,7 @@ Until now, whenever we constructed pre-defined widgets we relied on the [builder
 As a reminder, that is how we used it in our trusty "Hello World!" app.
 
 <span class="filename">Filename: listings/hello_world/3/main.rs</span>
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/hello_world/3/main.rs:all}}
 ```
 
@@ -32,7 +32,7 @@ To instantiate the widgets described by the `xml` files we use [`gtk::Builder`](
 All widgets that can be described that way can be found [here](../docs/gtk4/prelude/trait.BuildableExt.html#implementors-1)
 
 <span class="filename">Filename: listings/interface_builder/1/main.rs</span>
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/interface_builder/1/main.rs:build_ui}}
 ```
 
@@ -45,11 +45,8 @@ At least we did not lose any flexibility by using `gtk::Builder`.
 It is for example still possible to refer to custom widgets such as this bare-bones `CustomButton`.
 
 <span class="filename">Filename: listings/interface_builder/2/custom_button/imp.rs</span>
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/interface_builder/2/custom_button/imp.rs:imp}}
-# // Please ignore this line
-# // It is only there to make mdbook happy
-# fn main() {}
 ```
 
 Within the `xml` file we reference the widget with the `NAME` we gave it in `imp.rs`.
@@ -62,7 +59,7 @@ Within the `xml` file we reference the widget with the `NAME` we gave it in `imp
 We also have to make sure to register the custom widget before it is used by the interface builder.
 
 <span class="filename">Filename: listings/interface_builder/2/main.rs</span>
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/interface_builder/2/main.rs:main}}
 ```
 
@@ -92,22 +89,16 @@ Now, we create a custom widget and let it inherit from a pre-existing one.
 Within our code we create a custom widget inheriting from `gtk::ApplicationWindow` to make use of our template.
 
 <span class="filename">Filename: listings/interface_builder/3/window/mod.rs</span>
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/interface_builder/3/window/mod.rs}}
-# // Please ignore this line
-# // It is only there to make mdbook happy
-# fn main() {}
 ```
 
 In the private struct, we then add the derive macro `gtk::CompositeTemplate`.
 We also specify that the template information comes from a file `window.ui` in the same folder.
 
 <span class="filename">Filename: listings/interface_builder/3/window/imp.rs</span>
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/interface_builder/3/window/imp.rs:object}}
-# // Please ignore this line
-# // It is only there to make mdbook happy
-# fn main() {}
 ```
 
 One very convenient feature of templates is the template child.
@@ -119,29 +110,23 @@ Template child then:
 We need both for our custom button, so we add it to the struct.
 
 <span class="filename">Filename: listings/interface_builder/3/window/imp.rs</span>
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/interface_builder/3/window/imp.rs:subclass}}
-# // Please ignore this line
-# // It is only there to make mdbook happy
-# fn main() {}
 ```
 
 Within the `ObjectSubclass` trait, we make sure that `NAME` corresponds to `class` in the template and `ParentType` corresponds to `parent` in the template.
 We also bind and initialize the template in `class_init` and `instance_init`.
 
 <span class="filename">Filename: listings/interface_builder/3/window/imp.rs</span>
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/interface_builder/3/window/imp.rs:object_impl}}
-# // Please ignore this line
-# // It is only there to make mdbook happy
-# fn main() {}
 ```
 
 Finally, we connect the callback to the "clicked" signal of `button` within `constructed`.
 The button is easily available thanks to the stored reference in `self`.
 
 <span class="filename">Filename: listings/interface_builder/3/main.rs</span>
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/interface_builder/3/main.rs:build_ui}}
 ```
 With composite templates, `main.rs` actually became more concise.

--- a/book/src/lists.md
+++ b/book/src/lists.md
@@ -9,7 +9,7 @@ Each label will display an integer starting from 0 and ranging up to 100.
 
 <span class="filename">Filename: listings/lists/1/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/lists/1/main.rs:list_box}}
 ```
 
@@ -19,7 +19,7 @@ Now we can scroll through our elements.
 
 <span class="filename">Filename: listings/lists/1/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/lists/1/main.rs:scrolled_window}}
 ```
 
@@ -54,24 +54,18 @@ We only need to let it inherit from GObject instead of `Button` and let the `new
 
 <span class="filename">Filename: listings/lists/2/integer_object/mod.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/lists/2/integer_object/mod.rs:integer_object}}
 #
-# // Please ignore this line
-# // It is only there to make mdbook happy
-# fn main() {}
 ```
 
 The `imp` module can stay the same apart from the rename from `CustomButton` to `IntegerObject`.
 
 <span class="filename">Filename: listings/lists/2/integer_object/imp.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/lists/2/integer_object/imp.rs:integer_object}}
 #
-# // Please ignore this line
-# // It is only there to make mdbook happy
-# fn main() {}
 ```
 
 We now fill the model with integers from 0 to 100 000.
@@ -80,7 +74,7 @@ Neither `Label` nor any other widget is mentioned here.
 
 <span class="filename">Filename: listings/lists/2/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/lists/2/main.rs:model}}
 ```
 
@@ -91,7 +85,7 @@ We connect to it to create a `Label` for every requested widget.
 
 <span class="filename">Filename: listings/lists/2/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/lists/2/main.rs:factory_setup}}
 ```
 
@@ -99,7 +93,7 @@ In the "bind" step we bind the data in our model to the individual list items.
 
 <span class="filename">Filename: listings/lists/2/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/lists/2/main.rs:factory_bind}}
 ```
 
@@ -109,7 +103,7 @@ Then we pass the model and the factory to the [`ListView`](../docs/gtk4/struct.L
 
 <span class="filename">Filename: listings/lists/2/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/lists/2/main.rs:selection_list}}
 ```
 
@@ -117,7 +111,7 @@ Every `ListView` has to be a direct child of a `ScrolledWindow`, so we are addin
 
 <span class="filename">Filename: listings/lists/2/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/lists/2/main.rs:scrolled_window}}
 ```
 
@@ -131,7 +125,7 @@ For that we first add the method `increase_number` to our `IntegerObject`.
 
 <span class="filename">Filename: listings/lists/3/integer_object/mod.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/lists/3/integer_object/mod.rs:integer_object}}
 ```
 
@@ -139,7 +133,7 @@ In order to interact with our `ListView`, we connect to its "activate" signal.
 
 <span class="filename">Filename: listings/lists/3/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/lists/3/main.rs:list_view_activate}}
 ```
 
@@ -150,7 +144,7 @@ One naive approach would be to bind the properties in the "bind" step of the `Si
 
 <span class="filename">Filename: listings/lists/3/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/lists/3/main.rs:factory_bind}}
 ```
 
@@ -167,7 +161,7 @@ Let us see how the "setup" step now works.
 
 <span class="filename">Filename: listings/lists/4/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/lists/4/main.rs:factory_setup}}
 ```
 
@@ -191,7 +185,7 @@ We can, for example, filter our model to only allow even numbers.
 
 <span class="filename">Filename: listings/lists/5/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/lists/5/main.rs:filter}}
 ```
 
@@ -199,7 +193,7 @@ Additionally, we can reverse the order of our model.
 
 <span class="filename">Filename: listings/lists/5/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/lists/5/main.rs:sorter}}
 ```
 
@@ -207,7 +201,7 @@ To ensure that our filter and sorter get updated when we modify the numbers, we 
 
 <span class="filename">Filename: listings/lists/5/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/lists/5/main.rs:activate}}
 ```
 

--- a/book/src/main_event_loop.md
+++ b/book/src/main_event_loop.md
@@ -18,7 +18,7 @@ Let us look at one example.
 
 <span class="filename">Filename: listings/main_event_loop/1/main.rs</span>
 
-```rust ,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/main_event_loop/1/main.rs}}
 ```
 
@@ -30,7 +30,7 @@ For that we just need to spawn a new thread and let the operation run there.
 
 <span class="filename">Filename: listings/main_event_loop/2/main.rs</span>
 
-```rust ,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/main_event_loop/2/main.rs:callback}}
 ```
 
@@ -45,7 +45,7 @@ We want to send a `bool` to inform, whether we want the button to react to click
 
 <span class="filename">Filename: listings/main_event_loop/3/main.rs</span>
 
-```rust ,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/main_event_loop/3/main.rs:callback}}
 ```
 
@@ -56,7 +56,7 @@ The converted code looks and behaves very similar to the multi-threaded code.
 
 <span class="filename">Filename: listings/main_event_loop/4/main.rs</span>
 
-```rust ,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/main_event_loop/4/main.rs:callback}}
 ```
 
@@ -64,7 +64,7 @@ Since we are single-threaded again, we could even get rid of the channels while 
 
 <span class="filename">Filename: listings/main_event_loop/5/main.rs</span>
 
-```rust ,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/main_event_loop/5/main.rs:callback}}
 ```
 

--- a/book/src/saving_window_state.md
+++ b/book/src/saving_window_state.md
@@ -18,12 +18,9 @@ First, we create one and add methods for getting and setting the window state.
 
 <span class="filename">Filename: listings/saving_window_state/1/custom_window/mod.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/saving_window_state/1/custom_window/mod.rs:mod}}
 
-# // Please ignore this line
-# // It is only there to make mdbook happy
-# fn main() {}
 ```
 
 The implementation struct holds the `settings`.
@@ -31,12 +28,9 @@ We also override the `constructed` and `close_request` methods, where we load or
 
 <span class="filename">Filename: listings/saving_window_state/1/custom_window/imp.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/saving_window_state/1/custom_window/imp.rs:imp}}
 
-# // Please ignore this line
-# // It is only there to make mdbook happy
-# fn main() {}
 ```
 
 That is it!
@@ -61,7 +55,7 @@ We then have to initialize `pretty_env_logger` by calling `init` in `main`.
 
 <span class="filename">Filename: listings/saving_window_state/1/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/saving_window_state/1/main.rs:main}}
 ```
 

--- a/book/src/settings.md
+++ b/book/src/settings.md
@@ -16,7 +16,7 @@ The `id` is the same application id we used when we created our application.
 
 <span class="filename">Filename: listings/settings/1/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/settings/1/main.rs:application}}
 ```
 The `path` must start and end with a forward slash character ('/') and must not contain two sequential slash characters.
@@ -40,7 +40,7 @@ We initialize the `Settings` object by specifying the application id.
 
 <span class="filename">Filename: listings/settings/1/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/settings/1/main.rs:settings}}
 ```
 
@@ -48,7 +48,7 @@ Then we get the settings key and use it when we create our `Switch`.
 
 <span class="filename">Filename: listings/settings/1/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/settings/1/main.rs:switch}}
 ```
 
@@ -56,7 +56,7 @@ Finally, we assure that the switch state is stored in the settings whenever we c
 
 <span class="filename">Filename: listings/settings/1/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/settings/1/main.rs:connect_state_set}}
 ```
 
@@ -71,7 +71,7 @@ Additionally, we specify [`SettingsBindFlags`](https://gtk-rs.org/gtk-rs-core/st
 
 <span class="filename">Filename: listings/settings/2/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/settings/2/main.rs:settings_bind}}
 ```
 

--- a/book/src/todo_app_1.md
+++ b/book/src/todo_app_1.md
@@ -23,11 +23,8 @@ As usual, we have to list all [ancestors](https://docs.gtk.org/gtk4/class.Applic
 
 <span class="filename">Filename: listings/todo_app/1/window/mod.rs</span>
 
-```rust
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/todo_app/1/window/mod.rs:glib_wrapper}}
-# // Please ignore this line
-# // It is only there to make mdbook happy
-# fn main() {}
 ```
 
 Then we initialize the composite template for `imp::Window`.
@@ -38,18 +35,15 @@ We only have to assure that the `class` attribute of the template in `window.ui`
 
 <span class="filename">Filename: listings/todo_app/1/window/imp.rs</span>
 
-```rust
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/todo_app/1/window/imp.rs:struct_and_subclass}}
-# // Please ignore this line
-# // It is only there to make mdbook happy
-# fn main() {}
 ```
 
 `main.rs` also does not hold any surprises for us.
 
 <span class="filename">Filename: listings/todo_app/1/main.rs</span>
 
-```rust
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/todo_app/1/main.rs:main}}
 ```
 
@@ -69,22 +63,16 @@ This object will store the state of the task consisting of:
 
 <span class="filename">Filename: listings/todo_app/1/todo_object/mod.rs</span>
 
-```rust
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/todo_app/1/todo_object/mod.rs:glib_wrapper_and_new}}
-# // Please ignore this line
-# // It is only there to make mdbook happy
-# fn main() {}
 ```
 
 Unlike the lists chapter, the state is stored in a struct rather than in individual members of `imp::TodoObject`.
 
 <span class="filename">Filename: listings/todo_app/1/todo_object/mod.rs</span>
 
-```rust
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/todo_app/1/todo_object/mod.rs:todo_data}}
-# // Please ignore this line
-# // It is only there to make mdbook happy
-# fn main() {}
 ```
 
 Not only that, we see that it is also wrapped in a [`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html).
@@ -94,11 +82,8 @@ If you are curious, you can press on the small eye symbol on the top right of th
 
 <span class="filename">Filename: listings/todo_app/1/todo_object/imp.rs</span>
 
-```rust
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/todo_app/1/todo_object/imp.rs:struct_and_subclass}}
-# // Please ignore this line
-# // It is only there to make mdbook happy
-# fn main() {}
 ```
 
 Let us move on to the individual tasks.
@@ -120,11 +105,8 @@ In the code, we [derive](https://docs.gtk.org/gtk4/class.Box.html#hierarchy) `To
 
 <span class="filename">Filename: listings/todo_app/1/todo_row/mod.rs</span>
 
-```rust
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/todo_app/1/todo_row/mod.rs:glib_wrapper}}
-# // Please ignore this line
-# // It is only there to make mdbook happy
-# fn main() {}
 ```
 
 In `imp::TodoRow`, we hold references to `completed_button` and `content_label`.
@@ -134,11 +116,8 @@ Why we need that will become clear as soon as we get to bind the state of `TodoO
 
 <span class="filename">Filename: listings/todo_app/1/todo_row/imp.rs</span>
 
-```rust
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/todo_app/1/todo_row/imp.rs:struct_and_subclass}}
-# // Please ignore this line
-# // It is only there to make mdbook happy
-# fn main() {}
 ```
 
 Now we can bring everything together.
@@ -146,11 +125,8 @@ We override the `imp::Window::constructed` in order to set up window contents at
 
 <span class="filename">Filename: listings/todo_app/1/window/imp.rs</span>
 
-```rust
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/todo_app/1/window/imp.rs:constructed}}
-# // Please ignore this line
-# // It is only there to make mdbook happy
-# fn main() {}
 ```
 
 Since we need to access the list model quite often, we add the convenience method `Window::model` for that.
@@ -159,11 +135,8 @@ Then we store a reference to the model in `imp::Window` as well as in `gtk::List
 
 <span class="filename">Filename: listings/todo_app/1/window/mod.rs</span>
 
-```rust
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/todo_app/1/window/mod.rs:model}}
-# // Please ignore this line
-# // It is only there to make mdbook happy
-# fn main() {}
 ```
 
 In `Window::setup_callbacks` we connect to the "activate" signal of the entry.
@@ -173,11 +146,8 @@ Finally, the entry will be cleared.
 
 <span class="filename">Filename: listings/todo_app/1/window/mod.rs</span>
 
-```rust
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/todo_app/1/window/mod.rs:setup_callbacks}}
-# // Please ignore this line
-# // It is only there to make mdbook happy
-# fn main() {}
 ```
 The list elements for the `gtk::ListView` are produced by a factory.
 Before we move on to the implementation, let us take a step back and think about which behavior we expect here.
@@ -194,11 +164,8 @@ We will create empty `TodoRow` objects in the "setup" step in `Window::setup_fac
 
 <span class="filename">Filename: listings/todo_app/1/window/mod.rs</span>
 
-```rust
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/todo_app/1/window/mod.rs:setup_factory}}
-# // Please ignore this line
-# // It is only there to make mdbook happy
-# fn main() {}
 ```
 
 Binding properties in `TodoRow::bind` works just like in former chapters.
@@ -209,11 +176,8 @@ Unbinding will only work if it can access the stored `glib::Binding`.
 
 <span class="filename">Filename: listings/todo_app/1/todo_row/mod.rs</span>
 
-```rust
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/todo_app/1/todo_row/mod.rs:bind}}
-# // Please ignore this line
-# // It is only there to make mdbook happy
-# fn main() {}
 ```
 
 `TodoRow::unbind` takes care of the cleanup.
@@ -222,11 +186,8 @@ In the end, it clears the vector.
 
 <span class="filename">Filename: listings/todo_app/1/todo_row/mod.rs</span>
 
-```rust
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/todo_app/1/todo_row/mod.rs:unbind}}
-# // Please ignore this line
-# // It is only there to make mdbook happy
-# fn main() {}
 ```
 
 That was it, we created a basic To-Do app!

--- a/book/src/widgets.md
+++ b/book/src/widgets.md
@@ -31,7 +31,7 @@ And indeed, `ButtonExt` includes the method [`connect_clicked`](../docs/gtk4/pre
 
 <span class="filename">Filename: listings/hello_world/3/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/hello_world/3/main.rs:button}}
 ```
 
@@ -40,7 +40,7 @@ In our example we did that by adding the following line:
 
 <span class="filename">Filename: listings/hello_world/3/main.rs</span>
 
-```rust,no_run
+```rust ,no_run,noplayground
 {{#rustdoc_include ../listings/hello_world/3/main.rs:prelude}}
 ```
 With it, we import all necessary traits for dealing with widgets.


### PR DESCRIPTION
Before we had to add main to many snippets
in order to stop mdbook for adding it itself