### PR TITLE
Nicer variants for getters that returns glib::Value

### DIFF
--- a/gdk4/src/content_deserializer.rs
+++ b/gdk4/src/content_deserializer.rs
@@ -2,6 +2,7 @@
 
 use crate::ContentDeserializer;
 use glib::translate::*;
+use glib::value::FromValue;
 
 impl ContentDeserializer {
     pub fn set_value(&self, value: glib::Value) {
@@ -22,6 +23,16 @@ impl ContentDeserializer {
                 self.to_glib_none().0,
             ))
         }
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Similar to [`Self::value`] but panics if the value is of a different type.
+    #[doc(alias = "gdk_content_deserializer_get_value")]
+    #[doc(alias = "get_value")]
+    pub fn value_as<V: for<'b> FromValue<'b> + 'static>(&self) -> V {
+        self.value()
+            .get_owned::<V>()
+            .expect("Failed to get the value")
     }
 
     #[doc(alias = "gdk_content_deserializer_return_error")]

--- a/gdk4/src/content_serializer.rs
+++ b/gdk4/src/content_serializer.rs
@@ -2,6 +2,7 @@
 
 use crate::ContentSerializer;
 use glib::translate::*;
+use glib::value::FromValue;
 
 impl ContentSerializer {
     #[doc(alias = "gdk_content_serializer_get_priority")]
@@ -12,6 +13,16 @@ impl ContentSerializer {
                 self.to_glib_none().0,
             ))
         }
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Similar to [`Self::value`] but panics if the value is of a different type.
+    #[doc(alias = "gdk_content_serializer_get_value")]
+    #[doc(alias = "get_value")]
+    pub fn value_as<V: for<'b> FromValue<'b> + 'static>(&self) -> V {
+        self.value()
+            .get_owned::<V>()
+            .expect("Failed to get the value")
     }
 
     #[doc(alias = "gdk_content_serializer_return_error")]

--- a/gtk4/src/constant_expression.rs
+++ b/gtk4/src/constant_expression.rs
@@ -1,7 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use glib::translate::*;
-use glib::{ToValue, Value};
+use glib::{value::FromValue, ToValue, Value};
 
 glib::wrapper! {
     #[derive(Debug)]
@@ -52,6 +52,17 @@ impl ConstantExpression {
             ))
         }
     }
+
+    // rustdoc-stripper-ignore-next
+    /// Similar to [`Self::value`] but panics if the value is of a different type.
+    #[doc(alias = "gtk_constant_expression_get_value")]
+    #[doc(alias = "get_value")]
+    pub fn value_as<V: for<'b> FromValue<'b> + 'static>(&self) -> V {
+        let value = self.value();
+        value
+            .get_owned::<V>()
+            .expect("Failed to get ConstantExpression value")
+    }
 }
 
 #[cfg(test)]
@@ -68,8 +79,10 @@ mod tests {
             assert_eq!(expr2.value().get::<String>().unwrap(), "hello");
             let expr1 = ConstantExpression::new(&23);
             assert_eq!(expr1.value().get::<i32>().unwrap(), 23);
+            assert_eq!(expr1.value_as::<i32>(), 23);
             let expr2 = ConstantExpression::for_value(&"hello".to_value());
             assert_eq!(expr2.value().get::<String>().unwrap(), "hello");
+            assert_eq!(expr2.value_as::<String>(), "hello");
         });
     }
 }

--- a/gtk4/src/drop_target.rs
+++ b/gtk4/src/drop_target.rs
@@ -3,7 +3,7 @@
 use crate::DropTarget;
 use glib::signal::connect_raw;
 use glib::Type;
-use glib::{translate::*, ObjectType, SignalHandlerId};
+use glib::{translate::*, value::FromValue, ObjectType, SignalHandlerId};
 use std::boxed::Box as Box_;
 use std::mem::transmute;
 
@@ -18,6 +18,17 @@ impl DropTarget {
                 types.len(),
             )
         }
+    }
+
+    #[doc(alias = "gtk_drop_target_get_value")]
+    #[doc(alias = "get_value")]
+    // rustdoc-stripper-ignore-next
+    /// Similar to [`Self::value`] but panics if the value is of a different type.
+    pub fn value_as<V: for<'b> FromValue<'b> + 'static>(&self) -> Option<V> {
+        self.value().map(|v| {
+            v.get_owned::<V>()
+                .expect("Failed to get value as this type")
+        })
     }
 
     #[doc(alias = "gtk_drop_target_get_gtypes")]

--- a/gtk4/src/expression.rs
+++ b/gtk4/src/expression.rs
@@ -2,7 +2,7 @@
 
 use crate::ExpressionWatch;
 use glib::translate::*;
-use glib::{IsA, Object, StaticType, Type, Value};
+use glib::{value::FromValue, IsA, Object, StaticType, Type, Value};
 use std::boxed::Box as Box_;
 
 glib::wrapper! {
@@ -119,6 +119,19 @@ impl Expression {
                 None
             }
         }
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Similar to [`Self::evaluate`] but panics if the value is of a different type.
+    #[doc(alias = "gtk_expression_evaluate")]
+    pub fn evaluate_as<V: for<'b> FromValue<'b> + 'static, T: IsA<Object>>(
+        &self,
+        this: Option<&T>,
+    ) -> Option<V> {
+        self.evaluate(this).map(|v| {
+            v.get_owned::<V>()
+                .expect("Failed to evaluate to this value type")
+        })
     }
 
     #[doc(alias = "gtk_expression_watch")]

--- a/gtk4/src/expression_watch.rs
+++ b/gtk4/src/expression_watch.rs
@@ -1,6 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use glib::translate::*;
+use glib::value::FromValue;
 use glib::Value;
 
 glib::wrapper! {
@@ -30,6 +31,16 @@ impl ExpressionWatch {
                 None
             }
         }
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Similar to [`Self::evaluate`] but panics if the value is of a different type.
+    #[doc(alias = "gtk_expression_evaluate")]
+    pub fn evaluate_as<V: for<'b> FromValue<'b> + 'static>(&self) -> Option<V> {
+        self.evaluate().map(|v| {
+            v.get_owned::<V>()
+                .expect("Failed to evaluate to this value type")
+        })
     }
 
     #[doc(alias = "gtk_expression_watch_unwatch")]


### PR DESCRIPTION
Some functions that had a `value` getter, got a `value_as` variant to cast it to a different type. Not sure how that sounds :)