### PR TITLE
Add composite template callback macro

### DIFF
--- a/examples/composite_template/ex_application_window/ex_application_window.ui
+++ b/examples/composite_template/ex_application_window/ex_application_window.ui
@@ -17,27 +17,125 @@
     <child>
       <object class="GtkBox">
         <property name="orientation">vertical</property>
-        <property name="valign">center</property>
-        <property name="spacing">6</property>
-        <property name="margin-start">12</property>
-        <property name="margin-end">12</property>
-        <property name="margin-top">12</property>
-        <property name="margin-bottom">12</property>
         <child>
-          <object class="GtkLabel" id="label">
-            <property name="label">Composite Template</property>
-            <style>
-              <class name="large-title"/>
-            </style>
+          <object class="GtkBox">
+            <property name="orientation">vertical</property>
+            <property name="valign">center</property>
+            <property name="vexpand">1</property>
+            <property name="spacing">6</property>
+            <property name="margin-start">12</property>
+            <property name="margin-end">12</property>
+            <property name="margin-top">12</property>
+            <property name="margin-bottom">12</property>
+            <child>
+              <object class="GtkLabel" id="label">
+                <property name="label">Composite Template</property>
+                <style>
+                  <class name="large-title"/>
+                </style>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="subtitle_label">
+                <property name="wrap">True</property>
+                <property name="justify">center</property>
+                <style>
+                  <class name="dim-label"/>
+                </style>
+              </object>
+            </child>
           </object>
         </child>
         <child>
-          <object class="GtkLabel" id="subtitle_label">
-            <property name="wrap">True</property>
-            <property name="justify">center</property>
-            <style>
-              <class name="dim-label"/>
-            </style>
+          <object class="GtkGrid">
+            <property name="halign">center</property>
+            <property name="vexpand">1</property>
+            <property name="column-spacing">6</property>
+            <property name="row-spacing">6</property>
+            <child>
+              <object class="GtkEntry" id="entry_a">
+                <property name="text">Hello</property>
+                <property name="placeholder-text">First</property>
+                <layout>
+                  <property name="column">0</property>
+                  <property name="row">0</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkEntry" id="entry_b">
+                <property name="text">World</property>
+                <property name="placeholder-text">Second</property>
+                <layout>
+                  <property name="column">1</property>
+                  <property name="row">0</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="halign">start</property>
+                <binding name="label">
+                  <closure type="gchararray" function="concat_strs">
+                    <constant type="gchararray">Result: </constant>
+                    <lookup type="GtkEntry" name="text">entry_a</lookup>
+                    <constant type="gchararray">, </constant>
+                    <lookup type="GtkEntry" name="text">entry_b</lookup>
+                  </closure>
+                </binding>
+                <layout>
+                  <property name="column">0</property>
+                  <property name="row">1</property>
+                  <property name="column-span">2</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="halign">start</property>
+                <binding name="label">
+                  <closure type="gchararray" function="concat_strs">
+                    <constant type="gchararray">Lengths: </constant>
+                    <closure type="gchararray" function="to_string">
+                      <closure type="guint64" function="strlen">
+                        <lookup type="GtkEntry" name="text">entry_a</lookup>
+                      </closure>
+                    </closure>
+                    <constant type="gchararray">, </constant>
+                    <closure type="gchararray" function="to_string">
+                      <closure type="guint64" function="strlen">
+                        <lookup type="GtkEntry" name="text">entry_b</lookup>
+                      </closure>
+                    </closure>
+                  </closure>
+                </binding>
+                <layout>
+                  <property name="column">0</property>
+                  <property name="row">2</property>
+                  <property name="column-span">2</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkButton">
+                <property name="label">Reset First</property>
+                <signal name="clicked" handler="reset_entry" object="entry_a" swapped="true"/>
+                <layout>
+                  <property name="column">0</property>
+                  <property name="row">3</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkButton">
+                <property name="label">Reset Second</property>
+                <signal name="clicked" handler="reset_entry" object="entry_b" swapped="true"/>
+                <layout>
+                  <property name="column">1</property>
+                  <property name="row">3</property>
+                </layout>
+              </object>
+            </child>
           </object>
         </child>
       </object>

