### PR TITLE
gsk: drop manual FromGlibContainerAsVec impl for ColorStop

### DIFF
--- a/gsk4/src/color_stop.rs
+++ b/gsk4/src/color_stop.rs
@@ -3,7 +3,6 @@
 use gdk::RGBA;
 use glib::translate::*;
 use std::fmt;
-use std::ptr;
 
 glib::wrapper! {
     #[doc(alias = "GskColorStop")]


### PR DESCRIPTION
Depends on https://github.com/gtk-rs/gtk-rs-core/pull/311