### PR TITLE
gdk: add sanity checks for Texture::download

### DIFF
--- a/gdk4/src/texture.rs
+++ b/gdk4/src/texture.rs
@@ -1,5 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+use crate::prelude::*;
 use crate::Texture;
 use glib::translate::*;
 use glib::IsA;
@@ -14,6 +15,18 @@ pub trait TextureExtManual: 'static {
 impl<O: IsA<Texture>> TextureExtManual for O {
     fn download(&self, data: &mut [u8], stride: usize) {
         unsafe {
+            assert!(
+                stride >= 4,
+                "Stride for a CAIRO_FORMAT_ARGB32 should be >= 4"
+            );
+            assert!(
+                stride as i32 >= self.as_ref().width() * 4,
+                "The stride must be >= 4*width"
+            );
+            assert!(
+                data.len() as i32 >= stride as i32 * self.as_ref().height(),
+                "The data is not big enough to download the texture"
+            );
             ffi::gdk_texture_download(self.as_ref().to_glib_none().0, data.as_mut_ptr(), stride);
         }
     }


### PR DESCRIPTION
Fixes #677 