--- a/examples/composite_template/ex_application_window/imp.rs
+++ b/examples/composite_template/ex_application_window/imp.rs
@@ -33,11 +33,46 @@ impl ObjectSubclass for ExApplicationWindow {
     // bind_template() to set the template and bind all children at once.
     fn class_init(klass: &mut Self::Class) {
         Self::bind_template(klass);
+        UtilityCallbacks::bind_template_callbacks(klass);
     }
 
     // You must call `Widget`'s `init_template()` within `instance_init()`.
     fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
         obj.init_template();
+    }
+}
+
+struct UtilityCallbacks {}
+
+#[gtk::template_callbacks(functions)]
+impl UtilityCallbacks {
+    #[template_callback]
+    fn to_string(value: &glib::Value) -> String {
+        if let Ok(value) = value.get::<u64>() {
+            value.to_string()
+        } else if let Ok(value) = value.get::<&str>() {
+            value.to_owned()
+        } else {
+            "".into()
+        }
+    }
+    #[template_callback]
+    fn strlen(s: &str) -> u64 {
+        s.len() as u64
+    }
+    #[template_callback(name = "concat_strs")]
+    fn concat(#[rest] values: &[glib::Value]) -> String {
+        let mut res = String::new();
+        for (index, value) in values.iter().enumerate() {
+            res.push_str(value.get::<&str>().unwrap_or_else(|e| {
+                panic!("Expected string value for argument {}: {}", index, e);
+            }));
+        }
+        res
+    }
+    #[template_callback(function = false, name = "reset_entry")]
+    fn reset(entry: &gtk::Entry) {
+        entry.set_text("Nothing");
     }
 }
 

--- a/examples/composite_template/ex_menu_button/ex_menu_button.ui
+++ b/examples/composite_template/ex_menu_button/ex_menu_button.ui
@@ -6,6 +6,7 @@
     </property>
     <child>
       <object class="GtkToggleButton" id="toggle">
+        <signal name="toggled" handler="toggle_toggled" swapped="true"/>
         <property name="child">
           <object class="GtkBox">
             <property name="spacing">6</property>
@@ -28,6 +29,7 @@
     </child>
     <child>
       <object class="GtkPopover" id="popover">
+        <signal name="closed" handler="popover_closed" swapped="true"/>
         <property name="child">
           <object class="GtkLabel">
             <property name="label">Hello from a custom child widget!</property>

--- a/examples/composite_template/ex_menu_button/imp.rs
+++ b/examples/composite_template/ex_menu_button/imp.rs
@@ -19,6 +19,7 @@ impl ObjectSubclass for ExMenuButton {
 
     fn class_init(klass: &mut Self::Class) {
         Self::bind_template(klass);
+        Self::bind_template_callbacks(klass);
     }
 
     fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
@@ -26,25 +27,21 @@ impl ObjectSubclass for ExMenuButton {
     }
 }
 
