### PR TITLE
Remove unused dependencies

### DIFF
--- a/gdk4/sys/Cargo.toml
+++ b/gdk4/sys/Cargo.toml
@@ -48,9 +48,6 @@ git = "https://github.com/gtk-rs/gtk-rs-core"
 [dependencies.gobject-sys]
 git = "https://github.com/gtk-rs/gtk-rs-core"
 
-[dependencies.graphene-sys]
-git = "https://github.com/gtk-rs/gtk-rs-core"
-
 [dependencies.pango-sys]
 git = "https://github.com/gtk-rs/gtk-rs-core"
 

--- a/gtk4-macros/Cargo.toml
+++ b/gtk4-macros/Cargo.toml
@@ -16,8 +16,6 @@ proc-macro = true
 
 [dependencies]
 anyhow = "1.0"
-heck = "0.3"
-itertools = "0.10"
 proc-macro-crate = "1.0"
 proc-macro-error = "1.0"
 proc-macro2 = "1.0"


### PR DESCRIPTION
gtk4-rs is crate with quite a lot of dependencies, so I though I'd just run [`cargo-udeps`](https://lib.rs/crates/cargo-udeps) to find unused dependencies. And indeed, I found a few.

Let's let the CI figure out if they were actually unnecessary :)