### PR TITLE
book: Fix error message for `activate_action`

### DIFF
--- a/book/listings/actions/3/main.rs
+++ b/book/listings/actions/3/main.rs
@@ -69,7 +69,7 @@ fn build_ui(app: &Application) {
         let parameter = 1;
         button
             .activate_action("win.count", Some(&parameter.to_variant()))
-            .expect("The action could not be activated.");
+            .expect("The action does not exist.");
     });
 
     // Create a `gtk::Box` and add `button` and `label` to it


### PR DESCRIPTION
@bilelmoussaoui  can [this](https://gtk-rs.org/gtk4-rs/git/docs/gtk4/prelude/trait.WidgetExt.html#returns-1) part or the whole docs be overriden?