### PR TITLE
Point to git 0.15 versions of the gtk-rs-core dependencies

### DIFF
--- a/gdk4-wayland/Cargo.toml
+++ b/gdk4-wayland/Cargo.toml
@@ -25,8 +25,8 @@ features = ["dox"]
 [dependencies]
 ffi = {path = "./sys", package = "gdk4-wayland-sys", version = "0.4.1"}
 gdk = {path = "../gdk4", package = "gdk4", version = "0.4.1"}
-gio = {version = "0.15.1", features = ["v2_66"]}
-glib = {version = "0.15.1", features = ["v2_66"]}
+gio = {version = "0.15.1", features = ["v2_66"], git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15"}
+glib = {version = "0.15.1", features = ["v2_66"], git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15"}
 libc = "0.2"
 wayland-client = {version = "0.29", features = ["use_system_lib"], optional = true}
 khronos-egl = {version = "4.1.0", optional = true}

--- a/gdk4-wayland/sys/Cargo.toml
+++ b/gdk4-wayland/sys/Cargo.toml
@@ -11,14 +11,12 @@ name = "gdk4-wayland-sys"
 repository = "https://github.com/gtk-rs/gtk4-rs"
 version = "0.4.1"
 rust-version = "1.56"
-
 [package.metadata.system-deps.gtk4_wayland]
 name = "gtk4-wayland"
 version = "4.0.0"
 
 [package.metadata.system-deps.gtk4_wayland.v4_4]
 version = "4.3.2"
-
 [package.metadata.docs.rs]
 features = ["dox"]
 

--- a/gdk4-wayland/sys/Cargo.toml
+++ b/gdk4-wayland/sys/Cargo.toml
@@ -35,6 +35,8 @@ libc = "0.2"
 [dependencies.glib]
 package = "glib-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [build-dependencies]
 system-deps = "6"

--- a/gdk4-x11/Cargo.toml
+++ b/gdk4-x11/Cargo.toml
@@ -24,8 +24,8 @@ features = ["dox"]
 [dependencies]
 ffi = {path = "./sys", package = "gdk4-x11-sys", version = "0.4.1"}
 gdk = {path = "../gdk4", package = "gdk4", version = "0.4.1"}
-gio = {features = ["v2_66"], version = "0.15.1"}
-glib = {features = ["v2_66"], version = "0.15.1"}
+gio = {features = ["v2_66"], version = "0.15.1", git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15"}
+glib = {features = ["v2_66"], version = "0.15.1", git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15"}
 libc = "0.2"
 x11 = {version = "2.18", optional = true }
 khronos-egl = {version = "4.1.0", optional = true}

--- a/gdk4-x11/sys/Cargo.toml
+++ b/gdk4-x11/sys/Cargo.toml
@@ -40,6 +40,8 @@ version = "0.4.1"
 [dependencies.glib]
 package = "glib-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [build-dependencies]
 system-deps = "6"

--- a/gdk4-x11/sys/Cargo.toml
+++ b/gdk4-x11/sys/Cargo.toml
@@ -11,14 +11,12 @@ name = "gdk4-x11-sys"
 repository = "https://github.com/gtk-rs/gtk4-rs"
 version = "0.4.1"
 rust-version = "1.56"
-
 [package.metadata.system-deps.gtk4_x11]
 name = "gtk4-x11"
 version = "4.0.0"
 
 [package.metadata.system-deps.gtk4_x11.v4_4]
 version = "4.3.2"
-
 [package.metadata.docs.rs]
 features = ["dox"]
 

--- a/gdk4/Cargo.toml
+++ b/gdk4/Cargo.toml
@@ -26,13 +26,13 @@ features = ["dox"]
 
 [dependencies]
 bitflags = "1.0"
-cairo-rs = "0.15.1"
+cairo-rs = {version ="0.15.1", git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15" }
 ffi = {package = "gdk4-sys", path = "./sys", version = "0.4.1"}
-gdk-pixbuf = "0.15.1"
-gio = {version = "0.15.1", features = ["v2_66"]}
-glib = {version = "0.15.1", features = ["v2_66"]}
+gdk-pixbuf = {version = "0.15.1", git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15" }
+gio = {version = "0.15.1", features = ["v2_66"], git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15"}
+glib = {version = "0.15.1", features = ["v2_66"], git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15"}
 libc = "0.2"
-pango = {version = "0.15.1", features = ["v1_46"]}
+pango = {version = "0.15.1", features = ["v1_46"], git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15"}
 
 [dev-dependencies]
 gir-format-check = "^0.1"

--- a/gdk4/sys/Cargo.toml
+++ b/gdk4/sys/Cargo.toml
@@ -11,10 +11,8 @@ name = "gdk4-sys"
 repository = "https://github.com/gtk-rs/gtk4-rs"
 version = "0.4.1"
 rust-version = "1.56"
-
 [package.metadata.docs.rs]
 features = ["dox"]
-
 [package.metadata.system-deps.gtk4]
 name = "gtk4"
 version = "4.0.0"

--- a/gdk4/sys/Cargo.toml
+++ b/gdk4/sys/Cargo.toml
@@ -43,26 +43,38 @@ libc = "0.2"
 [dependencies.cairo]
 package = "cairo-sys-rs"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.gdk-pixbuf]
 package = "gdk-pixbuf-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.gio]
 package = "gio-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.glib]
 package = "glib-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.gobject]
 package = "gobject-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.pango]
 package = "pango-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [build-dependencies]
 system-deps = "6"

--- a/gsk4/Cargo.toml
+++ b/gsk4/Cargo.toml
@@ -27,13 +27,13 @@ features = ["dox"]
 
 [dependencies]
 bitflags = "1.0"
-cairo-rs = "0.15.1"
+cairo-rs = {version = "0.15.1", git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15" }
 ffi = {package = "gsk4-sys", path = "./sys", version = "0.4.1"}
 gdk = {package = "gdk4", path = "../gdk4", version = "0.4.1"}
-glib = {features = ["v2_66"], version = "0.15.1"}
-graphene = {package = "graphene-rs", version = "0.15.1"}
+glib = {features = ["v2_66"], version = "0.15.1", git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15"}
+graphene = {package = "graphene-rs", version = "0.15.1", git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15"}
 libc = "0.2"
-pango = {features = ["v1_46"], version = "0.15.1"}
+pango = {features = ["v1_46"], version = "0.15.1", git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15"}
 
 [dev-dependencies]
 gir-format-check = "^0.1"

--- a/gsk4/sys/Cargo.toml
+++ b/gsk4/sys/Cargo.toml
@@ -11,10 +11,8 @@ name = "gsk4-sys"
 repository = "https://github.com/gtk-rs/gtk4-rs"
 version = "0.4.1"
 rust-version = "1.56"
-
 [package.metadata.docs.rs]
 features = ["dox"]
-
 [package.metadata.system-deps.gtk4]
 name = "gtk4"
 version = "4.0.0"

--- a/gsk4/sys/Cargo.toml
+++ b/gsk4/sys/Cargo.toml
@@ -43,6 +43,8 @@ libc = "0.2"
 [dependencies.cairo]
 package = "cairo-sys-rs"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.gdk]
 package = "gdk4-sys"
@@ -52,18 +54,26 @@ version = "0.4.1"
 [dependencies.glib]
 package = "glib-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.gobject]
 package = "gobject-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.graphene]
 package = "graphene-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.pango]
 package = "pango-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [build-dependencies]
 system-deps = "6"

--- a/gtk4/Cargo.toml
+++ b/gtk4/Cargo.toml
@@ -27,20 +27,20 @@ features = ["dox"]
 
 [dependencies]
 bitflags = "1.0"
-cairo-rs = "0.15.1"
+cairo-rs = {version = "0.15.1", git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15" }
 ffi = {package = "gtk4-sys", path = "./sys", version = "0.4.1"}
 field-offset = "0.3"
 futures-channel = "0.3"
 gdk = {package = "gdk4", path = "../gdk4", version = "0.4.1"}
-gdk-pixbuf = "0.15.1"
-gio = {features = ["v2_66"], version = "0.15.1"}
-glib = {features = ["v2_66"], version = "0.15.1"}
-graphene = {package = "graphene-rs", version = "0.15.1"}
+gdk-pixbuf = {version = "0.15.1", git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15" }
+gio = {features = ["v2_66"], version = "0.15.1", git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15"}
+glib = {features = ["v2_66"], version = "0.15.1", git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15"}
+graphene = {package = "graphene-rs", version = "0.15.1", git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15"}
 gsk = {package = "gsk4", path = "../gsk4", version = "0.4.1"}
 gtk4-macros = {path = "../gtk4-macros", version = "0.4.1"}
 libc = "0.2"
 once_cell = "1.0"
-pango = {features = ["v1_46"], version = "0.15.1"}
+pango = {features = ["v1_46"], version = "0.15.1", git = "https://github.com/gtk-rs/gtk-rs-core", branch = "0.15"}
 
 [dev-dependencies]
 futures-executor = "0.3"

--- a/gtk4/sys/Cargo.toml
+++ b/gtk4/sys/Cargo.toml
@@ -44,10 +44,14 @@ libc = "0.2"
 [dependencies.cairo]
 package = "cairo-sys-rs"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.gdk-pixbuf]
 package = "gdk-pixbuf-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.gdk]
 package = "gdk4-sys"
@@ -57,18 +61,26 @@ version = "0.4.1"
 [dependencies.gio]
 package = "gio-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.glib]
 package = "glib-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.gobject]
 package = "gobject-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.graphene]
 package = "graphene-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [dependencies.gsk]
 package = "gsk4-sys"
@@ -78,6 +90,8 @@ version = "0.4.1"
 [dependencies.pango]
 package = "pango-sys"
 version = "0.15.1"
+git = "https://github.com/gtk-rs/gtk-rs-core"
+branch = "0.15"
 
 [build-dependencies]
 system-deps = "6"

--- a/gtk4/sys/Cargo.toml
+++ b/gtk4/sys/Cargo.toml
@@ -12,10 +12,8 @@ name = "gtk4-sys"
 repository = "https://github.com/gtk-rs/gtk4-rs"
 version = "0.4.1"
 rust-version = "1.56"
-
 [package.metadata.docs.rs]
 features = ["dox"]
-
 [package.metadata.system-deps.gtk4]
 name = "gtk4"
 version = "4.0.0"


### PR DESCRIPTION
This makes sure we're building against the latest 0.15 versions while
still being able to publish to crates.io.