### PR TITLE
docs: add very brief info for each subclass module

### DIFF
--- a/gdk4-wayland/src/wayland_surface.rs
+++ b/gdk4-wayland/src/wayland_surface.rs
@@ -7,6 +7,8 @@ use wayland_client::protocol::wl_surface::WlSurface;
 use wayland_client::sys::client::wl_proxy;
 use wayland_client::Proxy;
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`WaylandSurface`](crate::WaylandSurface).
 pub trait WaylandSurfaceExtManual: 'static {
     #[doc(alias = "gdk_wayland_surface_get_wl_surface")]
     #[doc(alias = "get_wl_surface")]

--- a/gdk4/src/cairo_interaction.rs
+++ b/gdk4/src/cairo_interaction.rs
@@ -5,6 +5,8 @@ use cairo::{Context, Region};
 use gdk_pixbuf::Pixbuf;
 use glib::translate::*;
 
+// rustdoc-stripper-ignore-next
+/// Trait containing integration methods with [`cairo::Surface`].
 pub trait GdkCairoSurfaceExt {
     #[doc(alias = "gdk_cairo_region_create_from_surface")]
     fn create_region(&self) -> Option<Region>;
@@ -20,6 +22,8 @@ impl GdkCairoSurfaceExt for cairo::Surface {
     }
 }
 
+// rustdoc-stripper-ignore-next
+/// Trait containing integration methods with [`cairo::Context`].
 pub trait GdkCairoContextExt {
     // rustdoc-stripper-ignore-next
     /// # Safety

--- a/gdk4/src/content_provider.rs
+++ b/gdk4/src/content_provider.rs
@@ -4,6 +4,8 @@ use crate::ContentProvider;
 use glib::translate::*;
 use glib::IsA;
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`ContentProvider`](crate::ContentProvider).
 pub trait ContentProviderExtManual {
     #[doc(alias = "gdk_content_provider_get_value")]
     fn value(&self, type_: glib::Type) -> Result<glib::Value, glib::Error>;

--- a/gdk4/src/display.rs
+++ b/gdk4/src/display.rs
@@ -52,6 +52,8 @@ impl Backend {
     }
 }
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`Display`](crate::Display).
 pub trait DisplayExtManual: 'static {
     #[doc(alias = "gdk_display_translate_key")]
     fn translate_key(

--- a/gdk4/src/draw_context.rs
+++ b/gdk4/src/draw_context.rs
@@ -4,6 +4,8 @@ use crate::DrawContext;
 use glib::translate::*;
 use glib::IsA;
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`DrawContext`](crate::DrawContext).
 pub trait DrawContextExtManual: 'static {
     #[doc(alias = "gdk_draw_context_get_frame_region")]
     #[doc(alias = "get_frame_region")]

--- a/gdk4/src/subclass/content_provider.rs
+++ b/gdk4/src/subclass/content_provider.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`ContentProvider`](crate::ContentProvider).
+
 use crate::{Clipboard, ContentFormats, ContentProvider};
 
 use crate::subclass::prelude::*;

--- a/gdk4/src/subclass/mod.rs
+++ b/gdk4/src/subclass/mod.rs
@@ -1,8 +1,13 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for creating custom types.
+
 pub mod content_provider;
 pub mod paintable;
 
+// rustdoc-stripper-ignore-next
+/// Traits intended for blanket imports.
 pub mod prelude {
     #[doc(hidden)]
     pub use gio::subclass::prelude::*;

--- a/gdk4/src/subclass/paintable.rs
+++ b/gdk4/src/subclass/paintable.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for implementing the [`Paintable`](crate::Paintable) interface.
+
 use crate::subclass::prelude::*;
 use crate::{Paintable, PaintableFlags, Snapshot};
 use glib::translate::*;

--- a/gdk4/src/surface.rs
+++ b/gdk4/src/surface.rs
@@ -4,6 +4,8 @@ use crate::Surface;
 use glib::object::IsA;
 use glib::translate::*;
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`Surface`](crate::Surface).
 pub trait SurfaceExtManual: 'static {
     #[doc(alias = "gdk_surface_create_similar_surface")]
     fn create_similar_surface(

--- a/gdk4/src/texture.rs
+++ b/gdk4/src/texture.rs
@@ -4,6 +4,8 @@ use crate::Texture;
 use glib::translate::*;
 use glib::IsA;
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`Texture`](crate::Texture).
 pub trait TextureExtManual: 'static {
     #[doc(alias = "gdk_texture_download")]
     fn download(&self, data: &mut [u8], stride: usize);

