### PR TITLE
Add CI for Windows MSVC

### DIFF
--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -1,0 +1,71 @@
+name: Windows MSVC
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  ci-msvc:
+    name: Windows MSVC
+    runs-on: windows-latest
+    env:
+      PKG_CONFIG_PATH: 'C:\gnome\lib\pkgconfig'
+
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Set up the PATH environment
+      run: |
+        echo "C:\pkg-config-lite-0.28-1\bin" >> $GITHUB_PATH
+        echo "C:\gnome\bin" >> $GITHUB_PATH
+      shell: bash
+        
+    - name: Install pkgconfig-lite
+      run: |
+        Invoke-WebRequest -Uri https://deac-fra.dl.sourceforge.net/project/pkgconfiglite/0.28-1/pkg-config-lite-0.28-1_bin-win32.zip -OutFile /pkg_config_lite.zip
+        Expand-Archive /pkg_config_lite.zip -DestinationPath C:\
+        ls C:\
+        ls C:\pkg-config-lite-0.28-1
+        ls C:\pkg-config-lite-0.28-1\bin
+        pkg-config --version
+
+    - name: Clone GTK
+      run: |
+        cd /
+        git clone https://gitlab.gnome.org/GNOME/gtk.git --depth 1
+        
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+        
+    - name: Install Python Dependencies
+      run: pip install meson ninja
+      
+    - name: Setup MSVC
+      uses: bus1/cabuild/action/msdevshell@v1
+      with:
+        architecture: x64
+        
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        
+    - name: Prepare GTK build
+      run: |
+        cd /gtk
+        meson setup builddir --prefix=C:/gnome -Dbuild-tests=false -Dmedia-gstreamer=disabled
+        
+    - name: Build and install GTK
+      run: |
+        cd /gtk
+        meson install -C builddir
+
+    - name: Build gtk4-rs
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --manifest-path gtk4/Cargo.toml


### PR DESCRIPTION
This took me embarrassingly long to get it working...

At this point, it just compiles the gtk4 crate from this repository with the windows-msvc toolchain. Maybe tests could be added and also a cache to speed up compilation because compiling GTK from source takes roughly 15 minutes.