### PR TITLE
CI: Stop passing manifest path to windows build

### DIFF
--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -80,15 +80,15 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: build
-        args: --manifest-path ./gtk4/Cargo.toml --features v4_6 # investigate why --workspace builds gdk4-wayland
+        args: --features v4_6
     - name: Clippy
       uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: --manifest-path ./gtk4/Cargo.toml --features v4_6 # investigate why --workspace builds gdk4-wayland
+        args: --features v4_6
     - name: Tests
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --manifest-path ./gtk4/Cargo.toml --features v4_6 # investigate why --workspace builds gdk4-wayland
+        args: --features v4_6
 


### PR DESCRIPTION
I want to check which crates are built in this case.