### PR TITLE
gsk: mark Transform::to_string as renamed

### DIFF
--- a/gsk4/Gir.toml
+++ b/gsk4/Gir.toml
@@ -153,3 +153,6 @@ status = "generate"
     [[object.function]]
     name = "print"
     ignore = true # Same as Transform::to_string
+    [[object.function]]
+    name = "to_string"
+    rename = "to_str"


### PR DESCRIPTION
Otherwise it's not properly documented