--- a/gdk4/src/toplevel.rs
+++ b/gdk4/src/toplevel.rs
@@ -8,6 +8,8 @@ use glib::IsA;
 use std::boxed::Box as Box_;
 use std::mem::transmute;
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`Toplevel`](crate::Toplevel).
 pub trait ToplevelExtManual {
     #[doc(alias = "gdk_toplevel_inhibit_system_shortcuts")]
     fn inhibit_system_shortcuts<P: AsRef<Event>>(&self, event: Option<&P>);

--- a/gsk4/src/renderer.rs
+++ b/gsk4/src/renderer.rs
@@ -4,6 +4,8 @@ use crate::{RenderNode, Renderer};
 use glib::object::IsA;
 use glib::translate::*;
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`Renderer`](crate::Renderer).
 pub trait GskRendererExtManual: 'static {
     #[doc(alias = "gsk_renderer_render")]
     fn render<P: AsRef<RenderNode>>(&self, root: &P, region: Option<&cairo::Region>);

--- a/gtk4/src/accessible.rs
+++ b/gtk4/src/accessible.rs
@@ -4,6 +4,8 @@ use crate::{Accessible, AccessibleProperty, AccessibleRelation, AccessibleState}
 use glib::translate::*;
 use glib::{IsA, ToValue};
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`Accessible`](crate::Accessible).
 pub trait AccessibleExtManual {
     #[doc(alias = "gtk_accessible_update_property")]
     #[doc(alias = "gtk_accessible_update_property_value")]

--- a/gtk4/src/actionable.rs
+++ b/gtk4/src/actionable.rs
@@ -5,6 +5,8 @@ use glib::object::IsA;
 use glib::translate::*;
 use libc::c_char;
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`Actionable`](crate::Actionable).
 pub trait ActionableExtManual: 'static {
     #[doc(alias = "gtk_actionable_set_action_target")]
     fn set_action_target(&self, string: &str);

--- a/gtk4/src/cell_area.rs
+++ b/gtk4/src/cell_area.rs
@@ -6,6 +6,8 @@ use gdk::Event;
 use glib::translate::*;
 use glib::{value::FromValue, IsA, ToValue};
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`CellArea`](crate::CellArea).
 pub trait CellAreaExtManual {
     #[doc(alias = "gtk_cell_area_add_with_properties")]
     fn add_with_properties(

--- a/gtk4/src/cell_layout.rs
+++ b/gtk4/src/cell_layout.rs
@@ -5,6 +5,8 @@ use crate::{CellLayout, CellRenderer};
 use glib::translate::*;
 use glib::IsA;
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`CellLayout`](crate::CellLayout).
 pub trait CellLayoutExtManual: 'static {
     #[doc(alias = "gtk_cell_layout_set_attributes")]
     fn set_attributes(&self, cell: &impl IsA<CellRenderer>, attributes: &[(&str, i32)]);

--- a/gtk4/src/cell_renderer.rs
+++ b/gtk4/src/cell_renderer.rs
@@ -4,6 +4,8 @@ use crate::{CellEditable, CellRenderer, CellRendererState, Widget};
 use glib::translate::*;
 use glib::IsA;
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`CellRenderer`](crate::CellRenderer).
 pub trait CellRendererExtManual {
     #[doc(alias = "gtk_cell_renderer_activate")]
     fn activate<Q: IsA<Widget>, R: AsRef<gdk::Event>>(

--- a/gtk4/src/color_chooser.rs
+++ b/gtk4/src/color_chooser.rs
@@ -6,6 +6,8 @@ use glib::object::IsA;
 use glib::translate::*;
 use libc::c_int;
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`ColorChooser`](crate::ColorChooser).
 pub trait ColorChooserExtManual: 'static {
     #[doc(alias = "gtk_color_chooser_add_palette")]
     fn add_palette(&self, orientation: Orientation, colors_per_line: i32, colors: &[RGBA]);

--- a/gtk4/src/combo_box.rs
+++ b/gtk4/src/combo_box.rs
@@ -4,6 +4,8 @@ use crate::ComboBox;
 use glib::object::IsA;
 use glib::translate::*;
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`ComboBox`](crate::ComboBox).
 pub trait ComboBoxExtManual: 'static {
     #[doc(alias = "gtk_combo_box_set_row_separator_func")]
     #[doc(alias = "set_row_separator_func")]

