### PR TITLE
[WIP] Add windows installation instructions

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -2,6 +2,7 @@
 
 [Introduction](introduction.md)
 - [Prerequisites](prerequisites.md)
+  - [Windows installation](windows_install.md)
 - [Hello World!](hello_world.md)
 - [Widgets](widgets.md)
 - [GObject Concepts](gobject_concepts.md)

--- a/book/src/windows_install.md
+++ b/book/src/windows_install.md
@@ -1,0 +1,70 @@
+# Installing GTK4 on Windows
+
+Installing GTK4 for gtk4-rs on Windows just takes a few minutes.
+Follow the **preparation** first and then proceed with installing GTK either for the **GNU toolchain**
+or the **MSVC toolchain**.
+
+## Preparation
+
+1. Install Rust using [rustup](https://rustup.rs)
+2. Install MSYS2 from [www.msys2.org](https://www.msys2.org/) 
+
+### Update path environment variable
+
+1. Go to settings -> Search and open `Advanced system settings` -> click on `Environment variables`
+2. Select `Path` -> Click on `Edit` -> Add the following three entries:
+ 
+```
+C:\msys64\mingw64\include
+C:\msys64\mingw64\bin
+C:\msys64\mingw64\lib
+```
+
+
+## GNU toolchain
+
+Using the GNU toolchain is usually the easier method and recommended unless you know you want to use MSVC instead.
+
+### Setup the `windows-gnu` toolchain for Rust
+
+Run the following commands from your terminal:
+
+1. `rustup toolchain install stable-gnu`
+2. `rustup default stable-gnu`
+
+### Install GTK
+
+Run the following command from your **MSYS2 terminal**:
+
+```sh
+pacman -S mingw-w64-x86_64-gtk4 mingw-w64-x86_64-pkg-config mingw-w64-x86_64-gcc
+```
+
+
+## MSVC toolchain
+
+### Install required tools
+1. Install [Visual Studio](https://visualstudio.microsoft.com/vs/) with C++ compiler tools
+2. Install git from [git-scm.com](https://git-scm.com/download/win)
+3. Install meson from [github.com/mesonbuild/meson](https://github.com/mesonbuild/meson/releases)
+4. Install python from [www.python.org](https://www.python.org/downloads/)
+
+### Install pkg-config
+
+Run the following command from your **MSYS2 terminal**:
+
+```sh
+pacman -S pkg-config
+```
+
+### Compile and install GTK4
+
+Run the following commands from your terminal:
+
+```sh
+git clone https://gitlab.gnome.org/GNOME/gtk.git
+cd gtk
+meson setup build -Dmedia-gstreamer=disabled -Dbuild-tests=false
+meson compile -C build
+meson install -C build
+```


### PR DESCRIPTION
This is still WIP because the MSVC toolchain instructions fail when linking a gtk4-rs project:

```
  = note: libgsk4-0fc395f4be3f05e4.rlib(gsk4-0fc395f4be3f05e4.gsk4.af9460af-cgu.8.rcgu.o) : error LNK2019: unresolved external symbol __imp_gsk_gl_renderer_new referenced in function _ZN4gsk44auto11gl_renderer10GLRenderer3new17h84977ca3354dedfcE
          libgsk4-0fc395f4be3f05e4.rlib(gsk4-0fc395f4be3f05e4.gsk4.af9460af-cgu.8.rcgu.o) : error LNK2019: unresolved external symbol __imp_gsk_gl_renderer_get_type referenced in function _ZN79_$LT$gsk4..auto..gl_renderer..GLRenderer$u20$as$u20$glib..types..StaticType$GT$11static_type17hf4aa13191ad26492E
          C:\Users\User\Downloads\relm4-main\relm4-main\target\debug\examples\simple.exe : fatal error LNK1120: 2 unresolved externals
```

Maybe someone knows how to fix the error...