### PR TITLE
Add method to create a "this" expression from GObject types

### DIFF
--- a/examples/expressions/main.rs
+++ b/examples/expressions/main.rs
@@ -36,11 +36,9 @@ fn build_ui(app: &gtk::Application) {
 
         // Instead of binding properties and manually unbinding them, you can create expressions.
         // The value can be obtained even if it is several steps away.
-        let metadata_expression = list_item
+        list_item
             .property_expression("item")
-            .chain_property::<Note>("metadata");
-
-        metadata_expression
+            .chain_property::<Note>("metadata")
             .chain_property::<Metadata>("title")
             .chain_closure_with_callback(|args| {
                 let title: String = args[1].get().unwrap();
@@ -48,7 +46,10 @@ fn build_ui(app: &gtk::Application) {
             })
             .bind(&title_label, "label", gtk::Widget::NONE);
 
-        metadata_expression
+        // Property expressions can also start from the `this` value, which is set as the last
+        // argument to the `bind` function.
+        gtk::ListItem::this_expression("item")
+            .chain_property::<Note>("metadata")
             .chain_property::<Metadata>("last-modified")
             .chain_closure::<String>(closure!(
                 |_: gtk::ListItem, last_modified: glib::DateTime| {

--- a/gtk4/src/expression.rs
+++ b/gtk4/src/expression.rs
@@ -277,6 +277,10 @@ pub trait GObjectPropertyExpressionExt {
     // rustdoc-stripper-ignore-next
     /// Create an expression looking up an object's property with a weak reference.
     fn property_expression_weak(&self, property_name: &str) -> crate::PropertyExpression;
+
+    // rustdoc-stripper-ignore-next
+    /// Create an expression looking up a property in the bound `this` object.
+    fn this_expression(property_name: &str) -> crate::PropertyExpression;
 }
 
 impl<T: IsA<glib::Object>> GObjectPropertyExpressionExt for T {
@@ -288,6 +292,11 @@ impl<T: IsA<glib::Object>> GObjectPropertyExpressionExt for T {
     fn property_expression_weak(&self, property_name: &str) -> crate::PropertyExpression {
         let obj_expr = crate::ObjectExpression::new(self);
         crate::PropertyExpression::new(T::static_type(), Some(&obj_expr), property_name)
+    }
+
+    fn this_expression(property_name: &str) -> crate::PropertyExpression {
+        skip_assert_initialized!();
+        crate::PropertyExpression::new(T::static_type(), Expression::NONE, property_name)
     }
 }
 


### PR DESCRIPTION
cc @SeaDve

Can be useful for some expressions, makes it so the expressions example could also be simplified as:

```rust
let metadata_expression = gtk::ListItem::this_expression("item")
             .chain_property::<Note>("metadata");
// ...
 metadata_expression
            .bind(&last_modified_label, "label", Some(list_item));
```

Not sure if it's worth creating an extra example for this?