### PR TITLE
Various cleanup

### DIFF
--- a/gdk4/Gir.toml
+++ b/gdk4/Gir.toml
@@ -176,7 +176,7 @@ final_type = false
 [[object]]
 name = "Gdk.Clipboard"
 status = "generate"
-generate_builder = true
+generate_builder = false
     [[object.function]]
     pattern = "set_(value|valist)"
     ignore = true
@@ -360,7 +360,7 @@ final_type = false
 [[object]]
 name = "Gdk.DeviceTool"
 status = "generate"
-generate_builder = true
+generate_builder = false
 
 [[object]]
 name = "Gdk.Display"
@@ -583,10 +583,6 @@ manual_traits = ["TextureExtManual"]
     name = "save_to_tiff_bytes"
         [object.function.return]
         nullable_return_is_error = "Failed to save the texture as tiff bytes"
-
-
-
-
 
 [[object]]
 name = "Gdk.Toplevel"

--- a/gdk4/src/auto/clipboard.rs
+++ b/gdk4/src/auto/clipboard.rs
@@ -6,14 +6,11 @@ use crate::ContentFormats;
 use crate::ContentProvider;
 use crate::Display;
 use crate::Texture;
-use glib::object::Cast;
 use glib::object::IsA;
 use glib::object::ObjectType as ObjectType_;
 use glib::signal::connect_raw;
 use glib::signal::SignalHandlerId;
 use glib::translate::*;
-use glib::StaticType;
-use glib::ToValue;
 use std::boxed::Box as Box_;
 use std::fmt;
 use std::mem::transmute;
@@ -28,14 +25,6 @@ glib::wrapper! {
 }
 
 impl Clipboard {
-    // rustdoc-stripper-ignore-next
-    /// Creates a new builder-pattern struct instance to construct [`Clipboard`] objects.
-    ///
-    /// This method returns an instance of [`ClipboardBuilder`](crate::builders::ClipboardBuilder) which can be used to create [`Clipboard`] objects.
-    pub fn builder() -> ClipboardBuilder {
-        ClipboardBuilder::default()
-    }
-
     #[doc(alias = "gdk_clipboard_get_content")]
     #[doc(alias = "get_content")]
     pub fn content(&self) -> Option<ContentProvider> {
@@ -181,40 +170,6 @@ impl Clipboard {
                 Box_::into_raw(f),
             )
         }
-    }
-}
-
-#[derive(Clone, Default)]
-// rustdoc-stripper-ignore-next
-/// A [builder-pattern] type to construct [`Clipboard`] objects.
-///
-/// [builder-pattern]: https://doc.rust-lang.org/1.0.0/style/ownership/builders.html
-pub struct ClipboardBuilder {
-    display: Option<Display>,
-}
-
-impl ClipboardBuilder {
-    // rustdoc-stripper-ignore-next
-    /// Create a new [`ClipboardBuilder`].
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    // rustdoc-stripper-ignore-next
-    /// Build the [`Clipboard`].
-    #[must_use = "The builder must be built to be used"]
-    pub fn build(self) -> Clipboard {
-        let mut properties: Vec<(&str, &dyn ToValue)> = vec![];
-        if let Some(ref display) = self.display {
-            properties.push(("display", display));
-        }
-        glib::Object::new::<Clipboard>(&properties)
-            .expect("Failed to create an instance of Clipboard")
-    }
-
-    pub fn display(mut self, display: &impl IsA<Display>) -> Self {
-        self.display = Some(display.clone().upcast());
-        self
     }
 }
 

--- a/gdk4/src/auto/device_tool.rs
+++ b/gdk4/src/auto/device_tool.rs
@@ -4,10 +4,7 @@
 
 use crate::AxisFlags;
 use crate::DeviceToolType;
-use glib::object::Cast;
 use glib::translate::*;
