### PR TITLE
gtk4: manually implement gtk_print_operation_get_error

### DIFF
--- a/gtk4/Gir.toml
+++ b/gtk4/Gir.toml
@@ -1735,6 +1735,10 @@ cfg_condition = "target_os = \"linux\""
 name = "Gtk.PrintOperation"
 status = "generate"
 trust_return_value_nullability = false
+    [[object.function]]
+    name = "get_error"
+    # It quacks like a fallible function, but it isn't.
+    ignore = true
 
 [[object]]
 name = "Gtk.PrintSettings"

--- a/gtk4/src/auto/print_operation.rs
+++ b/gtk4/src/auto/print_operation.rs
@@ -233,10 +233,6 @@ pub trait PrintOperationExt: 'static {
     #[doc(alias = "get_embed_page_setup")]
     fn embeds_page_setup(&self) -> bool;
 
-    #[doc(alias = "gtk_print_operation_get_error")]
-    #[doc(alias = "get_error")]
-    fn error(&self) -> Result<(), glib::Error>;
-
     #[doc(alias = "gtk_print_operation_get_has_selection")]
     #[doc(alias = "get_has_selection")]
     fn has_selection(&self) -> bool;
@@ -483,18 +479,6 @@ impl<O: IsA<PrintOperation>> PrintOperationExt for O {
             from_glib(ffi::gtk_print_operation_get_embed_page_setup(
                 self.as_ref().to_glib_none().0,
             ))
-        }
-    }
-
-    fn error(&self) -> Result<(), glib::Error> {
-        unsafe {
-            let mut error = ptr::null_mut();
-            let _ = ffi::gtk_print_operation_get_error(self.as_ref().to_glib_none().0, &mut error);
-            if error.is_null() {
-                Ok(())
-            } else {
-                Err(from_glib_full(error))
-            }
         }
     }
 

--- a/gtk4/src/lib.rs
+++ b/gtk4/src/lib.rs
@@ -163,6 +163,7 @@ mod param_spec_expression;
 #[cfg(any(target_os = "linux", feature = "dox"))]
 #[cfg_attr(feature = "dox", doc(cfg(target_os = "linux")))]
 mod print_job;
+mod print_operation;
 mod print_settings;
 mod property_expression;
 mod recent_data;

--- a/gtk4/src/print_operation.rs
+++ b/gtk4/src/print_operation.rs
@@ -1,0 +1,21 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::PrintOperation;
+use glib::translate::*;
+use std::ptr;
+
+impl PrintOperation {
+    #[doc(alias = "gtk_print_operation_get_error")]
+    #[doc(alias = "get_error")]
+    pub fn error(&self) -> Option<glib::Error> {
+        unsafe {
+            let mut error = ptr::null_mut();
+            ffi::gtk_print_operation_get_error(self.to_glib_none().0, &mut error);
+            if error.is_null() {
+                None
+            } else {
+                Some(from_glib_full(error))
+            }
+        }
+    }
+}


### PR DESCRIPTION
This moves `gtk_print_operation_get_error` to a manual wrapper.
It quacks like a fallible function, but it isn't. That was resulting in a wrong
auto-generated wrapper.