--- a/gtk4/src/dialog.rs
+++ b/gtk4/src/dialog.rs
@@ -36,6 +36,8 @@ impl Dialog {
     }
 }
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`Dialog`](crate::Dialog).
 pub trait DialogExtManual: 'static {
     #[doc(alias = "gtk_dialog_add_buttons")]
     fn add_buttons(&self, buttons: &[(&str, ResponseType)]);

--- a/gtk4/src/drawing_area.rs
+++ b/gtk4/src/drawing_area.rs
@@ -6,6 +6,8 @@ use glib::translate::*;
 use std::cell::RefCell;
 use std::ptr;
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`DrawingArea`](crate::DrawingArea).
 pub trait DrawingAreaExtManual: 'static {
     #[doc(alias = "gtk_drawing_area_set_draw_func")]
     #[doc(alias = "set_draw_func")]

--- a/gtk4/src/editable.rs
+++ b/gtk4/src/editable.rs
@@ -11,6 +11,8 @@ use std::mem::transmute;
 use std::slice;
 use std::str;
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`Editable`](crate::Editable).
 pub trait EditableExtManual: 'static {
     fn connect_insert_text<F>(&self, f: F) -> SignalHandlerId
     where

--- a/gtk4/src/entry.rs
+++ b/gtk4/src/entry.rs
@@ -5,6 +5,8 @@ use glib::translate::*;
 use glib::IsA;
 use std::convert::TryFrom;
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`Entry`](crate::Entry).
 pub trait EntryExtManual: 'static {
     #[doc(alias = "gtk_entry_get_invisible_char")]
     #[doc(alias = "get_invisible_char")]

--- a/gtk4/src/entry_buffer.rs
+++ b/gtk4/src/entry_buffer.rs
@@ -18,6 +18,8 @@ impl EntryBuffer {
     }
 }
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`EntryBuffer`](crate::EntryBuffer).
 pub trait EntryBufferExtManual: 'static {
     #[doc(alias = "gtk_entry_buffer_delete_text")]
     fn delete_text(&self, position: u16, n_chars: Option<u16>) -> u16;

--- a/gtk4/src/file_chooser.rs
+++ b/gtk4/src/file_chooser.rs
@@ -4,6 +4,8 @@ use crate::FileChooser;
 use glib::translate::*;
 use glib::IsA;
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`FileChooser`](crate::FileChooser).
 pub trait FileChooserExtManual: 'static {
     #[doc(alias = "gtk_file_chooser_add_choice")]
     fn add_choice(&self, id: &str, label: &str, options: &[(&str, &str)]);

--- a/gtk4/src/font_chooser.rs
+++ b/gtk4/src/font_chooser.rs
@@ -4,6 +4,8 @@ use crate::FontChooser;
 use glib::translate::*;
 use glib::IsA;
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`FontChooser`](crate::FontChooser).
 pub trait FontChooserExtManual: 'static {
     #[doc(alias = "gtk_font_chooser_set_filter_func")]
     #[doc(alias = "set_filter_func")]

--- a/gtk4/src/im_context.rs
+++ b/gtk4/src/im_context.rs
@@ -4,6 +4,8 @@ use crate::IMContext;
 use glib::translate::*;
 use glib::IsA;
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`IMContext`](crate::IMContext).
 #[allow(clippy::upper_case_acronyms)]
 pub trait IMContextExtManual {
     #[doc(alias = "gtk_im_context_filter_keypress")]

--- a/gtk4/src/native_dialog.rs
+++ b/gtk4/src/native_dialog.rs
@@ -7,6 +7,8 @@ use std::cell::Cell;
 use std::future::Future;
 use std::pin::Pin;
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`NativeDialog`](crate::NativeDialog).
 pub trait NativeDialogExtManual {
     // rustdoc-stripper-ignore-next
     /// Shows the dialog and returns a `Future` that resolves to the

--- a/gtk4/src/scale.rs
+++ b/gtk4/src/scale.rs
@@ -4,6 +4,8 @@ use crate::Scale;
 use glib::translate::*;
 use glib::IsA;
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`Scale`](crate::Scale).
 pub trait ScaleExtManual: 'static {
     #[doc(alias = "gtk_scale_set_format_value_func")]
     #[doc(alias = "set_format_value_func")]

