### PR TITLE
Allow chaining expressions with Closure objects

### DIFF
--- a/examples/expressions/main.rs
+++ b/examples/expressions/main.rs
@@ -1,6 +1,8 @@
 mod metadata;
 mod note;
 
+use glib::closure;
+
 use gtk::gio;
 use gtk::glib;
 use gtk::prelude::*;
@@ -48,11 +50,12 @@ fn build_ui(app: &gtk::Application) {
 
         metadata_expression
             .chain_property::<Metadata>("last-modified")
-            .chain_closure(|args| {
-                let last_modified: glib::DateTime = args[1].get().unwrap();
-                format!("Last Modified: {}", last_modified.format_iso8601().unwrap())
-            })
-            .bind(&last_modified_label, "label", gtk::Widget::NONE);
+            .chain_closure_obj::<String>(closure!(
+                |_: gtk::ListItem, last_modified: glib::DateTime| {
+                    format!("Last Modified: {}", last_modified.format_iso8601().unwrap())
+                }
+            ))
+            .bind(&last_modified_label, "label", Some(list_item));
 
         list_item.set_child(Some(&hbox));
     });

--- a/examples/expressions/main.rs
+++ b/examples/expressions/main.rs
@@ -42,7 +42,7 @@ fn build_ui(app: &gtk::Application) {
 
         metadata_expression
             .chain_property::<Metadata>("title")
-            .chain_closure(|args| {
+            .chain_closure_with_callback(|args| {
                 let title: String = args[1].get().unwrap();
                 format!("Title: {}", title)
             })
@@ -50,7 +50,7 @@ fn build_ui(app: &gtk::Application) {
 
         metadata_expression
             .chain_property::<Metadata>("last-modified")
-            .chain_closure_obj::<String>(closure!(
+            .chain_closure::<String>(closure!(
                 |_: gtk::ListItem, last_modified: glib::DateTime| {
                     format!("Last Modified: {}", last_modified.format_iso8601().unwrap())
                 }

--- a/gtk4/src/closure_expression.rs
+++ b/gtk4/src/closure_expression.rs
@@ -50,12 +50,11 @@ impl ClosureExpression {
     }
 
     #[doc(alias = "gtk_closure_expression_new")]
-    pub fn with_closure<R>(
-        params: impl IntoIterator<Item = impl AsRef<Expression>>,
-        closure: glib::Closure,
-    ) -> Self
+    pub fn with_closure<R, I, E>(params: I, closure: glib::Closure) -> Self
     where
         R: ValueType,
+        I: IntoIterator<Item = E>,
+        E: AsRef<Expression>,
     {
         assert_initialized_main_thread!();
 

--- a/gtk4/src/expression.rs
+++ b/gtk4/src/expression.rs
@@ -161,8 +161,9 @@ impl Expression {
     }
 
     // rustdoc-stripper-ignore-next
-    /// Create a [`gtk::PropertyExpression`] that looks up for `property_name`
-    /// with self as parameter. This is useful in long chains of [`gtk::Expression`]s.
+    /// Create a [`PropertyExpression`](crate::PropertyExpression) that looks up for
+    /// `property_name` with self as parameter. This is useful in long chains of
+    /// [`Expression`](crate::Expression)s.
     pub fn chain_property<T: IsA<glib::Object>>(
         &self,
         property_name: &str,
@@ -250,12 +251,13 @@ impl glib::value::ToValueOptional for Expression {
 }
 
 // rustdoc-stripper-ignore-next
-/// Trait containing convenience methods in creating [`gtk::PropertyExpression`] that
+/// Trait containing convenience methods in creating
+/// [`PropertyExpression`](crate::PropertyExpression) that
 /// looks up a property of a [`glib::Object`].
 ///
 /// # Example
 ///
-/// `label_expression` is a [`gtk::Expression`] that looks up at Button's `label`
+/// `label_expression` is an [`Expression`](crate::Expression) that looks up at Button's `label`
 /// property.
 ///
 /// ```no_run


### PR DESCRIPTION
I had to change `ClosureExpression::with_closure` to expand out the generic parameters, it could be changed back depending on this: https://github.com/rust-lang/rust/issues/83701

Also includes some docs fixes.