### PR TITLE
gtk: ignore StringList::take

### DIFF
--- a/gtk4/Gir.toml
+++ b/gtk4/Gir.toml
@@ -210,7 +210,6 @@ generate = [
     "Gtk.StateFlags",
     "Gtk.Statusbar",
     "Gtk.StringFilterMatchMode",
-    "Gtk.StringList",
     "Gtk.StringObject",
     "Gtk.StyleContextPrintFlags",
     "Gtk.StyleProvider",
@@ -1956,6 +1955,13 @@ status = "generate"
     [[object.function]]
     name = "set_expression"
     manual = true # use AsRef<Expression>
+
+[[object]]
+name = "Gtk.StringList"
+status = "generate"
+    [[object.function]]
+    name = "take"
+    ignore = true # A C helper, bindings should use append instead
 
 [[object]]
 name = "Gtk.StringSorter"

--- a/gtk4/src/auto/string_list.rs
+++ b/gtk4/src/auto/string_list.rs
@@ -58,13 +58,6 @@ impl StringList {
             );
         }
     }
-
-    #[doc(alias = "gtk_string_list_take")]
-    pub fn take(&self, string: &str) {
-        unsafe {
-            ffi::gtk_string_list_take(self.to_glib_none().0, string.to_glib_full());
-        }
-    }
 }
 
 impl fmt::Display for StringList {


### PR DESCRIPTION
It's a C convenient function, not useful for rust bindings
Fixes #648