--- a/gtk4/src/shortcut_trigger.rs
+++ b/gtk4/src/shortcut_trigger.rs
@@ -4,6 +4,8 @@ use crate::ShortcutTrigger;
 use glib::translate::*;
 use glib::IsA;
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`ShortcutTrigger`](crate::ShortcutTrigger).
 pub trait ShortcutTriggerExtManual {
     #[doc(alias = "gtk_shortcut_trigger_compare")]
     fn compare<P: IsA<ShortcutTrigger>>(&self, trigger2: &P) -> std::cmp::Ordering;

--- a/gtk4/src/subclass/actionable.rs
+++ b/gtk4/src/subclass/actionable.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for implementing the [`Actionable`](crate::Actionable) interface.
+
 use crate::subclass::prelude::*;
 use crate::Actionable;
 use glib::translate::*;

--- a/gtk4/src/subclass/adjustment.rs
+++ b/gtk4/src/subclass/adjustment.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`Adjustment`](crate::Adjustment).
+
 use crate::subclass::prelude::*;
 use glib::translate::*;
 use glib::Cast;

--- a/gtk4/src/subclass/application.rs
+++ b/gtk4/src/subclass/application.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`Application`](crate::Application).
+
 use gio::subclass::prelude::*;
 use glib::translate::*;
 use glib::Cast;

--- a/gtk4/src/subclass/application_window.rs
+++ b/gtk4/src/subclass/application_window.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`ApplicationWindow`](crate::ApplicationWindow).
+
 use crate::subclass::prelude::*;
 use crate::ApplicationWindow;
 

--- a/gtk4/src/subclass/box_.rs
+++ b/gtk4/src/subclass/box_.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`Box`](crate::Box).
+
 use crate::subclass::prelude::*;
 use crate::Box;
 

--- a/gtk4/src/subclass/buildable.rs
+++ b/gtk4/src/subclass/buildable.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for implementing the [`Buildable`](crate::Buildable) interface.
+
 use crate::prelude::*;
 use crate::subclass::prelude::*;
 use crate::{Buildable, Builder};

--- a/gtk4/src/subclass/builder_scope.rs
+++ b/gtk4/src/subclass/builder_scope.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for implementing the [`BuilderScope`](crate::BuilderScope) interface.
+
 use crate::subclass::prelude::*;
 use crate::{Builder, BuilderClosureFlags, BuilderScope};
 use glib::translate::*;

--- a/gtk4/src/subclass/button.rs
+++ b/gtk4/src/subclass/button.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`Button`](crate::Button).
+
 use crate::subclass::prelude::*;
 use crate::Button;
 use glib::translate::*;

--- a/gtk4/src/subclass/cell_area.rs
+++ b/gtk4/src/subclass/cell_area.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`CellArea`](crate::CellArea).
+
 use crate::subclass::prelude::*;
 use crate::{
     CellArea, CellAreaContext, CellRenderer, CellRendererState, DirectionType, SizeRequestMode,

--- a/gtk4/src/subclass/cell_area_context.rs
+++ b/gtk4/src/subclass/cell_area_context.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`CellAreaContext`](crate::CellAreaContext).
+
 use crate::subclass::prelude::*;
 use crate::CellAreaContext;
 use glib::translate::*;

--- a/gtk4/src/subclass/cell_editable.rs
+++ b/gtk4/src/subclass/cell_editable.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for implementing the [`CellEditable`](crate::CellEditable) interface.
+
 use crate::subclass::prelude::*;
 use crate::CellEditable;
 use glib::translate::*;

--- a/gtk4/src/subclass/cell_layout.rs
+++ b/gtk4/src/subclass/cell_layout.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for implementing the [`CellLayout`](crate::CellLayout) interface.
+
 use crate::subclass::prelude::*;
 use crate::{CellArea, CellLayout, CellRenderer, TreeIter, TreeModel};
 use glib::translate::*;

--- a/gtk4/src/subclass/cell_renderer.rs
+++ b/gtk4/src/subclass/cell_renderer.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`CellRenderer`](crate::CellRenderer).
+
 use libc::{c_char, c_int};
 use std::mem;
 

--- a/gtk4/src/subclass/cell_renderer_text.rs
+++ b/gtk4/src/subclass/cell_renderer_text.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`CellRendererText`](crate::CellRendererText).
+
 use crate::subclass::prelude::*;
 use crate::CellRendererText;
 use glib::translate::*;

--- a/gtk4/src/subclass/check_button.rs
+++ b/gtk4/src/subclass/check_button.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`CheckButton`](crate::CheckButton).
+
 use crate::subclass::prelude::*;
 use crate::CheckButton;
 use glib::translate::*;

