### PR TITLE
gtk/gsk: remove C convenience functions

### DIFF
--- a/gsk4/Gir.toml
+++ b/gsk4/Gir.toml
@@ -18,7 +18,6 @@ generate = [
     "Gsk.RenderNodeType",
     "Gsk.ScalingFilter",
     "Gsk.SerializationError",
-    "Gsk.ShaderArgsBuilder",
     "Gsk.TransformCategory",
 ]
 
@@ -135,6 +134,13 @@ manual_traits = ["GskRendererExtManual"]
 name = "Gsk.RenderNode"
 status = "manual" # fundemental type
 final_type = true # avoids the usage of RenderNodeExt trait
+
+[[object]]
+name = "Gsk.ShaderArgsBuilder"
+status = "generate"
+    [[object.function]]
+    name = "free_to_args"
+    ignore = true # C convenience functions
 
 [[object]]
 name = "Gsk.Transform"

--- a/gsk4/src/auto/shader_args_builder.rs
+++ b/gsk4/src/auto/shader_args_builder.rs
@@ -28,15 +28,6 @@ impl ShaderArgsBuilder {
         }
     }
 
-    #[doc(alias = "gsk_shader_args_builder_free_to_args")]
-    pub fn free_to_args(&self) -> Option<glib::Bytes> {
-        unsafe {
-            from_glib_full(ffi::gsk_shader_args_builder_free_to_args(
-                self.to_glib_none().0,
-            ))
-        }
-    }
-
     #[doc(alias = "gsk_shader_args_builder_set_bool")]
     pub fn set_bool(&self, idx: i32, value: bool) {
         unsafe {

--- a/gtk4/Gir.toml
+++ b/gtk4/Gir.toml
@@ -1872,6 +1872,9 @@ name = "Gtk.Snapshot"
 status = "generate"
 trust_return_value_nullability = false
     [[object.function]]
+    pattern = "free_to_(node|paintable)"
+    ignore = true # C convenience functions
+    [[object.function]]
     name = "append_border"
     manual = true
     [[object.function]]

--- a/gtk4/src/auto/snapshot.rs
+++ b/gtk4/src/auto/snapshot.rs
@@ -112,21 +112,6 @@ impl Snapshot {
         }
     }
 
-    #[doc(alias = "gtk_snapshot_free_to_node")]
-    pub fn free_to_node(&self) -> Option<gsk::RenderNode> {
-        unsafe { from_glib_full(ffi::gtk_snapshot_free_to_node(self.to_glib_full())) }
-    }
-
-    #[doc(alias = "gtk_snapshot_free_to_paintable")]
-    pub fn free_to_paintable(&self, size: Option<&graphene::Size>) -> Option<gdk::Paintable> {
-        unsafe {
-            from_glib_full(ffi::gtk_snapshot_free_to_paintable(
-                self.to_glib_full(),
-                size.to_glib_none().0,
-            ))
-        }
-    }
-
     #[doc(alias = "gtk_snapshot_gl_shader_pop_texture")]
     pub fn gl_shader_pop_texture(&self) {
         unsafe {


### PR DESCRIPTION
Not useful for Rust bindings as they should use to_* alternatives
Fixes #617