-impl ObjectImpl for ExMenuButton {
-    fn constructed(&self, obj: &Self::Type) {
-        self.parent_constructed(obj);
-
-        let popover = &*self.popover;
-        self.toggle
-            .connect_toggled(glib::clone!(@weak popover => move |toggle| {
-                if toggle.is_active() {
-                    popover.popup();
-                }
-            }));
-
-        let toggle = &*self.toggle;
-        self.popover
-            .connect_closed(glib::clone!(@weak toggle => move |_| {
-                toggle.set_active(false);
-            }));
+#[gtk::template_callbacks]
+impl ExMenuButton {
+    #[template_callback]
+    fn toggle_toggled(&self, toggle: &gtk::ToggleButton) {
+        if toggle.is_active() {
+            self.popover.popup();
+        }
     }
+    #[template_callback(name = "popover_closed")]
+    fn unset_toggle(&self) {
+        self.toggle.set_active(false);
+    }
+}
 
+impl ObjectImpl for ExMenuButton {
     // Needed for direct subclasses of GtkWidget;
     // Here you need to unparent all direct children
     // of your template.

--- a/gtk4-macros/src/lib.rs
+++ b/gtk4-macros/src/lib.rs
@@ -6,6 +6,7 @@
 
 mod attribute_parser;
 mod composite_template_derive;
+mod template_callbacks_attribute;
 mod util;
 
 use proc_macro::TokenStream;
@@ -17,22 +18,30 @@ use syn::{parse_macro_input, DeriveInput};
 /// The `template` attribute specifies where the template should be loaded
 /// from;  it can be a `file`, a `resource`, or a `string`.
 ///
+/// The `callbacks` attribute specifies this template has bound callbacks.
+/// See [`macro@template_callbacks`] for a description of how to use them.
+///
 /// The `template_child` attribute is used to mark all internal widgets
 /// we need to have programmatic access to.
 ///
 /// The `template_child` attribute can take two parameters:
-///     - `id` which defaults to the item name if not defined
-///     - `internal_child` whether the child should be accessible as an “internal-child”, defaults to `false`
+/// - `id` which defaults to the item name if not defined
+/// - `internal_child` whether the child should be accessible as an “internal-child”, defaults to `false`
 ///
 /// # Example
 ///
 /// Specify that `MyWidget` is using a composite template and load the
 /// template file the `composite_template.ui` file.
 ///
-/// Then, in the `ObjectSubclass` implementation you will need to call
-/// `bind_template` in the `class_init` function, and `init_template` in
-/// `instance_init` function.
+/// Then, in the [`ObjectSubclass`] implementation you will need to call
+/// [`bind_template`] in the [`class_init`] function, and [`init_template`] in
+/// [`instance_init`] function.
 ///
+/// [`ObjectSubclass`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/subclass/types/trait.ObjectSubclass.html
+/// [`bind_template`]: https://gtk-rs.org/gtk4-rs/stable/latest/docs/gtk4/subclass/widget/trait.CompositeTemplate.html#tymethod.bind_template
+/// [`class_init`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/subclass/types/trait.ObjectSubclass.html#method.class_init
+/// [`init_template`]: https://gtk-rs.org/gtk4-rs/stable/latest/docs/gtk4/prelude/trait.InitializingWidgetExt.html#tymethod.init_template
+/// [`instance_init`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/subclass/types/trait.ObjectSubclass.html#method.instance_init
 ///
 /// ```no_run
 /// # fn main() {}
@@ -89,4 +98,166 @@ pub fn composite_template_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let gen = composite_template_derive::impl_composite_template(&input);
     gen.into()
+}
+
+/// Attribute macro for creating template callbacks from Rust methods.
+///
+/// Widgets with [`CompositeTemplate`] can then make use of these callbacks from within their
+/// template XML definition. The attribute must be applied to an `impl` statement of a struct.
+/// Functions marked as callbacks within the `impl` will be stored in a static array. Then, in the
+/// [`ObjectSubclass`] implementation you will need to call [`bind_template_callbacks`] in the
+/// [`class_init`] function.
+///
+/// Template callbacks can be specified on both a widget's public `impl` or on its private `impl`.
+/// Template callbacks from other types can also be used. Care must be taken to call
+/// `bind_template_callbacks` on each type in order to use its callbacks.
+///
+/// These callbacks can be bound using the `<signal>` or `<closure>` tags in the template file.
+/// Note that the arguments and return type will only be checked at run time when the method is
+/// invoked.
+///
+/// Methods can optionally take `&self` as a first parameter. In this case, the attribute
+/// `swapped="true"` will usually have to be set on the `<signal>` or `<closure>` tag in order to
+/// invoke the function correctly.
+///
+/// The following options are supported on the attribute:
+/// - `functions` makes all callbacks use the `function` attribute by default. (see below)
+///
+/// The `template_callback` attribute is used to mark methods that will be exposed to the template
+/// scope. It can take the following options:
+/// - `name` renames the callback. Defaults to the function name if not defined.
+/// - `function` ignores the first value when calling the callback and disallows `self`.  Useful
+/// for callbacks called from `<closure>` tags.
+/// - `function = false` reverts the effects of `functions` used on the `impl`, so the callback
+/// gets the first value and can take `self` again. Mainly useful for callbacks that are invoked
+/// with `swapped="true"`.
+///
+/// The `rest` attribute can be placed on the last argument of a template callback. This attribute
+/// must be used on an argument of type `&[glib::Value]` and will pass in the remaining arguments.
+/// The first and last values will be omitted from the slice if this callback is a `function`.
+///
+/// Arguments and return types in template callbacks have some special restrictions, similar to the
+/// restrictions on [`glib::closure`]. Each argument's type must implement [`glib::ToValue`]. The
+/// last argument can also be `&[glib::Value]` annotated with `#[rest]` as described above. The
+/// return type of a callback, if present, must implement [`glib::FromValue`]. Type-checking of
+/// inputs and outputs is done at run-time; if the argument types or return type do not match the
+/// type of the signal or closure then the callback will panic. To implement your own type checking
+/// or to use dynamic typing, an argument's type can be left as a [`&glib::Value`].
+/// This can also be used if you need custom unboxing, such as if the target type does not
+/// implement `FromValue`.
+///
+/// [`glib::closure`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/macro.closure.html
+/// [`glib::wrapper`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/macro.wrapper.html
+/// [`ObjectSubclass`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/subclass/types/trait.ObjectSubclass.html
+/// [`class_init`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/subclass/types/trait.ObjectSubclass.html#method.class_init
+/// [`bind_template_callbacks`]: https://gtk-rs.org/gtk4-rs/stable/latest/docs/gtk4/subclass/widget/trait.CompositeTemplateCallbacks.html#tymethod.bind_template_callbacks
+/// [`glib::FromValue`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/value/trait.FromValue.html
+/// [`glib::ToValue`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/value/trait.ToValue.html
+/// [`&glib::Value`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/value/struct.Value.html
+///
+/// # Example
+///
+/// ```no_run
+/// # fn main() {}
+/// use gtk::prelude::*;
+/// use gtk::glib;
+/// use gtk::CompositeTemplate;
+/// use gtk::subclass::prelude::*;
+///
+/// mod imp {
+///     use super::*;
+///
+///     #[derive(Debug, Default, CompositeTemplate)]
+///     #[template(file = "test/template_callbacks.ui")]
+///     pub struct MyWidget {
+///         #[template_child]
+///         pub label: TemplateChild<gtk::Label>,
+///         #[template_child(id = "my_button_id")]
+///         pub button: TemplateChild<gtk::Button>,
+///     }
+///
+///     #[glib::object_subclass]
+///     impl ObjectSubclass for MyWidget {
+///         const NAME: &'static str = "MyWidget";
+///         type Type = super::MyWidget;
+///         type ParentType = gtk::Box;
+///
+///         fn class_init(klass: &mut Self::Class) {
+///             Self::bind_template(klass);
+///             // Bind the private callbacks
+///             Self::bind_template_callbacks(klass);
+///             // Bind the public callbacks
+///             Self::Type::bind_template_callbacks(klass);
+///             // Bind callbacks from another struct
+///             super::Utility::bind_template_callbacks(klass);
+///         }
+///
+///         fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
+///             obj.init_template();
+///         }
+///     }
+///
+///     #[gtk::template_callbacks]
+///     impl MyWidget {
+///         #[template_callback]
+///         fn button_clicked(&self, button: &gtk::Button) {
+///             button.set_label("I was clicked!");
+///             self.label.set_label("The button was clicked!");
+///         }
+///         #[template_callback(function, name = "strlen")]
+///         fn string_length(s: &str) -> u64 {
+///             s.len() as u64
+///         }
+///     }
+///
+///     impl ObjectImpl for MyWidget {}
+///     impl WidgetImpl for MyWidget {}
+///     impl BoxImpl for MyWidget {}
+/// }
+///
+/// glib::wrapper! {
+///     pub struct MyWidget(ObjectSubclass<imp::MyWidget>) @extends gtk::Widget, gtk::Box;
+/// }
+///
+/// #[gtk::template_callbacks]
+/// impl MyWidget {
+///     pub fn new() -> Self {
+///         glib::Object::new(&[]).expect("Failed to create an instance of MyWidget")
+///     }
+///     #[template_callback]
+///     pub fn print_both_labels(&self) {
+///         let self_ = imp::MyWidget::from_instance(self);
+///         println!("{} {}", self_.label.label(), self_.button.label().unwrap().as_str());
+///     }
+/// }
+///
+/// pub struct Utility {}
+///
+/// #[gtk::template_callbacks(functions)]
+/// impl Utility {
+///     #[template_callback]
+///     fn concat_strs(#[rest] values: &[glib::Value]) -> String {
+///         let mut res = String::new();
+///         for (index, value) in values.iter().enumerate() {
+///             res.push_str(value.get::<&str>().unwrap_or_else(|e| {
+///                 panic!("Expected string value for argument {}: {}", index, e);
+///             }));
+///         }
+///         res
+///     }
+///     #[template_callback(function = false)]
+///     fn reset_label(label: &gtk::Label) {
+///         label.set_label("");
+///     }
+/// }
+/// ```
+#[proc_macro_attribute]
+#[proc_macro_error]
+pub fn template_callbacks(attr: TokenStream, item: TokenStream) -> TokenStream {
+    use proc_macro_error::abort_call_site;
+    let args = parse_macro_input!(attr as template_callbacks_attribute::Args);
+    match syn::parse::<syn::ItemImpl>(item) {
+        Ok(input) => template_callbacks_attribute::impl_template_callbacks(input, args).into(),
+        Err(_) => abort_call_site!(template_callbacks_attribute::WRONG_PLACE_MSG),
+    }
 }

--- a/gtk4-macros/src/template_callbacks_attribute.rs
+++ b/gtk4-macros/src/template_callbacks_attribute.rs
@@ -1,0 +1,262 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::util::*;
+use proc_macro2::{Ident, Span, TokenStream};
+use proc_macro_error::{abort, abort_call_site};
+use quote::{quote, ToTokens, TokenStreamExt};
+use syn::{parse::Parse, Token};
+
+pub const WRONG_PLACE_MSG: &str =
+    "This macro should be used on the `impl` block for a CompositeTemplate widget";
+
+mod keywords {
+    syn::custom_keyword!(functions);
+    syn::custom_keyword!(function);
+    syn::custom_keyword!(name);
+}
+
+pub struct Args {
+    functions: bool,
+}
+
+impl Parse for Args {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let mut args = Self { functions: false };
+        while !input.is_empty() {
+            let lookahead = input.lookahead1();
+            if lookahead.peek(keywords::functions) {
+                input.parse::<keywords::functions>()?;
+                args.functions = true;
+            } else {
+                return Err(lookahead.error());
+            }
+            if !input.is_empty() {
+                input.parse::<Token![,]>()?;
+            }
+        }
+        Ok(args)
+    }
+}
+
+pub struct CallbackArgs {
+    name: Option<String>,
+    function: Option<bool>,
+}
+
+impl CallbackArgs {
+    fn is_function(&self, args: &Args) -> bool {
+        self.function.unwrap_or(args.functions)
+    }
+    fn start(&self, args: &Args) -> usize {
+        match self.is_function(args) {
+            true => 1,
+            false => 0,
+        }
+    }
+}
+
+impl Parse for CallbackArgs {
+    fn parse(stream: syn::parse::ParseStream) -> syn::Result<Self> {
+        let mut args = Self {
+            name: None,
+            function: None,
+        };
+        if stream.is_empty() {
+            return Ok(args);
+        }
+        let input;
+        syn::parenthesized!(input in stream);
+        while !input.is_empty() {
+            let lookahead = input.lookahead1();
+            if lookahead.peek(keywords::name) {
+                let kw = input.parse::<keywords::name>()?;
+                if args.name.is_some() {
+                    return Err(syn::Error::new_spanned(kw, "Duplicate `name` attribute"));
+                }
+                input.parse::<Token![=]>()?;
+                let name = input.parse::<syn::LitStr>()?;
+                args.name.replace(name.value());
+            } else if lookahead.peek(keywords::function) {
+                let kw = input.parse::<keywords::function>()?;
+                if args.function.is_some() {
+                    return Err(syn::Error::new_spanned(
+                        kw,
+                        "Only one of `function` is allowed",
+                    ));
+                }
+                let function = if input.peek(Token![=]) {
+                    input.parse::<Token![=]>()?;
+                    input.parse::<syn::LitBool>()?.value
+                } else {
+                    true
+                };
+                args.function.replace(function);
+            } else {
+                return Err(lookahead.error());
+            }
+            if !input.is_empty() {
+                input.parse::<Token![,]>()?;
+            }
+        }
+        Ok(args)
+    }
+}
+
+pub fn impl_template_callbacks(mut input: syn::ItemImpl, args: Args) -> TokenStream {
+    let syn::ItemImpl {
+        attrs,
+        generics,
+        trait_,
+        self_ty,
+        items,
+        ..
+    } = &mut input;
+    if trait_.is_some() {
+        abort_call_site!(WRONG_PLACE_MSG);
+    }
+    let crate_ident = crate_ident_new();
+
+    let mut callbacks = vec![];
+    for item in items.iter_mut() {
+        if let syn::ImplItem::Method(method) = item {
+            let mut i = 0;
+            let mut attr = None;
+            while i < method.attrs.len() {
+                if method.attrs[i].path.is_ident("template_callback") {
+                    if attr.is_some() {
+                        abort!(method.attrs[i], "Duplicate `template_callback` attribute");
+                    }
+                    attr.replace(method.attrs.remove(i));
+                } else {
+                    i += 1;
+                }
+            }
+
+            let attr = match attr {
+                Some(attr) => attr,
+                None => continue,
+            };
+
+            let ident = &method.sig.ident;
+            let callback_args =
+                syn::parse2::<CallbackArgs>(attr.tokens).unwrap_or_else(|e| abort!(e));
+            let name = callback_args
+                .name
+                .as_ref()
+                .cloned()
+                .unwrap_or_else(|| ident.to_string());
+            let start = callback_args.start(&args);
+
+            let call_site = Span::call_site();
+            let mut arg_names = vec![];
+            let mut has_rest = false;
+            let value_unpacks = method.sig.inputs.iter_mut().enumerate().map(|(index, arg)| {
+                if has_rest {
+                    abort!(arg, "Arguments past argument with `rest` attribute");
+                }
+                let index = index + start;
+                let name = Ident::new(&format!("value{}", index), call_site);
+                arg_names.push(name.clone());
+                let unwrap_value = |ty, err_msg| {
+                    let index_err_msg = format!(
+                        "Failed to get argument `{}` at index {}: Closure invoked with only {{}} arguments",
+                        ident,
+                        index
+                    );
+                    quote! {
+                        let #name = <[#crate_ident::glib::Value]>::get(&values, #index)
+                            .unwrap_or_else(|| panic!(#index_err_msg, values.len()));
+                        let #name = #crate_ident::glib::Value::get::<#ty>(#name)
+                            .unwrap_or_else(|e| panic!(#err_msg, e));
+                    }
+                };
+                match arg {
+                    syn::FnArg::Receiver(receiver) => {
+                        if receiver.reference.is_none() || receiver.mutability.is_some() {
+                            abort!(receiver, "Receiver must be &self");
+                        }
+                        let err_msg = format!(
+                            "Wrong type for `self` in template callback `{}`: {{:?}}",
+                            ident
+                        );
+                        let self_value_ty = quote! {
+                            &<#self_ty as #crate_ident::glib::subclass::types::FromObject>::FromObjectType
+                        };
+                        let mut unwrap = unwrap_value(self_value_ty, err_msg);
+                        unwrap.append_all(quote! {
+                            let #name = <#self_ty as #crate_ident::glib::subclass::types::FromObject>::from_object(#name);
+                        });
+                        unwrap
+                    },
+                    syn::FnArg::Typed(typed) => {
+                        let mut i = 0;
+                        while i < typed.attrs.len() {
+                            if typed.attrs[i].path.is_ident("rest") {
+                                let rest = typed.attrs.remove(i);
+                                if has_rest {
+                                    abort!(rest, "Duplicate `rest` attribute");
+                                }
+                                if !rest.tokens.is_empty() {
+                                    abort!(rest, "Tokens after `rest` attribute");
+                                }
+                                has_rest = true;
+                            } else {
+                                i += 1;
+                            }
+                        }
+                        if has_rest {
+                            let end = if callback_args.is_function(&args) {
+                                quote! { (values.len() - #start) }
+                            } else {
+                                quote! { values.len() }
+                            };
+                            quote! {
+                                let #name = &values[#index..#end];
+                            }
+                        } else {
+                            let ty = typed.ty.as_ref();
+                            let err_msg = format!(
+                                "Wrong type for argument {} in template callback `{}`: {{:?}}",
+                                index,
+                                ident
+                            );
+                            unwrap_value(ty.to_token_stream(), err_msg)
+                        }
+                    }
+                }
+            }).collect::<Vec<_>>();
+
+            let call = quote! { #self_ty::#ident(#(#arg_names),*) };
+            let call = match method.sig.output {
+                syn::ReturnType::Default => quote! {
+                    #call;
+                    None
+                },
+                syn::ReturnType::Type(_, _) => quote! {
+                    let ret = #call;
+                    Some(#crate_ident::glib::value::ToValue::to_value(&ret))
+                },
+            };
+
+            callbacks.push(quote! {
+                (#name, |values| {
+                    #(#value_unpacks)*
+                    #call
+                })
+            });
+        }
+    }
+
+    quote! {
+        #(#attrs)*
+        impl #generics #self_ty {
+            #(#items)*
+        }
+
+        impl #crate_ident::subclass::widget::CompositeTemplateCallbacks for #self_ty {
+            const CALLBACKS: &'static [#crate_ident::subclass::widget::TemplateCallback] = &[
+                #(#callbacks),*
+            ];
+        }
+    }
+}

--- a/gtk4-macros/src/test/template_callbacks.ui
+++ b/gtk4-macros/src/test/template_callbacks.ui
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="MyWidget" parent="GtkBox">
+    <child>
+      <object class="GtkLabel" id="label">
+        <property name="label">Some label</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkButton" id="my_button">
+        <signal name="clicked" handler="button_clicked" swapped="true"/>
+        <property name="label">Some button</property>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/gtk4/Cargo.toml
+++ b/gtk4/Cargo.toml
@@ -43,4 +43,5 @@ once_cell = "1.0"
 pango = {git = "https://github.com/gtk-rs/gtk-rs-core", version = "0.15", features = ["v1_46"]}
 
 [dev-dependencies]
+futures-executor = "0.3"
 gir-format-check = "^0.1"

--- a/gtk4/Gir.toml
+++ b/gtk4/Gir.toml
@@ -640,6 +640,9 @@ generate_builder = false
     name = "get_object"
     manual = true # add dynamic casting
     [[object.function]]
+    name = "get_current_object"
+    manual = true # don't ref_sink the object
+    [[object.function]]
     name = "value_from_string"
     manual = true # ParamSpec is a fundemental type
 

--- a/gtk4/src/auto/builder.rs
+++ b/gtk4/src/auto/builder.rs
@@ -225,12 +225,6 @@ impl Builder {
         }
     }
 
-    #[doc(alias = "gtk_builder_get_current_object")]
-    #[doc(alias = "get_current_object")]
-    pub fn current_object(&self) -> Option<glib::Object> {
-        unsafe { from_glib_none(ffi::gtk_builder_get_current_object(self.to_glib_none().0)) }
-    }
-
     #[doc(alias = "gtk_builder_get_objects")]
     #[doc(alias = "get_objects")]
     pub fn objects(&self) -> Vec<glib::Object> {

--- a/gtk4/src/builder.rs
+++ b/gtk4/src/builder.rs
@@ -18,6 +18,20 @@ impl Builder {
         }
     }
 
+    #[doc(alias = "gtk_builder_get_current_object")]
+    #[doc(alias = "get_current_object")]
+    pub fn current_object(&self) -> Option<glib::Object> {
+        unsafe {
+            let ptr = ffi::gtk_builder_get_current_object(self.to_glib_none().0);
+            if ptr.is_null() {
+                None
+            } else {
+                glib::gobject_ffi::g_object_ref(ptr as *mut glib::gobject_ffi::GObject);
+                Some(from_glib_full(ptr))
+            }
+        }
+    }
+
     #[doc(alias = "gtk_builder_get_object")]
     #[doc(alias = "get_object")]
     pub fn object<T: IsA<Object>>(&self, name: &str) -> Option<T> {

--- a/gtk4/src/builder_rust_scope.rs
+++ b/gtk4/src/builder_rust_scope.rs
@@ -1,0 +1,171 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::subclass::prelude::*;
+use crate::BuilderScope;
+use std::rc::Rc;
+
+glib::wrapper! {
+    // rustdoc-stripper-ignore-next
+    /// An implementation of [`BuilderScope`](crate::BuilderScope) that can bind Rust callbacks.
+    ///
+    /// ```no_run
+    /// # use gtk4 as gtk;
+    /// use gtk::prelude::*;
+    /// use gtk::subclass::prelude::*;
+    ///
+    /// # fn main() {
+    /// let builder = gtk::Builder::new();
+    /// let scope = gtk::BuilderRustScope::new();
+    /// scope.add_callback("print_label", |values| {
+    ///     let button = values[1].get::<gtk::Button>().unwrap();
+    ///     println!("{}", button.label().unwrap().as_str());
+    ///     None
+    /// });
+    /// builder.set_scope(Some(&scope));
+    /// # }
+    /// ```
+    pub struct BuilderRustScope(ObjectSubclass<imp::BuilderRustScope>)
+        @implements BuilderScope;
+}
+
+impl Default for BuilderRustScope {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BuilderRustScope {
+    pub fn new() -> Self {
+        glib::Object::new(&[]).unwrap()
+    }
+    // rustdoc-stripper-ignore-next
+    /// Adds a Rust callback to the scope with the given `name`. The callback can then be accessed
+    /// from a [`Builder`](crate::Builder) by referring to it in the builder XML, or by using
+    /// [`Builder::create_closure`](crate::Builder::create_closure).
+    pub fn add_callback<N: Into<String>, F: Fn(&[glib::Value]) -> Option<glib::Value> + 'static>(
+        &self,
+        name: N,
+        callback: F,
+    ) {
+        imp::BuilderRustScope::from_instance(self)
+            .callbacks
+            .borrow_mut()
+            .insert(name.into(), Rc::new(callback));
+    }
+}
+
+mod imp {
+    use crate::prelude::*;
+    use crate::subclass::prelude::*;
+    use crate::{Builder, BuilderClosureFlags, BuilderError, BuilderScope};
+    use glib::translate::*;
+    use glib::{Closure, RustClosure};
+    use std::{cell::RefCell, collections::HashMap, rc::Rc};
+
+    type Callback = dyn Fn(&[glib::Value]) -> Option<glib::Value>;
+
+    #[derive(Default)]
+    pub struct BuilderRustScope {
+        pub callbacks: RefCell<HashMap<String, Rc<Callback>>>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for BuilderRustScope {
+        const NAME: &'static str = "GtkBuilderRustScope";
+        type Type = super::BuilderRustScope;
+        type Interfaces = (BuilderScope,);
+    }
+
+    impl ObjectImpl for BuilderRustScope {}
+
+    impl BuilderScopeImpl for BuilderRustScope {
+        fn create_closure(
+            &self,
+            _builder_scope: &Self::Type,
+            builder: &Builder,
+            function_name: &str,
+            flags: BuilderClosureFlags,
+            object: Option<&glib::Object>,
+        ) -> Result<Closure, glib::Error> {
+            self.callbacks
+                .borrow()
+                .get(function_name)
+                .ok_or_else(|| {
+                    glib::Error::new(
+                        BuilderError::InvalidFunction,
+                        &format!("No function named `{}`", function_name),
+                    )
+                })
+                .map(|callback| {
+                    let callback = callback.clone();
+                    let swapped = flags.contains(BuilderClosureFlags::SWAPPED);
+                    let object = object.cloned().or_else(|| builder.current_object());
+                    if let Some(object) = object {
+                        let object_weak = object.downgrade();
+                        let closure = if swapped {
+                            RustClosure::new_local(move |args| {
+                                let mut args = args.to_owned();
+                                let object = object_weak.upgrade().expect(
+                                    "Internal error: Object destroyed before closure invalidated",
+                                );
+                                let obj_v = unsafe {
+                                    let mut v = glib::Value::uninitialized();
+                                    glib::gobject_ffi::g_value_init(
+                                        v.to_glib_none_mut().0,
+                                        object.type_().into_glib(),
+                                    );
+                                    glib::gobject_ffi::g_value_set_object(
+                                        v.to_glib_none_mut().0,
+                                        object.as_object_ref().to_glib_none().0,
+                                    );
+                                    v
+                                };
+                                args.push(obj_v);
+                                let len = args.len();
+                                args.swap(0, len - 1);
+                                callback(&args)
+                            })
+                        } else {
+                            RustClosure::new_local(move |args| {
+                                let mut args = args.to_owned();
+                                let object = object_weak
+                                    .upgrade()
+                                    .expect("Object destroyed before closure invalidated");
+                                let obj_v = unsafe {
+                                    let mut v = glib::Value::uninitialized();
+                                    glib::gobject_ffi::g_value_init(
+                                        v.to_glib_none_mut().0,
+                                        object.type_().into_glib(),
+                                    );
+                                    glib::gobject_ffi::g_value_set_object(
+                                        v.to_glib_none_mut().0,
+                                        object.as_object_ref().to_glib_none().0,
+                                    );
+                                    v
+                                };
+                                args.push(obj_v);
+                                callback(&args)
+                            })
+                        };
+                        object.watch_closure(closure.as_ref());
+                        closure.as_ref().clone()
+                    } else {
+                        if swapped {
+                            RustClosure::new_local(move |args| {
+                                let mut args = args.to_owned();
+                                if !args.is_empty() {
+                                    let len = args.len();
+                                    args.swap(0, len - 1);
+                                }
+                                callback(&args)
+                            })
+                        } else {
+                            RustClosure::new_local(move |args| callback(args))
+                        }
+                        .as_ref()
+                        .clone()
+                    }
+                })
+        }
+    }
+}

--- a/gtk4/src/lib.rs
+++ b/gtk4/src/lib.rs
@@ -107,6 +107,7 @@ mod bookmark_list;
 mod bool_filter;
 mod border;
 mod builder;
+mod builder_rust_scope;
 mod cell_area;
 mod cell_editable;
 mod cell_layout;
@@ -197,6 +198,7 @@ mod widget;
 
 pub use bitset_iter::BitsetIter;
 pub use border::Border;
+pub use builder_rust_scope::BuilderRustScope;
 pub use closure_expression::ClosureExpression;
 pub use constant_expression::ConstantExpression;
 pub use css_location::CssLocation;

--- a/gtk4/src/subclass/mod.rs
+++ b/gtk4/src/subclass/mod.rs
@@ -151,6 +151,7 @@ pub mod prelude {
     pub use super::tree_model_filter::{TreeModelFilterImpl, TreeModelFilterImplExt};
     pub use super::tree_view::{TreeViewImpl, TreeViewImplExt};
     pub use super::widget::CompositeTemplate;
+    pub use super::widget::CompositeTemplateCallbacks;
     pub use super::widget::TemplateChild;
     pub use super::widget::WidgetClassSubclassExt;
     pub use super::widget::{WidgetImpl, WidgetImplExt};


### PR DESCRIPTION
Fixes #24, also fixes part 3 of #77. Depends on gtk-rs/gtk-rs-core#338.

While getting to this work, I noticed that calling `Builder::current_object` while inside `create_closure` caused GTK to crash because `from_glib_none` has consumed the floating reference. I changed `current_object` to a manual implementation that calls `g_object_ref` via `clone`, and that fixes it. Long-term it seems that `BuilderScopeImpl` should probably be an unsafe trait since all its methods are able to get access to the builder while the object is being constructed.