--- a/gtk4/src/subclass/color_chooser.rs
+++ b/gtk4/src/subclass/color_chooser.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for implementing the [`ColorChooser`](crate::ColorChooser) interface.
+
 use crate::subclass::prelude::*;
 use crate::{ColorChooser, Orientation};
 use gdk::RGBA;

--- a/gtk4/src/subclass/combo_box.rs
+++ b/gtk4/src/subclass/combo_box.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`ComboBox`](crate::ComboBox).
+
 use crate::subclass::prelude::*;
 use crate::ComboBox;
 use glib::translate::*;

--- a/gtk4/src/subclass/constraint_target.rs
+++ b/gtk4/src/subclass/constraint_target.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for implementing the [`ConstraintTarget`](crate::ConstraintTarget) interface.
+
 use crate::subclass::prelude::*;
 use crate::ConstraintTarget;
 

--- a/gtk4/src/subclass/dialog.rs
+++ b/gtk4/src/subclass/dialog.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`Dialog`](crate::Dialog).
+
 use crate::subclass::prelude::*;
 use crate::{Dialog, ResponseType};
 use glib::translate::*;

--- a/gtk4/src/subclass/drawing_area.rs
+++ b/gtk4/src/subclass/drawing_area.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`DrawingA£rea`](crate::DrawingA£rea).
+
 use crate::subclass::prelude::*;
 use crate::DrawingArea;
 use glib::translate::*;

--- a/gtk4/src/subclass/editable.rs
+++ b/gtk4/src/subclass/editable.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for implementing the [`Editable`](crate::Editable) interface.
+
 use crate::subclass::prelude::*;
 use crate::Editable;
 use glib::translate::*;

--- a/gtk4/src/subclass/entry.rs
+++ b/gtk4/src/subclass/entry.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`Entry`](crate::Entry).
+
 use crate::subclass::prelude::*;
 use crate::Entry;
 use glib::translate::*;

--- a/gtk4/src/subclass/entry_buffer.rs
+++ b/gtk4/src/subclass/entry_buffer.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`EntryBuffer`](crate::EntryBuffer).
+
 use crate::subclass::prelude::*;
 use crate::EntryBuffer;
 use glib::translate::*;

--- a/gtk4/src/subclass/filter.rs
+++ b/gtk4/src/subclass/filter.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`Filter`](crate::Filter).
+
 use crate::subclass::prelude::*;
 use crate::{Filter, FilterMatch};
 use glib::translate::*;

--- a/gtk4/src/subclass/fixed.rs
+++ b/gtk4/src/subclass/fixed.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`Fixed`](crate::Fixed).
+
 use crate::subclass::prelude::*;
 use crate::Fixed;
 

--- a/gtk4/src/subclass/flow_box_child.rs
+++ b/gtk4/src/subclass/flow_box_child.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`FlowBoxChild`](crate::FlowBoxChild).
+
 use crate::subclass::prelude::*;
 use crate::FlowBoxChild;
 use glib::translate::*;

--- a/gtk4/src/subclass/font_chooser.rs
+++ b/gtk4/src/subclass/font_chooser.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for implementing the [`FontChooser`](crate::FontChooser) interface.
+
 use crate::subclass::prelude::*;
 use crate::FontChooser;
 use glib::translate::*;

--- a/gtk4/src/subclass/frame.rs
+++ b/gtk4/src/subclass/frame.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`Frame`](crate::Frame).
+
 use crate::subclass::prelude::*;
 use crate::{Allocation, Frame};
 use glib::translate::*;

--- a/gtk4/src/subclass/gl_area.rs
+++ b/gtk4/src/subclass/gl_area.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`GLArea`](crate::GLArea).
+
 use crate::subclass::prelude::*;
 use crate::GLArea;
 use gdk::GLContext;

--- a/gtk4/src/subclass/grid.rs
+++ b/gtk4/src/subclass/grid.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`Grid`](crate::Grid).
+
 use crate::subclass::prelude::*;
 use crate::Grid;
 

--- a/gtk4/src/subclass/im_context.rs
+++ b/gtk4/src/subclass/im_context.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`IMContext`](crate::IMContext).
+
 use crate::subclass::prelude::*;
 use crate::{IMContext, Widget};
 use glib::translate::*;

--- a/gtk4/src/subclass/layout_child.rs
+++ b/gtk4/src/subclass/layout_child.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`LayoutChild`](crate::LayoutChild).
+
 use crate::subclass::prelude::*;
 use crate::LayoutChild;
 

