### PR TITLE
Add a custom model example

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -110,6 +110,10 @@ name = "gtk_builder"
 path = "gtk_builder/main.rs"
 
 [[bin]]
+name = "list_box_model"
+path = "list_box_model/main.rs"
+
+[[bin]]
 name = "list_view_apps_launcher"
 path = "list_view_apps_launcher/main.rs"
 

--- a/examples/list_box_model/README.md
+++ b/examples/list_box_model/README.md
@@ -1,0 +1,18 @@
+# ListBox and ListModel example
+
+This example demonstrates how to use `gtk::ListBox` in combination with
+a custom model and a custom row type.
+The custom model resides in `model.rs` and the custom row type in `row_data.rs`.
+
+It sets up a `gtk::ListBox` containing, per row, a label, spinbutton and
+an edit button. The edit button allows to edit the underlying data structure
+and changes are taking place immediately in the listbox by making use of GObject
+property bindings.
+
+In addition, it is possible to add new rows and delete old ones.
+
+Run it by executing:
+
+```bash
+cargo run --bin list_box_model
+```

--- a/examples/list_box_model/list_box_row/imp.rs
+++ b/examples/list_box_model/list_box_row/imp.rs
@@ -1,0 +1,154 @@
+use std::cell::RefCell;
+
+use gtk::{
+    glib::{self, clone, ParamSpec, ParamSpecObject, Value},
+    prelude::*,
+    subclass::prelude::*,
+    ResponseType,
+};
+
+use crate::row_data::RowData;
+
+#[derive(Default, Debug)]
+pub struct ListBoxRow {
+    row_data: RefCell<Option<RowData>>,
+    parent_window: RefCell<Option<gtk::Window>>,
+}
+
+#[glib::object_subclass]
+impl ObjectSubclass for ListBoxRow {
+    const NAME: &'static str = "ExListBoxRow";
+    type ParentType = gtk::ListBoxRow;
+    type Type = super::ListBoxRow;
+}
+
+impl ObjectImpl for ListBoxRow {
+    fn properties() -> &'static [ParamSpec] {
+        use once_cell::sync::Lazy;
+        static PROPERTIES: Lazy<Vec<ParamSpec>> = Lazy::new(|| {
+            vec![
+                ParamSpecObject::new(
+                    "rowdata",
+                    "RowData",
+                    "RowData",
+                    RowData::static_type(),
+                    glib::ParamFlags::READWRITE | glib::ParamFlags::CONSTRUCT,
+                ),
+                ParamSpecObject::new(
+                    "parent-window",
+                    "Parent Window",
+                    "Parent Window",
+                    gtk::Window::static_type(),
+                    glib::ParamFlags::READWRITE | glib::ParamFlags::CONSTRUCT,
+                ),
+            ]
+        });
+        PROPERTIES.as_ref()
+    }
+
+    fn set_property(&self, _obj: &Self::Type, _id: usize, value: &Value, pspec: &ParamSpec) {
+        match pspec.name() {
+            "rowdata" => {
+                let row_data = value.get().unwrap();
+                self.row_data.replace(row_data);
+            }
+            "parent-window" => {
+                let parent_window = value.get().unwrap();
+                self.parent_window.replace(parent_window);
+            }
+            _ => unimplemented!(),
+        }
+    }
+
+    fn property(&self, _obj: &Self::Type, _id: usize, pspec: &ParamSpec) -> Value {
+        match pspec.name() {
+            "rowdata" => self.row_data.borrow().to_value(),
+            "parent-window" => self.parent_window.borrow().to_value(),
+            _ => unimplemented!(),
+        }
+    }
+
+    fn constructed(&self, obj: &Self::Type) {
+        let item = self.row_data.borrow();
+        let item = item.as_ref().cloned().unwrap();
+
+        let hbox = gtk::Box::new(gtk::Orientation::Horizontal, 5);
+
+        // Create the label and spin button that shows the two values
+        // of the item. We bind the properties for the two values to the
+        // corresponding properties of the widgets so that they are automatically
+        // updated whenever the item is changing. By specifying SYNC_CREATE the
+        // widget will automatically get the initial value of the item set.
+        //
+        // In case of the spin button the binding is bidirectional, that is any
+        // change of value in the spin button will be automatically reflected in
+        // the item.
+        let label = gtk::Label::new(None);
+        item.bind_property("name", &label, "label")
+            .flags(glib::BindingFlags::DEFAULT | glib::BindingFlags::SYNC_CREATE)
+            .build();
+        hbox.append(&label);
+
+        let spin_button = gtk::SpinButton::with_range(0.0, 100.0, 1.0);
+        item.bind_property("count", &spin_button, "value")
+            .flags(
+                glib::BindingFlags::DEFAULT
+                    | glib::BindingFlags::SYNC_CREATE
+                    | glib::BindingFlags::BIDIRECTIONAL,
+            )
+            .build();
+        hbox.append(&spin_button);
+
+        // When the edit button is clicked, a new modal dialog is created for editing
+        // the corresponding row
+        let edit_button = gtk::Button::with_label("Edit");
+        edit_button.connect_clicked(clone!(@strong item, @strong self.parent_window as window => move |_| {
+            let window = window.borrow();
+            let window = window.as_ref().unwrap();
+            let dialog = gtk::Dialog::with_buttons(
+                Some("Edit Item"),
+                Some(window),
+                gtk::DialogFlags::MODAL,
+                &[("Close", ResponseType::Close)]);
+            dialog.set_default_response(ResponseType::Close);
+            dialog.connect_response(|dialog, _| dialog.close());
+
+            let content_area = dialog.content_area();
+
+            // Similarly to the label and spin button inside the listbox, the text entry
+            // and spin button in the edit dialog are connected via property bindings to
+            // the item. Any changes will be immediately reflected inside the item and
+            // by the listbox
+            let entry = gtk::Entry::new();
+            item.bind_property("name", &entry, "text")
+                .flags(glib::BindingFlags::DEFAULT | glib::BindingFlags::SYNC_CREATE | glib::BindingFlags::BIDIRECTIONAL)
+                .build();
+
+            // Activating the entry (enter) will send response `ResponseType::Close` to the dialog
+            entry.connect_activate(clone!(@weak dialog => move |_| {
+                dialog.response(ResponseType::Close);
+            }));
+            content_area.append(&entry);
+
+            let spin_button = gtk::SpinButton::with_range(0.0, 100.0, 1.0);
+            item.bind_property("count", &spin_button, "value")
+                .flags(glib::BindingFlags::DEFAULT | glib::BindingFlags::SYNC_CREATE | glib::BindingFlags::BIDIRECTIONAL)
+                .build();
+            content_area.append(&spin_button);
+
+            dialog.show()
+        }));
+        hbox.append(&edit_button);
+
+        obj.set_child(Some(&hbox));
+
+        // When a row is activated (select + enter) we simply emit the clicked
+        // signal on the corresponding edit button to open the edit dialog
+        obj.connect_activate(clone!(@weak edit_button => move |_| {
+            edit_button.emit_clicked();
+        }));
+    }
+}
+
+impl WidgetImpl for ListBoxRow {}
+impl ListBoxRowImpl for ListBoxRow {}