-use glib::StaticType;
-use glib::ToValue;
 use std::fmt;
 
 glib::wrapper! {
@@ -20,14 +17,6 @@ glib::wrapper! {
 }
 
 impl DeviceTool {
-    // rustdoc-stripper-ignore-next
-    /// Creates a new builder-pattern struct instance to construct [`DeviceTool`] objects.
-    ///
-    /// This method returns an instance of [`DeviceToolBuilder`](crate::builders::DeviceToolBuilder) which can be used to create [`DeviceTool`] objects.
-    pub fn builder() -> DeviceToolBuilder {
-        DeviceToolBuilder::default()
-    }
-
     #[doc(alias = "gdk_device_tool_get_axes")]
     #[doc(alias = "get_axes")]
     pub fn axes(&self) -> AxisFlags {
@@ -50,67 +39,6 @@ impl DeviceTool {
     #[doc(alias = "get_tool_type")]
     pub fn tool_type(&self) -> DeviceToolType {
         unsafe { from_glib(ffi::gdk_device_tool_get_tool_type(self.to_glib_none().0)) }
-    }
-}
-
-#[derive(Clone, Default)]
-// rustdoc-stripper-ignore-next
-/// A [builder-pattern] type to construct [`DeviceTool`] objects.
-///
-/// [builder-pattern]: https://doc.rust-lang.org/1.0.0/style/ownership/builders.html
-pub struct DeviceToolBuilder {
-    axes: Option<AxisFlags>,
-    hardware_id: Option<u64>,
-    serial: Option<u64>,
-    tool_type: Option<DeviceToolType>,
-}
-
-impl DeviceToolBuilder {
-    // rustdoc-stripper-ignore-next
-    /// Create a new [`DeviceToolBuilder`].
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    // rustdoc-stripper-ignore-next
-    /// Build the [`DeviceTool`].
-    #[must_use = "The builder must be built to be used"]
-    pub fn build(self) -> DeviceTool {
-        let mut properties: Vec<(&str, &dyn ToValue)> = vec![];
-        if let Some(ref axes) = self.axes {
-            properties.push(("axes", axes));
-        }
-        if let Some(ref hardware_id) = self.hardware_id {
-            properties.push(("hardware-id", hardware_id));
-        }
-        if let Some(ref serial) = self.serial {
-            properties.push(("serial", serial));
-        }
-        if let Some(ref tool_type) = self.tool_type {
-            properties.push(("tool-type", tool_type));
-        }
-        glib::Object::new::<DeviceTool>(&properties)
-            .expect("Failed to create an instance of DeviceTool")
-    }
-
-    pub fn axes(mut self, axes: AxisFlags) -> Self {
-        self.axes = Some(axes);
-        self
-    }
-
-    pub fn hardware_id(mut self, hardware_id: u64) -> Self {
-        self.hardware_id = Some(hardware_id);
-        self
-    }
-
-    pub fn serial(mut self, serial: u64) -> Self {
-        self.serial = Some(serial);
-        self
-    }
-
-    pub fn tool_type(mut self, tool_type: DeviceToolType) -> Self {
-        self.tool_type = Some(tool_type);
-        self
     }
 }
 

--- a/gdk4/src/auto/mod.rs
+++ b/gdk4/src/auto/mod.rs
@@ -180,7 +180,5 @@ pub mod traits {
 }
 #[doc(hidden)]
 pub mod builders {
-    pub use super::clipboard::ClipboardBuilder;
     pub use super::cursor::CursorBuilder;
-    pub use super::device_tool::DeviceToolBuilder;
 }

--- a/gdk4/src/display.rs
+++ b/gdk4/src/display.rs
@@ -103,11 +103,16 @@ impl<O: IsA<Display>> DisplayExtManual for O {
                 consumed.as_mut_ptr(),
             ));
             if ret {
-                let keyval: Key = keyval.assume_init().into();
+                let keyval = keyval.assume_init();
                 let effective_group = effective_group.assume_init();
                 let level = level.assume_init();
                 let consumed = consumed.assume_init();
-                Some((keyval, effective_group, level, from_glib(consumed)))
+                Some((
+                    from_glib(keyval),
+                    effective_group,
+                    level,
+                    from_glib(consumed),
+                ))
             } else {
                 None
             }
@@ -166,7 +171,7 @@ impl<O: IsA<Display>> DisplayExtManual for O {
             if ret {
                 let n_keys = n_entries.assume_init() as usize;
                 let keyvals: Vec<u32> = FromGlibContainer::from_glib_full_num(keyvals, n_keys);
-                let keyvals = keyvals.into_iter().map(|k| k.into());
+                let keyvals = keyvals.into_iter().map(|k| from_glib(k));
                 let keys: Vec<KeymapKey> = FromGlibContainer::from_glib_full_num(keys, n_keys);
 
                 Some(keys.into_iter().zip(keyvals).collect())

--- a/gdk4/src/key_event.rs
+++ b/gdk4/src/key_event.rs
@@ -41,7 +41,7 @@ impl KeyEvent {
     #[doc(alias = "gdk_key_event_get_keyval")]
     #[doc(alias = "get_keyval")]
     pub fn keyval(&self) -> Key {
-        unsafe { ffi::gdk_key_event_get_keyval(self.to_glib_none().0).into() }
+        unsafe { from_glib(ffi::gdk_key_event_get_keyval(self.to_glib_none().0)) }
     }
 
     #[doc(alias = "gdk_key_event_get_layout")]
@@ -68,9 +68,9 @@ impl KeyEvent {
                 modifiers.as_mut_ptr(),
             ));
             if ret {
-                let keyval: Key = keyval.assume_init().into();
+                let keyval = keyval.assume_init();
                 let modifiers = modifiers.assume_init();
-                Some((keyval, from_glib(modifiers)))
+                Some((from_glib(keyval), from_glib(modifiers)))
             } else {
                 None
             }

--- a/gdk4/src/keys.rs
+++ b/gdk4/src/keys.rs
@@ -2,9 +2,8 @@
 
 use glib::translate::*;
 use glib::GString;
-use libc::c_uint;
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Key(u32);
 
 impl ::std::ops::Deref for Key {
@@ -12,13 +11,6 @@ impl ::std::ops::Deref for Key {
 
     fn deref(&self) -> &u32 {
         &self.0
-    }
-}
-
-impl ::std::convert::From<u32> for Key {
-    fn from(value: u32) -> Self {
-        skip_assert_initialized!();
-        Self(value)
     }
 }
 
@@ -41,7 +33,7 @@ impl Key {
     #[doc(alias = "gdk_keyval_from_name")]
     pub fn from_name(name: &str) -> Self {
         skip_assert_initialized!();
-        unsafe { ffi::gdk_keyval_from_name(name.to_glib_none().0) }.into()
+        unsafe { from_glib(ffi::gdk_keyval_from_name(name.to_glib_none().0)) }
     }
 
     #[doc(alias = "gdk_keyval_convert_case")]
@@ -50,47 +42,50 @@ impl Key {
         unsafe {
             let mut lower = std::mem::MaybeUninit::uninit();
             let mut upper = std::mem::MaybeUninit::uninit();
-            ffi::gdk_keyval_convert_case(**self, lower.as_mut_ptr(), upper.as_mut_ptr());
-            let lower = Self(lower.assume_init());
-            let upper = Self(upper.assume_init());
-            (lower, upper)
+            ffi::gdk_keyval_convert_case(self.into_glib(), lower.as_mut_ptr(), upper.as_mut_ptr());
+            let lower = lower.assume_init();
+            let upper = upper.assume_init();
+            (from_glib(lower), from_glib(upper))
         }
     }
 
     #[doc(alias = "gdk_keyval_to_unicode")]
     pub fn to_unicode(&self) -> Option<char> {
         skip_assert_initialized!();
-        unsafe { ::std::char::from_u32(ffi::gdk_keyval_to_unicode(**self)).filter(|x| *x != '\0') }
+        unsafe {
+            ::std::char::from_u32(ffi::gdk_keyval_to_unicode(self.into_glib()))
+                .filter(|x| *x != '\0')
+        }
     }
 
     #[doc(alias = "gdk_keyval_name")]
     pub fn name(&self) -> Option<GString> {
         skip_assert_initialized!();
-        unsafe { from_glib_none(ffi::gdk_keyval_name(**self as c_uint)) }
+        unsafe { from_glib_none(ffi::gdk_keyval_name(self.into_glib())) }
     }
 
     #[doc(alias = "gdk_keyval_is_upper")]
     pub fn is_upper(&self) -> bool {
         skip_assert_initialized!();
-        unsafe { from_glib(ffi::gdk_keyval_is_upper(**self)) }
+        unsafe { from_glib(ffi::gdk_keyval_is_upper(self.into_glib())) }
     }
 
     #[doc(alias = "gdk_keyval_is_lower")]
     pub fn is_lower(&self) -> bool {
         skip_assert_initialized!();
-        unsafe { from_glib(ffi::gdk_keyval_is_lower(**self)) }
+        unsafe { from_glib(ffi::gdk_keyval_is_lower(self.into_glib())) }
     }
 
     #[doc(alias = "gdk_keyval_to_upper")]
     pub fn to_upper(&self) -> Self {
         skip_assert_initialized!();
-        unsafe { ffi::gdk_keyval_to_upper(**self) }.into()
+        unsafe { from_glib(ffi::gdk_keyval_to_upper(self.into_glib())) }
     }
 
     #[doc(alias = "gdk_keyval_to_lower")]
     pub fn to_lower(&self) -> Self {
         skip_assert_initialized!();
-        unsafe { ffi::gdk_keyval_to_lower(**self) }.into()
+        unsafe { from_glib(ffi::gdk_keyval_to_lower(self.into_glib())) }
     }
 }
 
@@ -4660,5 +4655,6 @@ pub mod constants {
     pub const zerosubscript: Key = Key(ffi::GDK_KEY_zerosubscript as u32);
     #[doc(alias = "GDK_KEY_zerosuperior")]
     pub const zerosuperior: Key = Key(ffi::GDK_KEY_zerosuperior as u32);
+    #[doc(alias = "GDK_KEY_zstroke")]
     pub const zstroke: Key = Key(ffi::GDK_KEY_zstroke as u32);
 }

--- a/gdk4/src/keys.rs
+++ b/gdk4/src/keys.rs
@@ -15,12 +15,6 @@ impl ::std::ops::Deref for Key {
     }
 }
 
-impl ::std::ops::DerefMut for Key {
-    fn deref_mut(&mut self) -> &mut u32 {
-        &mut self.0
-    }
-}
-
 impl ::std::convert::From<u32> for Key {
     fn from(value: u32) -> Self {
         skip_assert_initialized!();

--- a/gtk4/src/border.rs
+++ b/gtk4/src/border.rs
@@ -2,7 +2,6 @@
 
 use glib::translate::*;
 use std::fmt;
-use std::ops;
 
 glib::wrapper! {
     #[doc(alias = "GtkBorder")]
@@ -12,20 +11,6 @@ glib::wrapper! {
         copy => |ptr| ffi::gtk_border_copy(mut_override(ptr)),
         free => |ptr| ffi::gtk_border_free(ptr),
         type_ => || ffi::gtk_border_get_type(),
-    }
-}
-
-impl ops::Deref for Border {
-    type Target = ffi::GtkBorder;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl ops::DerefMut for Border {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
     }
 }
 

--- a/gtk4/src/border.rs
+++ b/gtk4/src/border.rs
@@ -45,35 +45,35 @@ impl Border {
     }
 
     pub fn left(&self) -> i16 {
-        self.left
+        self.0.left
     }
 
     pub fn set_left(&mut self, left: i16) {
-        self.left = left;
+        self.0.left = left;
     }
 
     pub fn right(&self) -> i16 {
-        self.right
+        self.0.right
     }
 
     pub fn set_right(&mut self, right: i16) {
-        self.right = right;
+        self.0.right = right;
     }
 
     pub fn top(&self) -> i16 {
-        self.top
+        self.0.top
     }
 
     pub fn set_top(&mut self, top: i16) {
-        self.top = top;
+        self.0.top = top;
     }
 
     pub fn bottom(&self) -> i16 {
-        self.bottom
+        self.0.bottom
     }
 
     pub fn set_bottom(&mut self, bottom: i16) {
-        self.bottom = bottom;
+        self.0.bottom = bottom;
     }
 }
 
@@ -96,10 +96,10 @@ impl fmt::Debug for Border {
 
 impl PartialEq for Border {
     fn eq(&self, other: &Self) -> bool {
-        self.left == other.left
-            && self.right == other.right
-            && self.top == other.top
-            && self.bottom == other.bottom
+        self.left() == other.left()
+            && self.right() == other.right()
+            && self.top() == other.top()
+            && self.bottom() == other.bottom()
     }
 }
 

--- a/gtk4/src/event_controller_key.rs
+++ b/gtk4/src/event_controller_key.rs
@@ -27,7 +27,7 @@ impl EventControllerKey {
             let f: &F = &*(f as *const F);
             f(
                 &from_glib_borrow(this),
-                keyval.into(),
+                from_glib(keyval),
                 keycode,
                 from_glib(state),
             )
@@ -64,7 +64,7 @@ impl EventControllerKey {
             let f: &F = &*(f as *const F);
             f(
                 &from_glib_borrow(this),
-                keyval.into(),
+                from_glib(keyval),
                 keycode,
                 from_glib(state),
             )

--- a/gtk4/src/keyval_trigger.rs
+++ b/gtk4/src/keyval_trigger.rs
@@ -30,7 +30,7 @@ impl KeyvalTrigger {
     #[doc(alias = "gtk_keyval_trigger_get_keyval")]
     #[doc(alias = "get_keyval")]
     pub fn keyval(&self) -> Key {
-        unsafe { ffi::gtk_keyval_trigger_get_keyval(self.to_glib_none().0).into() }
+        unsafe { from_glib(ffi::gtk_keyval_trigger_get_keyval(self.to_glib_none().0)) }
     }
 
     #[doc(alias = "gtk_keyval_trigger_get_modifiers")]

--- a/gtk4/src/label.rs
+++ b/gtk4/src/label.rs
@@ -7,6 +7,6 @@ impl Label {
     #[doc(alias = "gtk_label_get_mnemonic_keyval")]
     #[doc(alias = "get_mnemonic_keyval")]
     pub fn mnemonic_keyval(&self) -> gdk::keys::Key {
-        unsafe { ffi::gtk_label_get_mnemonic_keyval(self.to_glib_none().0).into() }
+        unsafe { from_glib(ffi::gtk_label_get_mnemonic_keyval(self.to_glib_none().0)) }
     }
 }

--- a/gtk4/src/mnemonic_trigger.rs
+++ b/gtk4/src/mnemonic_trigger.rs
@@ -23,7 +23,7 @@ impl MnemonicTrigger {
     #[doc(alias = "gtk_mnemonic_trigger_get_keyval")]
     #[doc(alias = "get_keyval")]
     pub fn keyval(&self) -> Key {
-        unsafe { ffi::gtk_mnemonic_trigger_get_keyval(self.to_glib_none().0).into() }
+        unsafe { from_glib(ffi::gtk_mnemonic_trigger_get_keyval(self.to_glib_none().0)) }
     }
 }
 


### PR DESCRIPTION
- Drop unneeded builder patterns from gdk
- Make use glib traits for gdk::Key and make it a copy type
- Drop Deref/DerefMut impl for gtk::Border