--- a/gtk4/src/subclass/layout_manager.rs
+++ b/gtk4/src/subclass/layout_manager.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`LayoutManager`](crate::LayoutManager).
+
 use crate::subclass::prelude::*;
 use glib::translate::*;
 use glib::Cast;

--- a/gtk4/src/subclass/list_box_row.rs
+++ b/gtk4/src/subclass/list_box_row.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`ListBoxRow`](crate::ListBoxRow).
+
 use crate::subclass::prelude::*;
 use crate::ListBoxRow;
 use glib::translate::*;

--- a/gtk4/src/subclass/media_file.rs
+++ b/gtk4/src/subclass/media_file.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`MediaFile`](crate::MediaFile).
+
 use crate::subclass::prelude::*;
 use crate::MediaFile;
 use glib::translate::*;

--- a/gtk4/src/subclass/media_stream.rs
+++ b/gtk4/src/subclass/media_stream.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`MediaStream`](crate::MediaStream).
+
 use crate::subclass::prelude::*;
 use crate::MediaStream;
 use glib::translate::*;

--- a/gtk4/src/subclass/mod.rs
+++ b/gtk4/src/subclass/mod.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for creating custom types.
+
 /// Struct to hold a pointer and free it on `Drop::drop`
 pub(crate) struct PtrHolder<T, F: Fn(*mut T) + 'static>(*mut T, F);
 
@@ -74,6 +77,7 @@ pub mod tree_view;
 pub mod widget;
 pub mod window;
 
+/// Traits intended for blanket imports.
 pub mod prelude {
     #[doc(hidden)]
     pub use gdk::subclass::prelude::*;

--- a/gtk4/src/subclass/native.rs
+++ b/gtk4/src/subclass/native.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for implementing the [`Native`](crate::Native) interface.
+
 use crate::subclass::prelude::*;
 use crate::Native;
 

--- a/gtk4/src/subclass/native_dialog.rs
+++ b/gtk4/src/subclass/native_dialog.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`NativeDialog`](crate::NativeDialog).
+
 use crate::subclass::prelude::*;
 use crate::{NativeDialog, ResponseType};
 use glib::translate::*;

--- a/gtk4/src/subclass/orientable.rs
+++ b/gtk4/src/subclass/orientable.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for implementing the [`Orientable`](crate::Orientable) interface.
+
 use crate::subclass::prelude::*;
 use crate::Orientable;
 

--- a/gtk4/src/subclass/popover.rs
+++ b/gtk4/src/subclass/popover.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`Popover`](crate::Popover).
+
 use crate::subclass::prelude::*;
 use crate::Popover;
 use glib::translate::*;

--- a/gtk4/src/subclass/print_operation.rs
+++ b/gtk4/src/subclass/print_operation.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`PrintOperation`](crate::PrintOperation).
+
 use crate::subclass::prelude::*;
 use crate::{
     PageSetup, PrintContext, PrintOperation, PrintOperationPreview, PrintOperationResult,

--- a/gtk4/src/subclass/print_operation_preview.rs
+++ b/gtk4/src/subclass/print_operation_preview.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for implementing the [`PrintOperationPreview`](crate::PrintOperationPreview) interface.
+
 use crate::subclass::prelude::*;
 use crate::{PageSetup, PrintContext, PrintOperationPreview};
 use glib::translate::*;

--- a/gtk4/src/subclass/range.rs
+++ b/gtk4/src/subclass/range.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`Range`](crate::Range).
+
 use crate::subclass::prelude::*;
 use crate::{Border, Range, ScrollType};
 use glib::translate::*;

--- a/gtk4/src/subclass/recent_manager.rs
+++ b/gtk4/src/subclass/recent_manager.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`RecentManager`](crate::RecentManager).
+
 use crate::subclass::prelude::*;
 use crate::RecentManager;
 use glib::translate::*;

--- a/gtk4/src/subclass/root.rs
+++ b/gtk4/src/subclass/root.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for implementing the [`Root`](crate::Root) interface.
+
 use crate::subclass::prelude::*;
 use crate::Root;
 

--- a/gtk4/src/subclass/scale.rs
+++ b/gtk4/src/subclass/scale.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`Scale`](crate::Scale).
+
 use crate::subclass::prelude::*;
 use crate::Scale;
 use glib::translate::*;

--- a/gtk4/src/subclass/scale_button.rs
+++ b/gtk4/src/subclass/scale_button.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`ScaleButton`](crate::ScaleButton).
+
 use crate::subclass::prelude::*;
 use crate::ScaleButton;
 use glib::translate::*;