--- a/examples/list_box_model/list_box_row/mod.rs
+++ b/examples/list_box_model/list_box_row/mod.rs
@@ -1,6 +1,6 @@
 mod imp;
 
-use gtk::{self, glib};
+use gtk::glib;
 
 use crate::row_data::RowData;
 

--- a/examples/list_box_model/list_box_row/mod.rs
+++ b/examples/list_box_model/list_box_row/mod.rs
@@ -1,0 +1,16 @@
+mod imp;
+
+use gtk::{self, glib};
+
+use crate::row_data::RowData;
+
+glib::wrapper! {
+    pub struct ListBoxRow(ObjectSubclass<imp::ListBoxRow>)
+        @extends gtk::Widget, gtk::ListBoxRow;
+}
+
+impl ListBoxRow {
+    pub fn new(row_data: &RowData, parent_window: &gtk::Window) -> Self {
+        glib::Object::new(&[("rowdata", &row_data), ("parent-window", &parent_window)]).unwrap()
+    }
+}

--- a/examples/list_box_model/list_box_row/mod.rs
+++ b/examples/list_box_model/list_box_row/mod.rs
@@ -10,7 +10,7 @@ glib::wrapper! {
 }
 
 impl ListBoxRow {
-    pub fn new(row_data: &RowData, parent_window: &gtk::Window) -> Self {
-        glib::Object::new(&[("rowdata", &row_data), ("parent-window", &parent_window)]).unwrap()
+    pub fn new(row_data: &RowData) -> Self {
+        glib::Object::new(&[("row-data", &row_data)]).unwrap()
     }
 }

--- a/examples/list_box_model/main.rs
+++ b/examples/list_box_model/main.rs
@@ -1,0 +1,190 @@
+mod model;
+pub mod row_data;
+
+use gtk::{
+    glib::{self, clone},
+    prelude::*,
+    ResponseType,
+};
+use row_data::RowData;
+
+fn main() {
+    let application = gtk::Application::new(
+        Some("com.github.gtk-rs.examples.listbox-model"),
+        Default::default(),
+    );
+
+    application.connect_activate(build_ui);
+
+    application.run();
+}
+
+fn build_ui(application: &gtk::Application) {
+    let window = gtk::ApplicationWindow::builder()
+        .default_width(320)
+        .default_height(480)
+        .application(application)
+        .title("ListView: Custom Model")
+        .build();
+
+    let vbox = gtk::Box::new(gtk::Orientation::Vertical, 5);
+
+    // Create our list store and specify that the type stored in the
+    // list should be the RowData GObject we define at the bottom
+    let model = model::Model::new();
+
+    // And then create the UI part, the listbox and bind the list store
+    // model to it. Whenever the UI needs to show a new row, e.g. because
+    // it was notified that the model changed, it will call the callback
+    // with the corresponding item from the model and will ask for a new
+    // gtk::ListBoxRow that should be displayed.
+    //
+    // The gtk::ListBoxRow can contain any possible widgets.
+    let listbox = gtk::ListBox::new();
+    listbox.bind_model(Some(&model),
+        clone!(@weak window => @default-panic, move |item| {
+            let box_ = gtk::ListBoxRow::new();
+            let item = item.downcast_ref::<RowData>().expect("Row data is of wrong type");
+
+            let hbox = gtk::Box::new(gtk::Orientation::Horizontal, 5);
+
+            // Create the label and spin button that shows the two values
+            // of the item. We bind the properties for the two values to the
+            // corresponding properties of the widgets so that they are automatically
+            // updated whenever the item is changing. By specifying SYNC_CREATE the
+            // widget will automatically get the initial value of the item set.
+            //
+            // In case of the spin button the binding is bidirectional, that is any
+            // change of value in the spin button will be automatically reflected in
+            // the item.
+            let label = gtk::Label::new(None);
+            item.bind_property("name", &label, "label")
+                .flags(glib::BindingFlags::DEFAULT | glib::BindingFlags::SYNC_CREATE)
+                .build();
+            hbox.append(&label);
+
+            let spin_button = gtk::SpinButton::with_range(0.0, 100.0, 1.0);
+            item.bind_property("count", &spin_button, "value")
+                .flags(glib::BindingFlags::DEFAULT | glib::BindingFlags::SYNC_CREATE | glib::BindingFlags::BIDIRECTIONAL)
+                .build();
+            hbox.append(&spin_button);
+
+            // When the edit button is clicked, a new modal dialog is created for editing
+            // the corresponding row
+            let edit_button = gtk::Button::with_label("Edit");
+            edit_button.connect_clicked(clone!(@weak window, @strong item => move |_| {
+            let dialog = gtk::Dialog::with_buttons(Some("Edit Item"), Some(&window), gtk::DialogFlags::MODAL,
+                &[("Close", ResponseType::Close)]);
+            dialog.set_default_response(ResponseType::Close);
+            dialog.connect_response(|dialog, _| dialog.close());
+
+            let content_area = dialog.content_area();
+
+            // Similarly to the label and spin button inside the listbox, the text entry
+            // and spin button in the edit dialog are connected via property bindings to
+            // the item. Any changes will be immediately reflected inside the item and
+            // by the listbox
+            let entry = gtk::Entry::new();
+            item.bind_property("name", &entry, "text")
+                .flags(glib::BindingFlags::DEFAULT | glib::BindingFlags::SYNC_CREATE | glib::BindingFlags::BIDIRECTIONAL)
+                .build();
+
+            // Activating the entry (enter) will send response `ResponseType::Close` to the dialog
+            entry.connect_activate(clone!(@weak dialog => move |_| {
+                dialog.response(ResponseType::Close);
+            }));
+            content_area.append(&entry);
+
+            let spin_button = gtk::SpinButton::with_range(0.0, 100.0, 1.0);
+            item.bind_property("count", &spin_button, "value")
+                .flags(glib::BindingFlags::DEFAULT | glib::BindingFlags::SYNC_CREATE | glib::BindingFlags::BIDIRECTIONAL)
+                .build();
+            content_area.append(&spin_button);
+
+            dialog.show();
+        }));
+        hbox.append(&edit_button);
+
+        box_.set_child(Some(&hbox));
+
+        // When a row is activated (select + enter) we simply emit the clicked
+        // signal on the corresponding edit button to open the edit dialog
+        box_.connect_activate(clone!(@weak edit_button => move |_| {
+            edit_button.emit_clicked();
+        }));
+
+        box_.show();
+
+        box_.upcast::<gtk::Widget>()
+    }));
+
+    let scrolled_window = gtk::ScrolledWindow::builder()
+        .hscrollbar_policy(gtk::PolicyType::Never) // Disable horizontal scrolling
+        .min_content_height(480)
+        .min_content_width(360)
+        .build();
+
+    scrolled_window.set_child(Some(&listbox));
+
+    let hbox = gtk::Box::new(gtk::Orientation::Horizontal, 5);
+
+    // The add button opens a new dialog which is basically the same as the edit
+    // dialog, except that we don't have a corresponding item yet at that point
+    // and only create it once the Ok button in the dialog is clicked, and only
+    // then add it to the model. Once added to the model, it will immediately
+    // appear in the listbox UI
+    let add_button = gtk::Button::with_label("Add");
+    add_button.connect_clicked(clone!(@weak window, @weak model => move |_| {
+            let dialog = gtk::Dialog::with_buttons(Some("Add Item"), Some(&window), gtk::DialogFlags::MODAL,
+                &[("Ok", ResponseType::Ok), ("Cancel", ResponseType::Cancel)]);
+            dialog.set_default_response(ResponseType::Ok);
+
+            let content_area = dialog.content_area();
+
+            let entry = gtk::Entry::new();
+            entry.connect_activate(clone!(@weak dialog => move |_| {
+                dialog.response(ResponseType::Ok);
+            }));
+            content_area.append(&entry);
+
+            let spin_button = gtk::SpinButton::with_range(0.0, 100.0, 1.0);
+            content_area.append(&spin_button);
+
+            dialog.connect_response(clone!(@weak model, @weak entry, @weak spin_button => move |dialog, resp| {
+                let text = entry.text();
+                if !text.is_empty() && resp == ResponseType::Ok {
+                    model.append(&RowData::new(&text, spin_button.value() as u32));
+                }
+                dialog.close();
+            }));
+
+            dialog.show();
+    }));
+
+    hbox.append(&add_button);
+
+    // Via the delete button we delete the item from the model that
+    // is at the index of the selected row. Also deleting from the
+    // model is immediately reflected in the listbox.
+    let delete_button = gtk::Button::with_label("Delete");
+    delete_button.connect_clicked(clone!(@weak model, @weak listbox => move |_| {
+        let selected = listbox.selected_row();
+
+        if let Some(selected) = selected {
+            let idx = selected.index();
+            model.remove(idx as u32);
+        }
+    }));
+    hbox.append(&delete_button);
+
+    vbox.append(&hbox);
+    vbox.append(&scrolled_window);
+
+    window.set_child(Some(&vbox));
+
+    for i in 0..10 {
+        model.append(&RowData::new(&format!("Name {}", i), i * 10));
+    }
+
+    window.show();
+}

--- a/examples/list_box_model/main.rs
+++ b/examples/list_box_model/main.rs
@@ -1,3 +1,4 @@
+mod list_box_row;
 mod model;
 pub mod row_data;
 
@@ -6,6 +7,7 @@ use gtk::{
     prelude::*,
     ResponseType,
 };
+use list_box_row::ListBoxRow;
 use row_data::RowData;
 
 fn main() {
@@ -24,7 +26,7 @@ fn build_ui(application: &gtk::Application) {
         .default_width(320)
         .default_height(480)
         .application(application)
-        .title("ListView: Custom Model")
+        .title("Custom Model")
         .build();
 
     let vbox = gtk::Box::new(gtk::Orientation::Vertical, 5);
@@ -40,83 +42,19 @@ fn build_ui(application: &gtk::Application) {
     // gtk::ListBoxRow that should be displayed.
     //
     // The gtk::ListBoxRow can contain any possible widgets.
+
     let listbox = gtk::ListBox::new();
-    listbox.bind_model(Some(&model),
+    listbox.bind_model(
+        Some(&model),
         clone!(@weak window => @default-panic, move |item| {
-            let box_ = gtk::ListBoxRow::new();
-            let item = item.downcast_ref::<RowData>().expect("Row data is of wrong type");
-
-            let hbox = gtk::Box::new(gtk::Orientation::Horizontal, 5);
-
-            // Create the label and spin button that shows the two values
-            // of the item. We bind the properties for the two values to the
-            // corresponding properties of the widgets so that they are automatically
-            // updated whenever the item is changing. By specifying SYNC_CREATE the
-            // widget will automatically get the initial value of the item set.
-            //
-            // In case of the spin button the binding is bidirectional, that is any
-            // change of value in the spin button will be automatically reflected in
-            // the item.
-            let label = gtk::Label::new(None);
-            item.bind_property("name", &label, "label")
-                .flags(glib::BindingFlags::DEFAULT | glib::BindingFlags::SYNC_CREATE)
-                .build();
-            hbox.append(&label);
-
-            let spin_button = gtk::SpinButton::with_range(0.0, 100.0, 1.0);
-            item.bind_property("count", &spin_button, "value")
-                .flags(glib::BindingFlags::DEFAULT | glib::BindingFlags::SYNC_CREATE | glib::BindingFlags::BIDIRECTIONAL)
-                .build();
-            hbox.append(&spin_button);
-
-            // When the edit button is clicked, a new modal dialog is created for editing
-            // the corresponding row
-            let edit_button = gtk::Button::with_label("Edit");
-            edit_button.connect_clicked(clone!(@weak window, @strong item => move |_| {
-            let dialog = gtk::Dialog::with_buttons(Some("Edit Item"), Some(&window), gtk::DialogFlags::MODAL,
-                &[("Close", ResponseType::Close)]);
-            dialog.set_default_response(ResponseType::Close);
-            dialog.connect_response(|dialog, _| dialog.close());
-
-            let content_area = dialog.content_area();
-
-            // Similarly to the label and spin button inside the listbox, the text entry
-            // and spin button in the edit dialog are connected via property bindings to
-            // the item. Any changes will be immediately reflected inside the item and
-            // by the listbox
-            let entry = gtk::Entry::new();
-            item.bind_property("name", &entry, "text")
-                .flags(glib::BindingFlags::DEFAULT | glib::BindingFlags::SYNC_CREATE | glib::BindingFlags::BIDIRECTIONAL)
-                .build();
-
-            // Activating the entry (enter) will send response `ResponseType::Close` to the dialog
-            entry.connect_activate(clone!(@weak dialog => move |_| {
-                dialog.response(ResponseType::Close);
-            }));
-            content_area.append(&entry);
-
-            let spin_button = gtk::SpinButton::with_range(0.0, 100.0, 1.0);
-            item.bind_property("count", &spin_button, "value")
-                .flags(glib::BindingFlags::DEFAULT | glib::BindingFlags::SYNC_CREATE | glib::BindingFlags::BIDIRECTIONAL)
-                .build();
-            content_area.append(&spin_button);
-
-            dialog.show();
-        }));
-        hbox.append(&edit_button);
-
-        box_.set_child(Some(&hbox));
-
-        // When a row is activated (select + enter) we simply emit the clicked
-        // signal on the corresponding edit button to open the edit dialog
-        box_.connect_activate(clone!(@weak edit_button => move |_| {
-            edit_button.emit_clicked();
-        }));
-
-        box_.show();
-
-        box_.upcast::<gtk::Widget>()
-    }));
+            ListBoxRow::new(
+                item.downcast_ref::<RowData>()
+                    .expect("RowData is of wrong type"),
+                window.upcast_ref(),
+            )
+            .upcast::<gtk::Widget>()
+        }),
+    );
 
     let scrolled_window = gtk::ScrolledWindow::builder()
         .hscrollbar_policy(gtk::PolicyType::Never) // Disable horizontal scrolling
@@ -135,30 +73,29 @@ fn build_ui(application: &gtk::Application) {
     // appear in the listbox UI
     let add_button = gtk::Button::with_label("Add");
     add_button.connect_clicked(clone!(@weak window, @weak model => move |_| {
-            let dialog = gtk::Dialog::with_buttons(Some("Add Item"), Some(&window), gtk::DialogFlags::MODAL,
-                &[("Ok", ResponseType::Ok), ("Cancel", ResponseType::Cancel)]);
-            dialog.set_default_response(ResponseType::Ok);
+        let dialog = gtk::Dialog::with_buttons(
+            Some("Add Item"),
+            Some(&window),
+            gtk::DialogFlags::MODAL,
+            &[("Ok", ResponseType::Ok), ("Cancel", ResponseType::Cancel)]);
+        dialog.set_default_response(ResponseType::Ok);
+        let content_area = dialog.content_area();
+        let entry = gtk::Entry::new();
+        entry.connect_activate(clone!(@weak dialog => move |_| {
+            dialog.response(ResponseType::Ok);
+        }));
+        content_area.append(&entry);
+        let spin_button = gtk::SpinButton::with_range(0.0, 100.0, 1.0);
+        content_area.append(&spin_button);
+        dialog.connect_response(clone!(@weak model, @weak entry, @weak spin_button => move |dialog, resp| {
+            let text = entry.text();
+            if !text.is_empty() && resp == ResponseType::Ok {
+                model.append(&RowData::new(&text, spin_button.value() as u32));
+            }
+            dialog.close();
+        }));
 
-            let content_area = dialog.content_area();
-
-            let entry = gtk::Entry::new();
-            entry.connect_activate(clone!(@weak dialog => move |_| {
-                dialog.response(ResponseType::Ok);
-            }));
-            content_area.append(&entry);
-
-            let spin_button = gtk::SpinButton::with_range(0.0, 100.0, 1.0);
-            content_area.append(&spin_button);
-
-            dialog.connect_response(clone!(@weak model, @weak entry, @weak spin_button => move |dialog, resp| {
-                let text = entry.text();
-                if !text.is_empty() && resp == ResponseType::Ok {
-                    model.append(&RowData::new(&text, spin_button.value() as u32));
-                }
-                dialog.close();
-            }));
-
-            dialog.show();
+        dialog.show()
     }));
 
     hbox.append(&add_button);

--- a/examples/list_box_model/main.rs
+++ b/examples/list_box_model/main.rs
@@ -76,7 +76,8 @@ fn build_ui(application: &gtk::Application) {
             Some("Add Item"),
             Some(&window),
             gtk::DialogFlags::MODAL,
-            &[("Ok", ResponseType::Ok), ("Cancel", ResponseType::Cancel)]);
+            &[("Ok", ResponseType::Ok), ("Cancel", ResponseType::Cancel)],
+        );
         dialog.set_default_response(ResponseType::Ok);
         let content_area = dialog.content_area();
         let entry = gtk::Entry::new();

--- a/examples/list_box_model/main.rs
+++ b/examples/list_box_model/main.rs
@@ -50,7 +50,6 @@ fn build_ui(application: &gtk::Application) {
             ListBoxRow::new(
                 item.downcast_ref::<RowData>()
                     .expect("RowData is of wrong type"),
-                window.upcast_ref(),
             )
             .upcast::<gtk::Widget>()
         }),

--- a/examples/list_box_model/model/imp.rs
+++ b/examples/list_box_model/model/imp.rs
@@ -1,0 +1,37 @@
+//! Defines the implementation of our model
+
+use gio::subclass::prelude::*;
+use gtk::{gio, glib, prelude::*};
+
+use std::cell::RefCell;
+
+use crate::row_data::RowData;
+
+#[derive(Debug, Default)]
+pub struct Model(pub RefCell<Vec<RowData>>);
+
+/// Basic declaration of our type for the GObject type system
+#[glib::object_subclass]
+impl ObjectSubclass for Model {
+    const NAME: &'static str = "Model";
+    type Type = super::Model;
+    type ParentType = glib::Object;
+    type Interfaces = (gio::ListModel,);
+}
+
+impl ObjectImpl for Model {}
+
+impl ListModelImpl for Model {
+    fn item_type(&self, _list_model: &Self::Type) -> glib::Type {
+        RowData::static_type()
+    }
+    fn n_items(&self, _list_model: &Self::Type) -> u32 {
+        self.0.borrow().len() as u32
+    }
+    fn item(&self, _list_model: &Self::Type, position: u32) -> Option<glib::Object> {
+        self.0
+            .borrow()
+            .get(position as usize)
+            .map(|o| o.clone().upcast::<glib::Object>())
+    }
+}

--- a/examples/list_box_model/model/imp.rs
+++ b/examples/list_box_model/model/imp.rs
@@ -8,7 +8,7 @@ use std::cell::RefCell;
 use crate::row_data::RowData;
 
 #[derive(Debug, Default)]
-pub struct Model(pub RefCell<Vec<RowData>>);
+pub struct Model(pub(super) RefCell<Vec<RowData>>);
 
 /// Basic declaration of our type for the GObject type system
 #[glib::object_subclass]

--- a/examples/list_box_model/model/imp.rs
+++ b/examples/list_box_model/model/imp.rs
@@ -15,7 +15,6 @@ pub struct Model(pub RefCell<Vec<RowData>>);
 impl ObjectSubclass for Model {
     const NAME: &'static str = "Model";
     type Type = super::Model;
-    type ParentType = glib::Object;
     type Interfaces = (gio::ListModel,);
 }
 

--- a/examples/list_box_model/model/mod.rs
+++ b/examples/list_box_model/model/mod.rs
@@ -13,13 +13,12 @@ glib::wrapper! {
 
 // Constructor for new instances. This simply calls glib::Object::new()
 impl Model {
-    #[allow(clippy::new_without_default)]
     pub fn new() -> Model {
         glib::Object::new(&[]).expect("Failed to create Model")
     }
 
     pub fn append(&self, obj: &RowData) {
-        let self_ = imp::Model::from_instance(self);
+        let self_ = self.impl_();
         let index = {
             // Borrow the data only once and ensure the borrow guard is dropped
             // before we emit the items_changed signal because the view
@@ -33,9 +32,15 @@ impl Model {
     }
 
     pub fn remove(&self, index: u32) {
-        let self_ = imp::Model::from_instance(self);
+        let self_ = self.impl_();
         self_.0.borrow_mut().remove(index as usize);
         // Emits a signal that 1 item was removed, 0 added at the position index
         self.items_changed(index, 1, 0);
+    }
+}
+
+impl Default for Model {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/examples/list_box_model/model/mod.rs
+++ b/examples/list_box_model/model/mod.rs
@@ -3,7 +3,6 @@
 mod imp;
 
 use crate::row_data::RowData;
-use glib::subclass::prelude::*;
 use gtk::{gio, glib, prelude::*};
 
 // Public part of the Model type.
@@ -18,12 +17,12 @@ impl Model {
     }
 
     pub fn append(&self, obj: &RowData) {
-        let self_ = self.impl_();
+        let imp = self.imp();
         let index = {
             // Borrow the data only once and ensure the borrow guard is dropped
             // before we emit the items_changed signal because the view
             // could call get_item / get_n_item from the signal handler to update its state
-            let mut data = self_.0.borrow_mut();
+            let mut data = imp.0.borrow_mut();
             data.push(obj.clone());
             data.len() - 1
         };
@@ -32,8 +31,8 @@ impl Model {
     }
 
     pub fn remove(&self, index: u32) {
-        let self_ = self.impl_();
-        self_.0.borrow_mut().remove(index as usize);
+        let imp = self.imp();
+        imp.0.borrow_mut().remove(index as usize);
         // Emits a signal that 1 item was removed, 0 added at the position index
         self.items_changed(index, 1, 0);
     }

--- a/examples/list_box_model/model/mod.rs
+++ b/examples/list_box_model/model/mod.rs
@@ -2,6 +2,8 @@
 
 mod imp;
 
+use gtk::subclass::prelude::*;
+
 use crate::row_data::RowData;
 use gtk::{gio, glib, prelude::*};
 

--- a/examples/list_box_model/model/mod.rs
+++ b/examples/list_box_model/model/mod.rs
@@ -1,0 +1,41 @@
+//! Defines our custom model
+
+mod imp;
+
+use crate::row_data::RowData;
+use glib::subclass::prelude::*;
+use gtk::{gio, glib, prelude::*};
+
+// Public part of the Model type.
+glib::wrapper! {
+    pub struct Model(ObjectSubclass<imp::Model>) @implements gio::ListModel;
+}
+
+// Constructor for new instances. This simply calls glib::Object::new()
+impl Model {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Model {
+        glib::Object::new(&[]).expect("Failed to create Model")
+    }
+
+    pub fn append(&self, obj: &RowData) {
+        let self_ = imp::Model::from_instance(self);
+        let index = {
+            // Borrow the data only once and ensure the borrow guard is dropped
+            // before we emit the items_changed signal because the view
+            // could call get_item / get_n_item from the signal handler to update its state
+            let mut data = self_.0.borrow_mut();
+            data.push(obj.clone());
+            data.len() - 1
+        };
+        // Emits a signal that 1 item was added, 0 removed at the position index
+        self.items_changed(index as u32, 0, 1);
+    }
+
+    pub fn remove(&self, index: u32) {
+        let self_ = imp::Model::from_instance(self);
+        self_.0.borrow_mut().remove(index as usize);
+        // Emits a signal that 1 item was removed, 0 added at the position index
+        self.items_changed(index, 1, 0);
+    }
+}

--- a/examples/list_box_model/row_data/imp.rs
+++ b/examples/list_box_model/row_data/imp.rs
@@ -3,14 +3,14 @@ use gtk::{
     glib::{self, ParamSpec, Value},
     prelude::*,
 };
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 
 // The actual data structure that stores our values. This is not accessible
 // directly from the outside.
 #[derive(Default)]
 pub struct RowData {
     name: RefCell<Option<String>>,
-    count: RefCell<u32>,
+    count: Cell<u32>,
 }
 
 // Basic declaration of our type for the GObject type system
@@ -70,7 +70,7 @@ impl ObjectImpl for RowData {
     fn property(&self, _obj: &Self::Type, _id: usize, pspec: &ParamSpec) -> Value {
         match pspec.name() {
             "name" => self.name.borrow().to_value(),
-            "count" => self.count.borrow().to_value(),
+            "count" => self.count.get().to_value(),
             _ => unimplemented!(),
         }
     }

--- a/examples/list_box_model/row_data/imp.rs
+++ b/examples/list_box_model/row_data/imp.rs
@@ -1,5 +1,8 @@
 use glib::subclass::prelude::*;
-use gtk::{glib, prelude::*};
+use gtk::{
+    glib::{self, ParamSpec, Value},
+    prelude::*,
+};
 use std::cell::RefCell;
 
 // The actual data structure that stores our values. This is not accessible
@@ -15,7 +18,6 @@ pub struct RowData {
 impl ObjectSubclass for RowData {
     const NAME: &'static str = "RowData";
     type Type = super::RowData;
-    type ParentType = glib::Object;
 }
 
 // The ObjectImpl trait provides the setters/getters for GObject properties.
@@ -25,9 +27,9 @@ impl ObjectSubclass for RowData {
 // This maps between the GObject properties and our internal storage of the
 // corresponding values of the properties.
 impl ObjectImpl for RowData {
-    fn properties() -> &'static [glib::ParamSpec] {
+    fn properties() -> &'static [ParamSpec] {
         use once_cell::sync::Lazy;
-        static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
+        static PROPERTIES: Lazy<Vec<ParamSpec>> = Lazy::new(|| {
             vec![
                 glib::ParamSpecString::new(
                     "name",
@@ -51,31 +53,21 @@ impl ObjectImpl for RowData {
         PROPERTIES.as_ref()
     }
 
-    fn set_property(
-        &self,
-        _obj: &Self::Type,
-        _id: usize,
-        value: &glib::Value,
-        pspec: &glib::ParamSpec,
-    ) {
+    fn set_property(&self, _obj: &Self::Type, _id: usize, value: &Value, pspec: &ParamSpec) {
         match pspec.name() {
             "name" => {
-                let name = value
-                    .get()
-                    .expect("type conformity checked by `Object::set_property`");
+                let name = value.get().unwrap();
                 self.name.replace(name);
             }
             "count" => {
-                let count = value
-                    .get()
-                    .expect("type conformity checked by `Object::set_property`");
+                let count = value.get().unwrap();
                 self.count.replace(count);
             }
             _ => unimplemented!(),
         }
     }
 
-    fn property(&self, _obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+    fn property(&self, _obj: &Self::Type, _id: usize, pspec: &ParamSpec) -> Value {
         match pspec.name() {
             "name" => self.name.borrow().to_value(),
             "count" => self.count.borrow().to_value(),

--- a/examples/list_box_model/row_data/imp.rs
+++ b/examples/list_box_model/row_data/imp.rs
@@ -1,0 +1,85 @@
+use glib::subclass::prelude::*;
+use gtk::{glib, prelude::*};
+use std::cell::RefCell;
+
+// The actual data structure that stores our values. This is not accessible
+// directly from the outside.
+#[derive(Default)]
+pub struct RowData {
+    name: RefCell<Option<String>>,
+    count: RefCell<u32>,
+}
+
+// Basic declaration of our type for the GObject type system
+#[glib::object_subclass]
+impl ObjectSubclass for RowData {
+    const NAME: &'static str = "RowData";
+    type Type = super::RowData;
+    type ParentType = glib::Object;
+}
+
+// The ObjectImpl trait provides the setters/getters for GObject properties.
+// Here we need to provide the values that are internally stored back to the
+// caller, or store whatever new value the caller is providing.
+//
+// This maps between the GObject properties and our internal storage of the
+// corresponding values of the properties.
+impl ObjectImpl for RowData {
+    fn properties() -> &'static [glib::ParamSpec] {
+        use once_cell::sync::Lazy;
+        static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
+            vec![
+                glib::ParamSpecString::new(
+                    "name",
+                    "Name",
+                    "Name",
+                    None, // Default value
+                    glib::ParamFlags::READWRITE,
+                ),
+                glib::ParamSpecUInt::new(
+                    "count",
+                    "Count",
+                    "Count",
+                    0,
+                    100,
+                    0, // Allowed range and default value
+                    glib::ParamFlags::READWRITE,
+                ),
+            ]
+        });
+
+        PROPERTIES.as_ref()
+    }
+
+    fn set_property(
+        &self,
+        _obj: &Self::Type,
+        _id: usize,
+        value: &glib::Value,
+        pspec: &glib::ParamSpec,
+    ) {
+        match pspec.name() {
+            "name" => {
+                let name = value
+                    .get()
+                    .expect("type conformity checked by `Object::set_property`");
+                self.name.replace(name);
+            }
+            "count" => {
+                let count = value
+                    .get()
+                    .expect("type conformity checked by `Object::set_property`");
+                self.count.replace(count);
+            }
+            _ => unimplemented!(),
+        }
+    }
+
+    fn property(&self, _obj: &Self::Type, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+        match pspec.name() {
+            "name" => self.name.borrow().to_value(),
+            "count" => self.count.borrow().to_value(),
+            _ => unimplemented!(),
+        }
+    }
+}

--- a/examples/list_box_model/row_data/mod.rs
+++ b/examples/list_box_model/row_data/mod.rs
@@ -1,0 +1,23 @@
+//! Our GObject subclass for carrying a name and count for the ListBox model
+//!
+//! Both name and count are stored in a RefCell to allow for interior mutability
+//! and are exposed via normal GObject properties. This allows us to use property
+//! bindings below to bind the values with what widgets display in the UI
+
+mod imp;
+
+use gtk::glib;
+
+// Public part of the RowData type. This behaves like a normal gtk-rs-style GObject
+// binding
+glib::wrapper! {
+    pub struct RowData(ObjectSubclass<imp::RowData>);
+}
+
+// Constructor for new instances. This simply calls glib::Object::new() with
+// initial values for our two properties and then returns the new instance
+impl RowData {
+    pub fn new(name: &str, count: u32) -> RowData {
+        glib::Object::new(&[("name", &name), ("count", &count)]).expect("Failed to create row data")
+    }
+}


### PR DESCRIPTION
This adapts the [gtk3 list_box_model example](https://github.com/gtk-rs/gtk3-rs/tree/master/examples/list_box_model) to work with gtk4.

Motivation: I asked about custom models in the matrix chat and was pointed to the gtk3 example, and after a short discussion I decided to add a gtk4 example

Note: I did not include a screenshot as gtk uses server-side-decorations on my system, and that'd be inconsistent with every other screenshot in the repo, I think