### PR TITLE
gsk: trust nullability annotations

### DIFF
--- a/examples/scale_bin/scale_bin/imp.rs
+++ b/examples/scale_bin/scale_bin/imp.rs
@@ -70,7 +70,7 @@ impl WidgetImpl for ScaleBin {
     fn size_allocate(&self, widget: &Self::Type, width: i32, height: i32, baseline: i32) {
         let zoom = self.zoom.get() as f32;
 
-        let transform = gsk::Transform::new().scale(zoom, zoom).unwrap();
+        let transform = gsk::Transform::new().scale(zoom, zoom);
 
         widget.first_child().unwrap().allocate(
             (width as f32 / zoom) as i32,

--- a/gdk4-wayland/Gir.toml
+++ b/gdk4-wayland/Gir.toml
@@ -9,6 +9,7 @@ use_gi_docgen = true
 single_version_file = true
 generate_safety_asserts = true
 deprecate_by_min_version = true
+trust_return_value_nullability = true
 
 generate = [
     "GdkWayland.WaylandGLContext",

--- a/gdk4-x11/Gir.toml
+++ b/gdk4-x11/Gir.toml
@@ -158,3 +158,7 @@ status = "generate"
     [[object.function]]
     name = "lookup_for_display"
     manual = true
+    [[object.function]]
+    name = "get_group"
+        [object.function.return]
+        nullable = true # TODO: fix upstream

--- a/gdk4-x11/Gir.toml
+++ b/gdk4-x11/Gir.toml
@@ -9,6 +9,7 @@ use_gi_docgen = true
 single_version_file = true
 generate_safety_asserts = true
 deprecate_by_min_version = true
+trust_return_value_nullability = true
 
 generate = [
     "GdkX11.X11AppLaunchContext",

--- a/gdk4-x11/src/auto/x11_display.rs
+++ b/gdk4-x11/src/auto/x11_display.rs
@@ -45,7 +45,7 @@ impl X11Display {
 
     #[doc(alias = "gdk_x11_display_get_default_group")]
     #[doc(alias = "get_default_group")]
-    pub fn default_group(&self) -> Option<gdk::Surface> {
+    pub fn default_group(&self) -> gdk::Surface {
         unsafe {
             from_glib_none(ffi::gdk_x11_display_get_default_group(
                 self.to_glib_none().0,
@@ -99,7 +99,7 @@ impl X11Display {
 
     #[doc(alias = "gdk_x11_display_get_primary_monitor")]
     #[doc(alias = "get_primary_monitor")]
-    pub fn primary_monitor(&self) -> Option<gdk::Monitor> {
+    pub fn primary_monitor(&self) -> gdk::Monitor {
         unsafe {
             from_glib_none(ffi::gdk_x11_display_get_primary_monitor(
                 self.to_glib_none().0,
@@ -109,13 +109,13 @@ impl X11Display {
 
     #[doc(alias = "gdk_x11_display_get_screen")]
     #[doc(alias = "get_screen")]
-    pub fn screen(&self) -> Option<X11Screen> {
+    pub fn screen(&self) -> X11Screen {
         unsafe { from_glib_none(ffi::gdk_x11_display_get_screen(self.to_glib_none().0)) }
     }
 
     #[doc(alias = "gdk_x11_display_get_startup_notification_id")]
     #[doc(alias = "get_startup_notification_id")]
-    pub fn startup_notification_id(&self) -> Option<glib::GString> {
+    pub fn startup_notification_id(&self) -> glib::GString {
         unsafe {
             from_glib_none(ffi::gdk_x11_display_get_startup_notification_id(
                 self.to_glib_none().0,

--- a/gdk4-x11/src/auto/x11_screen.rs
+++ b/gdk4-x11/src/auto/x11_screen.rs
@@ -40,7 +40,7 @@ impl X11Screen {
 
     #[doc(alias = "gdk_x11_screen_get_window_manager_name")]
     #[doc(alias = "get_window_manager_name")]
-    pub fn window_manager_name(&self) -> Option<glib::GString> {
+    pub fn window_manager_name(&self) -> glib::GString {
         unsafe {
             from_glib_none(ffi::gdk_x11_screen_get_window_manager_name(
                 self.to_glib_none().0,

--- a/gdk4-x11/src/auto/x11_surface.rs
+++ b/gdk4-x11/src/auto/x11_surface.rs
@@ -24,7 +24,7 @@ impl X11Surface {
 
     #[doc(alias = "gdk_x11_surface_get_group")]
     #[doc(alias = "get_group")]
-    pub fn group(&self) -> gdk::Surface {
+    pub fn group(&self) -> Option<gdk::Surface> {
         unsafe { from_glib_none(ffi::gdk_x11_surface_get_group(self.to_glib_none().0)) }
     }
 

--- a/gdk4-x11/src/auto/x11_surface.rs
+++ b/gdk4-x11/src/auto/x11_surface.rs
@@ -24,7 +24,7 @@ impl X11Surface {
 
     #[doc(alias = "gdk_x11_surface_get_group")]
     #[doc(alias = "get_group")]
-    pub fn group(&self) -> Option<gdk::Surface> {
+    pub fn group(&self) -> gdk::Surface {
         unsafe { from_glib_none(ffi::gdk_x11_surface_get_group(self.to_glib_none().0)) }
     }
 

--- a/gsk4/Gir.toml
+++ b/gsk4/Gir.toml
@@ -9,6 +9,7 @@ use_gi_docgen = true
 generate_safety_asserts = true
 single_version_file = true
 deprecate_by_min_version = true
+trust_return_value_nullability = true
 
 generate = [
     "Gsk.BlendMode",

--- a/gsk4/src/auto/blend_node.rs
+++ b/gsk4/src/auto/blend_node.rs
@@ -49,13 +49,13 @@ impl BlendNode {
 
     #[doc(alias = "gsk_blend_node_get_bottom_child")]
     #[doc(alias = "get_bottom_child")]
-    pub fn bottom_child(&self) -> Option<RenderNode> {
+    pub fn bottom_child(&self) -> RenderNode {
         unsafe { from_glib_none(ffi::gsk_blend_node_get_bottom_child(self.to_glib_none().0)) }
     }
 
     #[doc(alias = "gsk_blend_node_get_top_child")]
     #[doc(alias = "get_top_child")]
-    pub fn top_child(&self) -> Option<RenderNode> {
+    pub fn top_child(&self) -> RenderNode {
         unsafe { from_glib_none(ffi::gsk_blend_node_get_top_child(self.to_glib_none().0)) }
     }
 }

--- a/gsk4/src/auto/blur_node.rs
+++ b/gsk4/src/auto/blur_node.rs
@@ -37,7 +37,7 @@ impl BlurNode {
 
     #[doc(alias = "gsk_blur_node_get_child")]
     #[doc(alias = "get_child")]
-    pub fn child(&self) -> Option<RenderNode> {
+    pub fn child(&self) -> RenderNode {
         unsafe { from_glib_none(ffi::gsk_blur_node_get_child(self.to_glib_none().0)) }
     }
 

--- a/gsk4/src/auto/border_node.rs
+++ b/gsk4/src/auto/border_node.rs
@@ -27,7 +27,7 @@ impl glib::StaticType for BorderNode {
 impl BorderNode {
     #[doc(alias = "gsk_border_node_get_outline")]
     #[doc(alias = "get_outline")]
-    pub fn outline(&self) -> Option<RoundedRect> {
+    pub fn outline(&self) -> RoundedRect {
         unsafe { from_glib_none(ffi::gsk_border_node_get_outline(self.to_glib_none().0)) }
     }
 }

--- a/gsk4/src/auto/cairo_node.rs
+++ b/gsk4/src/auto/cairo_node.rs
@@ -32,13 +32,13 @@ impl CairoNode {
 
     #[doc(alias = "gsk_cairo_node_get_draw_context")]
     #[doc(alias = "get_draw_context")]
-    pub fn draw_context(&self) -> Option<cairo::Context> {
+    pub fn draw_context(&self) -> cairo::Context {
         unsafe { from_glib_full(ffi::gsk_cairo_node_get_draw_context(self.to_glib_none().0)) }
     }
 
     #[doc(alias = "gsk_cairo_node_get_surface")]
     #[doc(alias = "get_surface")]
-    pub fn surface(&self) -> Option<cairo::Surface> {
+    pub fn surface(&self) -> cairo::Surface {
         unsafe { from_glib_none(ffi::gsk_cairo_node_get_surface(self.to_glib_none().0)) }
     }
 }

--- a/gsk4/src/auto/clip_node.rs
+++ b/gsk4/src/auto/clip_node.rs
@@ -37,13 +37,13 @@ impl ClipNode {
 
     #[doc(alias = "gsk_clip_node_get_child")]
     #[doc(alias = "get_child")]
-    pub fn child(&self) -> Option<RenderNode> {
+    pub fn child(&self) -> RenderNode {
         unsafe { from_glib_none(ffi::gsk_clip_node_get_child(self.to_glib_none().0)) }
     }
 
     #[doc(alias = "gsk_clip_node_get_clip")]
     #[doc(alias = "get_clip")]
-    pub fn clip(&self) -> Option<graphene::Rect> {
+    pub fn clip(&self) -> graphene::Rect {
         unsafe { from_glib_none(ffi::gsk_clip_node_get_clip(self.to_glib_none().0)) }
     }
 }

--- a/gsk4/src/auto/color_matrix_node.rs
+++ b/gsk4/src/auto/color_matrix_node.rs
@@ -42,13 +42,13 @@ impl ColorMatrixNode {
 
     #[doc(alias = "gsk_color_matrix_node_get_child")]
     #[doc(alias = "get_child")]
-    pub fn child(&self) -> Option<RenderNode> {
+    pub fn child(&self) -> RenderNode {
         unsafe { from_glib_none(ffi::gsk_color_matrix_node_get_child(self.to_glib_none().0)) }
     }
 
     #[doc(alias = "gsk_color_matrix_node_get_color_matrix")]
     #[doc(alias = "get_color_matrix")]
-    pub fn color_matrix(&self) -> Option<graphene::Matrix> {
+    pub fn color_matrix(&self) -> graphene::Matrix {
         unsafe {
             from_glib_none(ffi::gsk_color_matrix_node_get_color_matrix(
                 self.to_glib_none().0,
@@ -58,7 +58,7 @@ impl ColorMatrixNode {
 
     #[doc(alias = "gsk_color_matrix_node_get_color_offset")]
     #[doc(alias = "get_color_offset")]
-    pub fn color_offset(&self) -> Option<graphene::Vec4> {
+    pub fn color_offset(&self) -> graphene::Vec4 {
         unsafe {
             from_glib_none(ffi::gsk_color_matrix_node_get_color_offset(
                 self.to_glib_none().0,

--- a/gsk4/src/auto/color_node.rs
+++ b/gsk4/src/auto/color_node.rs
@@ -37,7 +37,7 @@ impl ColorNode {
 
     #[doc(alias = "gsk_color_node_get_color")]
     #[doc(alias = "get_color")]
-    pub fn color(&self) -> Option<gdk::RGBA> {
+    pub fn color(&self) -> gdk::RGBA {
         unsafe { from_glib_none(ffi::gsk_color_node_get_color(self.to_glib_none().0)) }
     }
 }

--- a/gsk4/src/auto/conic_gradient_node.rs
+++ b/gsk4/src/auto/conic_gradient_node.rs
@@ -56,7 +56,7 @@ impl ConicGradientNode {
 
     #[doc(alias = "gsk_conic_gradient_node_get_center")]
     #[doc(alias = "get_center")]
-    pub fn center(&self) -> Option<graphene::Point> {
+    pub fn center(&self) -> graphene::Point {
         unsafe {
             from_glib_none(ffi::gsk_conic_gradient_node_get_center(
                 self.to_glib_none().0,

--- a/gsk4/src/auto/cross_fade_node.rs
+++ b/gsk4/src/auto/cross_fade_node.rs
@@ -42,7 +42,7 @@ impl CrossFadeNode {
 
     #[doc(alias = "gsk_cross_fade_node_get_end_child")]
     #[doc(alias = "get_end_child")]
-    pub fn end_child(&self) -> Option<RenderNode> {
+    pub fn end_child(&self) -> RenderNode {
         unsafe {
             from_glib_none(ffi::gsk_cross_fade_node_get_end_child(
                 self.to_glib_none().0,
@@ -58,7 +58,7 @@ impl CrossFadeNode {
 
     #[doc(alias = "gsk_cross_fade_node_get_start_child")]
     #[doc(alias = "get_start_child")]
-    pub fn start_child(&self) -> Option<RenderNode> {
+    pub fn start_child(&self) -> RenderNode {
         unsafe {
             from_glib_none(ffi::gsk_cross_fade_node_get_start_child(
                 self.to_glib_none().0,

--- a/gsk4/src/auto/debug_node.rs
+++ b/gsk4/src/auto/debug_node.rs
@@ -37,13 +37,13 @@ impl DebugNode {
 
     #[doc(alias = "gsk_debug_node_get_child")]
     #[doc(alias = "get_child")]
-    pub fn child(&self) -> Option<RenderNode> {
+    pub fn child(&self) -> RenderNode {
         unsafe { from_glib_none(ffi::gsk_debug_node_get_child(self.to_glib_none().0)) }
     }
 
     #[doc(alias = "gsk_debug_node_get_message")]
     #[doc(alias = "get_message")]
-    pub fn message(&self) -> Option<glib::GString> {
+    pub fn message(&self) -> glib::GString {
         unsafe { from_glib_none(ffi::gsk_debug_node_get_message(self.to_glib_none().0)) }
     }
 }

--- a/gsk4/src/auto/gl_shader.rs
+++ b/gsk4/src/auto/gl_shader.rs
@@ -137,13 +137,13 @@ impl GLShader {
 
     #[doc(alias = "gsk_gl_shader_get_source")]
     #[doc(alias = "get_source")]
-    pub fn source(&self) -> Option<glib::Bytes> {
+    pub fn source(&self) -> glib::Bytes {
         unsafe { from_glib_none(ffi::gsk_gl_shader_get_source(self.to_glib_none().0)) }
     }
 
     #[doc(alias = "gsk_gl_shader_get_uniform_name")]
     #[doc(alias = "get_uniform_name")]
-    pub fn uniform_name(&self, idx: i32) -> Option<glib::GString> {
+    pub fn uniform_name(&self, idx: i32) -> glib::GString {
         unsafe {
             from_glib_none(ffi::gsk_gl_shader_get_uniform_name(
                 self.to_glib_none().0,

--- a/gsk4/src/auto/gl_shader_node.rs
+++ b/gsk4/src/auto/gl_shader_node.rs
@@ -47,7 +47,7 @@ impl GLShaderNode {
 
     #[doc(alias = "gsk_gl_shader_node_get_args")]
     #[doc(alias = "get_args")]
-    pub fn args(&self) -> Option<glib::Bytes> {
+    pub fn args(&self) -> glib::Bytes {
         unsafe { from_glib_none(ffi::gsk_gl_shader_node_get_args(self.to_glib_none().0)) }
     }
 
@@ -59,7 +59,7 @@ impl GLShaderNode {
 
     #[doc(alias = "gsk_gl_shader_node_get_shader")]
     #[doc(alias = "get_shader")]
-    pub fn shader(&self) -> Option<GLShader> {
+    pub fn shader(&self) -> GLShader {
         unsafe { from_glib_none(ffi::gsk_gl_shader_node_get_shader(self.to_glib_none().0)) }
     }
 }

--- a/gsk4/src/auto/inset_shadow_node.rs
+++ b/gsk4/src/auto/inset_shadow_node.rs
@@ -55,7 +55,7 @@ impl InsetShadowNode {
 
     #[doc(alias = "gsk_inset_shadow_node_get_color")]
     #[doc(alias = "get_color")]
-    pub fn color(&self) -> Option<gdk::RGBA> {
+    pub fn color(&self) -> gdk::RGBA {
         unsafe { from_glib_none(ffi::gsk_inset_shadow_node_get_color(self.to_glib_none().0)) }
     }
 
@@ -73,7 +73,7 @@ impl InsetShadowNode {
 
     #[doc(alias = "gsk_inset_shadow_node_get_outline")]
     #[doc(alias = "get_outline")]
-    pub fn outline(&self) -> Option<RoundedRect> {
+    pub fn outline(&self) -> RoundedRect {
         unsafe {
             from_glib_none(ffi::gsk_inset_shadow_node_get_outline(
                 self.to_glib_none().0,

--- a/gsk4/src/auto/linear_gradient_node.rs
+++ b/gsk4/src/auto/linear_gradient_node.rs
@@ -64,7 +64,7 @@ impl LinearGradientNode {
 
     #[doc(alias = "gsk_linear_gradient_node_get_end")]
     #[doc(alias = "get_end")]
-    pub fn end(&self) -> Option<graphene::Point> {
+    pub fn end(&self) -> graphene::Point {
         unsafe { from_glib_none(ffi::gsk_linear_gradient_node_get_end(self.to_glib_none().0)) }
     }
 
@@ -76,7 +76,7 @@ impl LinearGradientNode {
 
     #[doc(alias = "gsk_linear_gradient_node_get_start")]
     #[doc(alias = "get_start")]
-    pub fn start(&self) -> Option<graphene::Point> {
+    pub fn start(&self) -> graphene::Point {
         unsafe {
             from_glib_none(ffi::gsk_linear_gradient_node_get_start(
                 self.to_glib_none().0,

--- a/gsk4/src/auto/opacity_node.rs
+++ b/gsk4/src/auto/opacity_node.rs
@@ -37,7 +37,7 @@ impl OpacityNode {
 
     #[doc(alias = "gsk_opacity_node_get_child")]
     #[doc(alias = "get_child")]
-    pub fn child(&self) -> Option<RenderNode> {
+    pub fn child(&self) -> RenderNode {
         unsafe { from_glib_none(ffi::gsk_opacity_node_get_child(self.to_glib_none().0)) }
     }
 

--- a/gsk4/src/auto/outset_shadow_node.rs
+++ b/gsk4/src/auto/outset_shadow_node.rs
@@ -55,7 +55,7 @@ impl OutsetShadowNode {
 
     #[doc(alias = "gsk_outset_shadow_node_get_color")]
     #[doc(alias = "get_color")]
-    pub fn color(&self) -> Option<gdk::RGBA> {
+    pub fn color(&self) -> gdk::RGBA {
         unsafe { from_glib_none(ffi::gsk_outset_shadow_node_get_color(self.to_glib_none().0)) }
     }
 
@@ -73,7 +73,7 @@ impl OutsetShadowNode {
 
     #[doc(alias = "gsk_outset_shadow_node_get_outline")]
     #[doc(alias = "get_outline")]
-    pub fn outline(&self) -> Option<RoundedRect> {
+    pub fn outline(&self) -> RoundedRect {
         unsafe {
             from_glib_none(ffi::gsk_outset_shadow_node_get_outline(
                 self.to_glib_none().0,

--- a/gsk4/src/auto/radial_gradient_node.rs
+++ b/gsk4/src/auto/radial_gradient_node.rs
@@ -54,7 +54,7 @@ impl RadialGradientNode {
 
     #[doc(alias = "gsk_radial_gradient_node_get_center")]
     #[doc(alias = "get_center")]
-    pub fn center(&self) -> Option<graphene::Point> {
+    pub fn center(&self) -> graphene::Point {
         unsafe {
             from_glib_none(ffi::gsk_radial_gradient_node_get_center(
                 self.to_glib_none().0,

--- a/gsk4/src/auto/render_node.rs
+++ b/gsk4/src/auto/render_node.rs
@@ -61,7 +61,7 @@ impl RenderNode {
     }
 
     #[doc(alias = "gsk_render_node_serialize")]
-    pub fn serialize(&self) -> Option<glib::Bytes> {
+    pub fn serialize(&self) -> glib::Bytes {
         unsafe {
             from_glib_full(ffi::gsk_render_node_serialize(
                 self.as_ref().to_glib_none().0,

--- a/gsk4/src/auto/renderer.rs
+++ b/gsk4/src/auto/renderer.rs
@@ -52,7 +52,7 @@ pub trait GskRendererExt: 'static {
         &self,
         root: impl AsRef<RenderNode>,
         viewport: Option<&graphene::Rect>,
-    ) -> Option<gdk::Texture>;
+    ) -> gdk::Texture;
 
     #[doc(alias = "gsk_renderer_unrealize")]
     fn unrealize(&self);
@@ -112,7 +112,7 @@ impl<O: IsA<Renderer>> GskRendererExt for O {
         &self,
         root: impl AsRef<RenderNode>,
         viewport: Option<&graphene::Rect>,
-    ) -> Option<gdk::Texture> {
+    ) -> gdk::Texture {
         unsafe {
             from_glib_full(ffi::gsk_renderer_render_texture(
                 self.as_ref().to_glib_none().0,

--- a/gsk4/src/auto/repeat_node.rs
+++ b/gsk4/src/auto/repeat_node.rs
@@ -42,13 +42,13 @@ impl RepeatNode {
 
     #[doc(alias = "gsk_repeat_node_get_child")]
     #[doc(alias = "get_child")]
-    pub fn child(&self) -> Option<RenderNode> {
+    pub fn child(&self) -> RenderNode {
         unsafe { from_glib_none(ffi::gsk_repeat_node_get_child(self.to_glib_none().0)) }
     }
 
     #[doc(alias = "gsk_repeat_node_get_child_bounds")]
     #[doc(alias = "get_child_bounds")]
-    pub fn child_bounds(&self) -> Option<graphene::Rect> {
+    pub fn child_bounds(&self) -> graphene::Rect {
         unsafe { from_glib_none(ffi::gsk_repeat_node_get_child_bounds(self.to_glib_none().0)) }
     }
 }

--- a/gsk4/src/auto/rounded_clip_node.rs
+++ b/gsk4/src/auto/rounded_clip_node.rs
@@ -38,13 +38,13 @@ impl RoundedClipNode {
 
     #[doc(alias = "gsk_rounded_clip_node_get_child")]
     #[doc(alias = "get_child")]
-    pub fn child(&self) -> Option<RenderNode> {
+    pub fn child(&self) -> RenderNode {
         unsafe { from_glib_none(ffi::gsk_rounded_clip_node_get_child(self.to_glib_none().0)) }
     }
 
     #[doc(alias = "gsk_rounded_clip_node_get_clip")]
     #[doc(alias = "get_clip")]
-    pub fn clip(&self) -> Option<RoundedRect> {
+    pub fn clip(&self) -> RoundedRect {
         unsafe { from_glib_none(ffi::gsk_rounded_clip_node_get_clip(self.to_glib_none().0)) }
     }
 }

--- a/gsk4/src/auto/shader_args_builder.rs
+++ b/gsk4/src/auto/shader_args_builder.rs
@@ -90,7 +90,7 @@ impl ShaderArgsBuilder {
     }
 
     #[doc(alias = "gsk_shader_args_builder_to_args")]
-    pub fn to_args(&self) -> Option<glib::Bytes> {
+    pub fn to_args(&self) -> glib::Bytes {
         unsafe { from_glib_full(ffi::gsk_shader_args_builder_to_args(self.to_glib_none().0)) }
     }
 }

--- a/gsk4/src/auto/shadow_node.rs
+++ b/gsk4/src/auto/shadow_node.rs
@@ -40,7 +40,7 @@ impl ShadowNode {
 
     #[doc(alias = "gsk_shadow_node_get_child")]
     #[doc(alias = "get_child")]
-    pub fn child(&self) -> Option<RenderNode> {
+    pub fn child(&self) -> RenderNode {
         unsafe { from_glib_none(ffi::gsk_shadow_node_get_child(self.to_glib_none().0)) }
     }
 

--- a/gsk4/src/auto/text_node.rs
+++ b/gsk4/src/auto/text_node.rs
@@ -46,13 +46,13 @@ impl TextNode {
 
     #[doc(alias = "gsk_text_node_get_color")]
     #[doc(alias = "get_color")]
-    pub fn color(&self) -> Option<gdk::RGBA> {
+    pub fn color(&self) -> gdk::RGBA {
         unsafe { from_glib_none(ffi::gsk_text_node_get_color(self.to_glib_none().0)) }
     }
 
     #[doc(alias = "gsk_text_node_get_font")]
     #[doc(alias = "get_font")]
-    pub fn font(&self) -> Option<pango::Font> {
+    pub fn font(&self) -> pango::Font {
         unsafe { from_glib_none(ffi::gsk_text_node_get_font(self.to_glib_none().0)) }
     }
 
@@ -77,7 +77,7 @@ impl TextNode {
 
     #[doc(alias = "gsk_text_node_get_offset")]
     #[doc(alias = "get_offset")]
-    pub fn offset(&self) -> Option<graphene::Point> {
+    pub fn offset(&self) -> graphene::Point {
         unsafe { from_glib_none(ffi::gsk_text_node_get_offset(self.to_glib_none().0)) }
     }
 

--- a/gsk4/src/auto/texture_node.rs
+++ b/gsk4/src/auto/texture_node.rs
@@ -38,7 +38,7 @@ impl TextureNode {
 
     #[doc(alias = "gsk_texture_node_get_texture")]
     #[doc(alias = "get_texture")]
-    pub fn texture(&self) -> Option<gdk::Texture> {
+    pub fn texture(&self) -> gdk::Texture {
         unsafe { from_glib_none(ffi::gsk_texture_node_get_texture(self.to_glib_none().0)) }
     }
 }

--- a/gsk4/src/auto/transform.rs
+++ b/gsk4/src/auto/transform.rs
@@ -47,7 +47,7 @@ impl Transform {
     }
 
     #[doc(alias = "gsk_transform_matrix")]
-    pub fn matrix(&self, matrix: &graphene::Matrix) -> Option<Transform> {
+    pub fn matrix(&self, matrix: &graphene::Matrix) -> Transform {
         unsafe {
             from_glib_full(ffi::gsk_transform_matrix(
                 self.to_glib_full(),
@@ -57,17 +57,17 @@ impl Transform {
     }
 
     #[doc(alias = "gsk_transform_perspective")]
-    pub fn perspective(&self, depth: f32) -> Option<Transform> {
+    pub fn perspective(&self, depth: f32) -> Transform {
         unsafe { from_glib_full(ffi::gsk_transform_perspective(self.to_glib_full(), depth)) }
     }
 
     #[doc(alias = "gsk_transform_rotate")]
-    pub fn rotate(&self, angle: f32) -> Option<Transform> {
+    pub fn rotate(&self, angle: f32) -> Transform {
         unsafe { from_glib_full(ffi::gsk_transform_rotate(self.to_glib_full(), angle)) }
     }
 
     #[doc(alias = "gsk_transform_rotate_3d")]
-    pub fn rotate_3d(&self, angle: f32, axis: &graphene::Vec3) -> Option<Transform> {
+    pub fn rotate_3d(&self, angle: f32, axis: &graphene::Vec3) -> Transform {
         unsafe {
             from_glib_full(ffi::gsk_transform_rotate_3d(
                 self.to_glib_full(),
@@ -78,7 +78,7 @@ impl Transform {
     }
 
     #[doc(alias = "gsk_transform_scale")]
-    pub fn scale(&self, factor_x: f32, factor_y: f32) -> Option<Transform> {
+    pub fn scale(&self, factor_x: f32, factor_y: f32) -> Transform {
         unsafe {
             from_glib_full(ffi::gsk_transform_scale(
                 self.to_glib_full(),
@@ -89,7 +89,7 @@ impl Transform {
     }
 
     #[doc(alias = "gsk_transform_scale_3d")]
-    pub fn scale_3d(&self, factor_x: f32, factor_y: f32, factor_z: f32) -> Option<Transform> {
+    pub fn scale_3d(&self, factor_x: f32, factor_y: f32, factor_z: f32) -> Transform {
         unsafe {
             from_glib_full(ffi::gsk_transform_scale_3d(
                 self.to_glib_full(),
@@ -103,7 +103,7 @@ impl Transform {
     #[cfg(any(feature = "v4_6", feature = "dox"))]
     #[cfg_attr(feature = "dox", doc(cfg(feature = "v4_6")))]
     #[doc(alias = "gsk_transform_skew")]
-    pub fn skew(&self, skew_x: f32, skew_y: f32) -> Option<Transform> {
+    pub fn skew(&self, skew_x: f32, skew_y: f32) -> Transform {
         unsafe { from_glib_full(ffi::gsk_transform_skew(self.to_glib_full(), skew_x, skew_y)) }
     }
 
@@ -230,7 +230,7 @@ impl Transform {
     }
 
     #[doc(alias = "gsk_transform_transform")]
-    pub fn transform(&self, other: Option<&Transform>) -> Option<Transform> {
+    pub fn transform(&self, other: Option<&Transform>) -> Transform {
         unsafe {
             from_glib_full(ffi::gsk_transform_transform(
                 self.to_glib_full(),
@@ -266,7 +266,7 @@ impl Transform {
     }
 
     #[doc(alias = "gsk_transform_translate")]
-    pub fn translate(&self, point: &graphene::Point) -> Option<Transform> {
+    pub fn translate(&self, point: &graphene::Point) -> Transform {
         unsafe {
             from_glib_full(ffi::gsk_transform_translate(
                 self.to_glib_full(),
@@ -276,7 +276,7 @@ impl Transform {
     }
 
     #[doc(alias = "gsk_transform_translate_3d")]
-    pub fn translate_3d(&self, point: &graphene::Point3D) -> Option<Transform> {
+    pub fn translate_3d(&self, point: &graphene::Point3D) -> Transform {
         unsafe {
             from_glib_full(ffi::gsk_transform_translate_3d(
                 self.to_glib_full(),

--- a/gsk4/src/auto/transform_node.rs
+++ b/gsk4/src/auto/transform_node.rs
@@ -38,13 +38,13 @@ impl TransformNode {
 
     #[doc(alias = "gsk_transform_node_get_child")]
     #[doc(alias = "get_child")]
-    pub fn child(&self) -> Option<RenderNode> {
+    pub fn child(&self) -> RenderNode {
         unsafe { from_glib_none(ffi::gsk_transform_node_get_child(self.to_glib_none().0)) }
     }
 
     #[doc(alias = "gsk_transform_node_get_transform")]
     #[doc(alias = "get_transform")]
-    pub fn transform(&self) -> Option<Transform> {
+    pub fn transform(&self) -> Transform {
         unsafe { from_glib_none(ffi::gsk_transform_node_get_transform(self.to_glib_none().0)) }
     }
 }

--- a/gsk4/src/container_node.rs
+++ b/gsk4/src/container_node.rs
@@ -12,7 +12,7 @@ define_render_node!(
 impl ContainerNode {
     #[doc(alias = "gsk_container_node_get_child")]
     #[doc(alias = "get_child")]
-    pub fn child(&self, idx: u32) -> Option<RenderNode> {
+    pub fn child(&self, idx: u32) -> RenderNode {
         assert!(idx < self.n_children());
         unsafe {
             from_glib_none(ffi::gsk_container_node_get_child(

--- a/gsk4/src/gl_shader_node.rs
+++ b/gsk4/src/gl_shader_node.rs
@@ -12,7 +12,7 @@ define_render_node!(
 impl GLShaderNode {
     #[doc(alias = "gsk_gl_shader_node_get_child")]
     #[doc(alias = "get_child")]
-    pub fn child(&self, idx: u32) -> Option<RenderNode> {
+    pub fn child(&self, idx: u32) -> RenderNode {
         assert!(idx < self.n_children());
         unsafe {
             from_glib_none(ffi::gsk_gl_shader_node_get_child(

--- a/gsk4/src/shadow_node.rs
+++ b/gsk4/src/shadow_node.rs
@@ -7,7 +7,7 @@ define_render_node!(ShadowNode, ffi::GskShadowNode, RenderNodeType::ShadowNode);
 impl ShadowNode {
     #[doc(alias = "gsk_shadow_node_get_shadow")]
     #[doc(alias = "get_shadow")]
-    pub fn shadow(&self, i: usize) -> Option<Shadow> {
+    pub fn shadow(&self, i: usize) -> Shadow {
         assert!(i < self.n_shadows());
         unsafe { from_glib_none(ffi::gsk_shadow_node_get_shadow(self.to_glib_none().0, i)) }
     }


### PR DESCRIPTION
The methods were checked one by one. The ones in RenderNode types, all take a not nullable param, so the getter shouldn't be nullable neither. 

Part of #68, before merging this; i will probably do gdk4-wayland/gdk4-x11 as those are small enough