### PR TITLE
gtk: make *_set_sort_func use gtk::Ordering

### DIFF
--- a/gtk4/Gir.toml
+++ b/gtk4/Gir.toml
@@ -1173,9 +1173,7 @@ status = "generate"
         nullable = false
     [[object.function]]
     name = "set_sort_func"
-        [[object.function.parameter]]
-        name = "sort_func" # use unset_sort_func instead
-        nullable = false
+    manual = true # make the sort closure return a Ordering instead of an int
 
 [[object]]
 name = "Gtk.FontButton"
@@ -1350,9 +1348,7 @@ trust_return_value_nullability = false
         nullable = false # we add a manual unset_header_func
     [[object.function]]
     name = "set_sort_func"
-        [[object.function.parameter]]
-        name = "sort_func"
-        nullable = false # we add a manual unset_sort_func
+    manual = true # make the sort closure return a Ordering instead of an int
 
 [[object]]
 name = "Gtk.ListItem"

--- a/gtk4/src/auto/flow_box.rs
+++ b/gtk4/src/auto/flow_box.rs
@@ -329,43 +329,6 @@ impl FlowBox {
         }
     }
 
-    #[doc(alias = "gtk_flow_box_set_sort_func")]
-    pub fn set_sort_func<P: Fn(&FlowBoxChild, &FlowBoxChild) -> i32 + 'static>(
-        &self,
-        sort_func: P,
-    ) {
-        let sort_func_data: Box_<P> = Box_::new(sort_func);
-        unsafe extern "C" fn sort_func_func<
-            P: Fn(&FlowBoxChild, &FlowBoxChild) -> i32 + 'static,
-        >(
-            child1: *mut ffi::GtkFlowBoxChild,
-            child2: *mut ffi::GtkFlowBoxChild,
-            user_data: glib::ffi::gpointer,
-        ) -> libc::c_int {
-            let child1 = from_glib_borrow(child1);
-            let child2 = from_glib_borrow(child2);
-            let callback: &P = &*(user_data as *mut _);
-            let res = (*callback)(&child1, &child2);
-            res
-        }
-        let sort_func = Some(sort_func_func::<P> as _);
-        unsafe extern "C" fn destroy_func<P: Fn(&FlowBoxChild, &FlowBoxChild) -> i32 + 'static>(
-            data: glib::ffi::gpointer,
-        ) {
-            let _callback: Box_<P> = Box_::from_raw(data as *mut _);
-        }
-        let destroy_call3 = Some(destroy_func::<P> as _);
-        let super_callback0: Box_<P> = sort_func_data;
-        unsafe {
-            ffi::gtk_flow_box_set_sort_func(
-                self.to_glib_none().0,
-                sort_func,
-                Box_::into_raw(super_callback0) as *mut _,
-                destroy_call3,
-            );
-        }
-    }
-
     #[doc(alias = "gtk_flow_box_set_vadjustment")]
     pub fn set_vadjustment(&self, adjustment: &impl IsA<Adjustment>) {
         unsafe {

--- a/gtk4/src/auto/list_box.rs
+++ b/gtk4/src/auto/list_box.rs
@@ -371,38 +371,6 @@ impl ListBox {
         }
     }
 
-    #[doc(alias = "gtk_list_box_set_sort_func")]
-    pub fn set_sort_func<P: Fn(&ListBoxRow, &ListBoxRow) -> i32 + 'static>(&self, sort_func: P) {
-        let sort_func_data: Box_<P> = Box_::new(sort_func);
-        unsafe extern "C" fn sort_func_func<P: Fn(&ListBoxRow, &ListBoxRow) -> i32 + 'static>(
-            row1: *mut ffi::GtkListBoxRow,
-            row2: *mut ffi::GtkListBoxRow,
-            user_data: glib::ffi::gpointer,
-        ) -> libc::c_int {
-            let row1 = from_glib_borrow(row1);
-            let row2 = from_glib_borrow(row2);
-            let callback: &P = &*(user_data as *mut _);
-            let res = (*callback)(&row1, &row2);
-            res
-        }
-        let sort_func = Some(sort_func_func::<P> as _);
-        unsafe extern "C" fn destroy_func<P: Fn(&ListBoxRow, &ListBoxRow) -> i32 + 'static>(
-            data: glib::ffi::gpointer,
-        ) {
-            let _callback: Box_<P> = Box_::from_raw(data as *mut _);
-        }
-        let destroy_call3 = Some(destroy_func::<P> as _);
-        let super_callback0: Box_<P> = sort_func_data;
-        unsafe {
-            ffi::gtk_list_box_set_sort_func(
-                self.to_glib_none().0,
-                sort_func,
-                Box_::into_raw(super_callback0) as *mut _,
-                destroy_call3,
-            );
-        }
-    }
-
     #[doc(alias = "gtk_list_box_unselect_all")]
     pub fn unselect_all(&self) {
         unsafe {

--- a/gtk4/src/flow_box.rs
+++ b/gtk4/src/flow_box.rs
@@ -1,7 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::FlowBox;
+use crate::{FlowBox, FlowBoxChild, Ordering};
 use glib::translate::*;
+use std::boxed::Box as Box_;
 use std::ptr;
 
 impl FlowBox {
@@ -32,6 +33,45 @@ impl FlowBox {
     pub fn unset_sort_func(&self) {
         unsafe {
             ffi::gtk_flow_box_set_sort_func(self.to_glib_none().0, None, ptr::null_mut(), None)
+        }
+    }
+
+    #[doc(alias = "gtk_flow_box_set_sort_func")]
+    pub fn set_sort_func<P: Fn(&FlowBoxChild, &FlowBoxChild) -> Ordering + 'static>(
+        &self,
+        sort_func: P,
+    ) {
+        let sort_func_data: Box_<P> = Box_::new(sort_func);
+        unsafe extern "C" fn sort_func_func<
+            P: Fn(&FlowBoxChild, &FlowBoxChild) -> Ordering + 'static,
+        >(
+            child1: *mut ffi::GtkFlowBoxChild,
+            child2: *mut ffi::GtkFlowBoxChild,
+            user_data: glib::ffi::gpointer,
+        ) -> libc::c_int {
+            let child1 = from_glib_borrow(child1);
+            let child2 = from_glib_borrow(child2);
+            let callback: &P = &*(user_data as *mut _);
+            let res = (*callback)(&child1, &child2);
+            res.into_glib()
+        }
+        let sort_func = Some(sort_func_func::<P> as _);
+        unsafe extern "C" fn destroy_func<
+            P: Fn(&FlowBoxChild, &FlowBoxChild) -> Ordering + 'static,
+        >(
+            data: glib::ffi::gpointer,
+        ) {
+            let _callback: Box_<P> = Box_::from_raw(data as *mut _);
+        }
+        let destroy_call3 = Some(destroy_func::<P> as _);
+        let super_callback0: Box_<P> = sort_func_data;
+        unsafe {
+            ffi::gtk_flow_box_set_sort_func(
+                self.to_glib_none().0,
+                sort_func,
+                Box_::into_raw(super_callback0) as *mut _,
+                destroy_call3,
+            );
         }
     }
 }

--- a/gtk4/src/list_box.rs
+++ b/gtk4/src/list_box.rs
@@ -1,7 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::ListBox;
+use crate::{ListBox, ListBoxRow, Ordering};
 use glib::translate::*;
+use std::boxed::Box as Box_;
 use std::ptr;
 
 impl ListBox {
@@ -32,6 +33,43 @@ impl ListBox {
     pub fn unset_header_func(&self) {
         unsafe {
             ffi::gtk_list_box_set_header_func(self.to_glib_none().0, None, ptr::null_mut(), None)
+        }
+    }
+
+    #[doc(alias = "gtk_list_box_set_sort_func")]
+    pub fn set_sort_func<P: Fn(&ListBoxRow, &ListBoxRow) -> Ordering + 'static>(
+        &self,
+        sort_func: P,
+    ) {
+        let sort_func_data: Box_<P> = Box_::new(sort_func);
+        unsafe extern "C" fn sort_func_func<
+            P: Fn(&ListBoxRow, &ListBoxRow) -> Ordering + 'static,
+        >(
+            row1: *mut ffi::GtkListBoxRow,
+            row2: *mut ffi::GtkListBoxRow,
+            user_data: glib::ffi::gpointer,
+        ) -> libc::c_int {
+            let row1 = from_glib_borrow(row1);
+            let row2 = from_glib_borrow(row2);
+            let callback: &P = &*(user_data as *mut _);
+            let res = (*callback)(&row1, &row2);
+            res.into_glib()
+        }
+        let sort_func = Some(sort_func_func::<P> as _);
+        unsafe extern "C" fn destroy_func<P: Fn(&ListBoxRow, &ListBoxRow) -> Ordering + 'static>(
+            data: glib::ffi::gpointer,
+        ) {
+            let _callback: Box_<P> = Box_::from_raw(data as *mut _);
+        }
+        let destroy_call3 = Some(destroy_func::<P> as _);
+        let super_callback0: Box_<P> = sort_func_data;
+        unsafe {
+            ffi::gtk_list_box_set_sort_func(
+                self.to_glib_none().0,
+                sort_func,
+                Box_::into_raw(super_callback0) as *mut _,
+                destroy_call3,
+            );
         }
     }
 

--- a/gtk4/src/tree_sortable.rs
+++ b/gtk4/src/tree_sortable.rs
@@ -1,8 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+use crate::Ordering;
 use glib::object::{Cast, IsA};
 use glib::translate::*;
-use std::cmp::Ordering;
 use std::fmt;
 use std::mem;
 


### PR DESCRIPTION
In rust, all the cmp functions returns a std::cmp::Ordering
which we can convert to a rust gtk::Ordering. The C functions though
can return a random int > 0, < 0 or 0. Instead of accepting a random int
here, request a gtk::Ordering which makes more sense for rust bindings.