--- a/gtk4/src/subclass/scrollable.rs
+++ b/gtk4/src/subclass/scrollable.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for implementing the [`Scrollable`](crate::Scrollable) interface.
+
 use crate::subclass::prelude::*;
 use crate::{Border, Scrollable};
 use glib::translate::*;

--- a/gtk4/src/subclass/selection_model.rs
+++ b/gtk4/src/subclass/selection_model.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for implementing the [`SelectionModel`](crate::SelectionModel) interface.
+
 use crate::{Bitset, SelectionModel};
 use gio::subclass::prelude::*;
 use glib::translate::*;

--- a/gtk4/src/subclass/shortcut_manager.rs
+++ b/gtk4/src/subclass/shortcut_manager.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for implementing the [`ShortcutManager`](crate::ShortcutManager) interface.
+
 use crate::subclass::prelude::*;
 use crate::{ShortcutController, ShortcutManager};
 use glib::translate::*;

--- a/gtk4/src/subclass/sorter.rs
+++ b/gtk4/src/subclass/sorter.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`Sorter`](crate::Sorter).
+
 use crate::subclass::prelude::*;
 use crate::{Ordering, Sorter, SorterOrder};
 use glib::translate::*;

--- a/gtk4/src/subclass/style_context.rs
+++ b/gtk4/src/subclass/style_context.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`StyleContext`](crate::StyleContext).
+
 use crate::subclass::prelude::*;
 use crate::StyleContext;
 use glib::translate::*;

--- a/gtk4/src/subclass/symbolic_paintable.rs
+++ b/gtk4/src/subclass/symbolic_paintable.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for implementing the [`SymbolicPaintable`](crate::SymbolicPaintable) interface.
+
 use crate::subclass::prelude::*;
 use crate::SymbolicPaintable;
 use gdk::subclass::prelude::PaintableImpl;

--- a/gtk4/src/subclass/text_buffer.rs
+++ b/gtk4/src/subclass/text_buffer.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`TextBuffer`](crate::TextBuffer).
+
 use crate::subclass::prelude::*;
 use crate::{TextBuffer, TextChildAnchor, TextIter, TextMark, TextTag};
 use glib::translate::*;

--- a/gtk4/src/subclass/text_view.rs
+++ b/gtk4/src/subclass/text_view.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`TextView`](crate::TextView).
+
 use crate::subclass::prelude::*;
 use crate::{
     DeleteType, MovementStep, Snapshot, TextExtendSelection, TextIter, TextView, TextViewLayer,

--- a/gtk4/src/subclass/toggle_button.rs
+++ b/gtk4/src/subclass/toggle_button.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`ToggleButton`](crate::ToggleButton).
+
 use crate::subclass::prelude::*;
 use crate::ToggleButton;
 use glib::translate::*;

--- a/gtk4/src/subclass/tree_drag_dest.rs
+++ b/gtk4/src/subclass/tree_drag_dest.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for implementing the [`TreeDragDest`](crate::TreeDragDest) interface.
+
 use crate::subclass::prelude::*;
 use crate::{TreeDragDest, TreePath};
 use glib::translate::*;

--- a/gtk4/src/subclass/tree_drag_source.rs
+++ b/gtk4/src/subclass/tree_drag_source.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for implementing the [`TreeDragSource`](crate::TreeDragSource) interface.
+
 use crate::subclass::prelude::*;
 use crate::{TreeDragSource, TreePath};
 use glib::translate::*;

--- a/gtk4/src/subclass/tree_model_filter.rs
+++ b/gtk4/src/subclass/tree_model_filter.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`TreeModelFilter`](crate::TreeModelFilter).
+
 use crate::subclass::prelude::*;
 use crate::{TreeIter, TreeModel, TreeModelFilter};
 use glib::translate::*;

--- a/gtk4/src/subclass/tree_view.rs
+++ b/gtk4/src/subclass/tree_view.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`TreeView`](crate::TreeView).
+
 use crate::subclass::prelude::*;
 use crate::{MovementStep, TreeIter, TreePath, TreeView, TreeViewColumn};
 use glib::translate::*;

--- a/gtk4/src/subclass/widget.rs
+++ b/gtk4/src/subclass/widget.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`Widget`](crate::Widget).
+
 use crate::prelude::*;
 use crate::subclass::prelude::*;
 use crate::{

--- a/gtk4/src/subclass/window.rs
+++ b/gtk4/src/subclass/window.rs
@@ -1,5 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`Window`](crate::Window).
+
 use crate::subclass::prelude::*;
 use crate::Window;
 use glib::translate::*;

