### PR TITLE
gsk: rename Rendrer trait

### DIFF
--- a/gsk4/Gir.toml
+++ b/gsk4/Gir.toml
@@ -118,17 +118,18 @@ version = "4.2"
 [[object]]
 name = "Gsk.Renderer"
 status = "generate"
-manual_traits = ["RendererExtManual"]
+trait_name = "GskRenderer"
+manual_traits = ["GskRendererExtManual"]
     [[object.function]]
     name = "render"
     # uses IsA<RenderNode> but RenderNode is not an Object
     manual = true
-    doc_trait_name = "RendererExtManual"
+    doc_trait_name = "GskRendererExtManual"
     [[object.function]]
     name = "render_texture"
     # uses IsA<RenderNode> but RenderNode is not an Object
     manual = true
-    doc_trait_name = "RendererExtManual"
+    doc_trait_name = "GskRendererExtManual"
 
 [[object]]
 name = "Gsk.RenderNode"

--- a/gsk4/src/auto/mod.rs
+++ b/gsk4/src/auto/mod.rs
@@ -46,5 +46,5 @@ pub use self::enums::TransformCategory;
 
 #[doc(hidden)]
 pub mod traits {
-    pub use super::renderer::RendererExt;
+    pub use super::renderer::GskRenderer;
 }

--- a/gsk4/src/auto/renderer.rs
+++ b/gsk4/src/auto/renderer.rs
@@ -32,7 +32,7 @@ impl Renderer {
 
 pub const NONE_RENDERER: Option<&Renderer> = None;
 
-pub trait RendererExt: 'static {
+pub trait GskRenderer: 'static {
     #[doc(alias = "gsk_renderer_get_surface")]
     #[doc(alias = "get_surface")]
     fn surface(&self) -> Option<gdk::Surface>;
@@ -53,7 +53,7 @@ pub trait RendererExt: 'static {
     fn connect_surface_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId;
 }
 
-impl<O: IsA<Renderer>> RendererExt for O {
+impl<O: IsA<Renderer>> GskRenderer for O {
     fn surface(&self) -> Option<gdk::Surface> {
         unsafe {
             from_glib_none(ffi::gsk_renderer_get_surface(

--- a/gsk4/src/prelude.rs
+++ b/gsk4/src/prelude.rs
@@ -5,7 +5,7 @@
 
 pub use crate::auto::traits::*;
 
-pub use crate::renderer::RendererExtManual;
+pub use crate::renderer::GskRendererExtManual;
 
 #[doc(hidden)]
 pub use gdk::prelude::*;

--- a/gsk4/src/renderer.rs
+++ b/gsk4/src/renderer.rs
@@ -4,7 +4,7 @@ use crate::{RenderNode, Renderer};
 use glib::object::IsA;
 use glib::translate::*;
 
-pub trait RendererExtManual: 'static {
+pub trait GskRendererExtManual: 'static {
     #[doc(alias = "gsk_renderer_render")]
     fn render<P: AsRef<RenderNode>>(&self, root: &P, region: Option<&cairo::Region>);
 
@@ -16,7 +16,7 @@ pub trait RendererExtManual: 'static {
     ) -> Option<gdk::Texture>;
 }
 
-impl<O: IsA<Renderer>> RendererExtManual for O {
+impl<O: IsA<Renderer>> GskRendererExtManual for O {
     fn render<P: AsRef<RenderNode>>(&self, root: &P, region: Option<&cairo::Region>) {
         unsafe {
             ffi::gsk_renderer_render(


### PR DESCRIPTION
to avoid the name clash with pango::Renderer
fixes #581