--- a/gtk4/src/symbolic_paintable.rs
+++ b/gtk4/src/symbolic_paintable.rs
@@ -4,6 +4,8 @@ use crate::SymbolicPaintable;
 use glib::translate::*;
 use glib::IsA;
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`SymbolicPaintable`](crate::SymbolicPaintable).
 pub trait SymbolicPaintableExtManual: 'static {
     #[doc(alias = "gtk_symbolic_paintable_snapshot_symbolic")]
     fn snapshot_symbolic(

--- a/gtk4/src/text_buffer.rs
+++ b/gtk4/src/text_buffer.rs
@@ -9,6 +9,8 @@ use std::boxed::Box as Box_;
 use std::mem::transmute;
 use std::{slice, str};
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`TextBuffer`](crate::TextBuffer).
 pub trait TextBufferExtManual: 'static {
     fn connect_insert_text<F: Fn(&Self, &mut TextIter, &str) + 'static>(
         &self,

--- a/gtk4/src/text_view.rs
+++ b/gtk4/src/text_view.rs
@@ -4,6 +4,8 @@ use crate::TextView;
 use glib::translate::*;
 use glib::IsA;
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`TextView`](crate::TextView).
 pub trait TextViewExtManual {
     #[doc(alias = "gtk_text_view_im_context_filter_keypress")]
     fn im_context_filter_keypress<R: AsRef<gdk::Event>>(&self, event: &R) -> bool;

--- a/gtk4/src/tree_model.rs
+++ b/gtk4/src/tree_model.rs
@@ -6,6 +6,8 @@ use glib::translate::*;
 use glib::value::FromValue;
 use glib::IsA;
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`TreeModel`](crate::TreeModel).
 pub trait TreeModelExtManual: 'static {
     #[doc(alias = "gtk_tree_model_get")]
     #[doc(alias = "gtk_tree_model_get_value")]

--- a/gtk4/src/tree_model_filter.rs
+++ b/gtk4/src/tree_model_filter.rs
@@ -20,6 +20,8 @@ impl TreeModelFilter {
     }
 }
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`TreeModelFilter`](crate::TreeModelFilter).
 pub trait TreeModelFilterExtManual: 'static {
     #[doc(alias = "gtk_tree_model_filter_set_modify_func")]
     fn set_modify_func<F: Fn(&TreeModel, &TreeIter, i32) -> glib::Value + 'static>(

--- a/gtk4/src/tree_sortable.rs
+++ b/gtk4/src/tree_sortable.rs
@@ -59,6 +59,8 @@ impl fmt::Display for SortColumn {
     }
 }
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`TreeSortable`](crate::TreeSortable).
 pub trait TreeSortableExtManual: 'static {
     #[doc(alias = "gtk_tree_sortable_set_default_sort_func")]
     fn set_default_sort_func<F>(&self, sort_func: F)

--- a/gtk4/src/tree_view.rs
+++ b/gtk4/src/tree_view.rs
@@ -5,6 +5,8 @@ use crate::{CellRenderer, TreeView, TreeViewColumn, TreeViewColumnSizing};
 use glib::translate::*;
 use glib::IsA;
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`TreeView`](crate::TreeView).
 pub trait TreeViewExtManual: 'static {
     #[doc(alias = "gtk_tree_view_insert_column_with_attributes")]
     fn insert_column_with_attributes(

--- a/gtk4/src/widget.rs
+++ b/gtk4/src/widget.rs
@@ -8,6 +8,8 @@ use glib::object::{Cast, IsA, WeakRef};
 use glib::translate::*;
 use glib::Continue;
 
+// rustdoc-stripper-ignore-next
+/// Trait containing manually implemented methods of [`Widget`](crate::Widget).
 pub trait WidgetExtManual: 'static {
     #[doc(alias = "gtk_widget_add_tick_callback")]
     fn add_tick_callback<P: Fn(&Self, &gdk::FrameClock) -> Continue + 'static>(


### PR DESCRIPTION
Ideally we would have a simple use case/example there in the future as well
and maybe make gir generate docs for vfuncs, why not :)

Gives something like this on the docs, inspired by the auto docs of the prelude traits

![image](https://user-images.githubusercontent.com/7660997/142033541-c9048d58-3cae-4619-87bb-6bf7804a9921.png)


