### PR TITLE
gtk4/{Text,Tree}Iter: derive Debug 

### DIFF
--- a/gtk4/Gir.toml
+++ b/gtk4/Gir.toml
@@ -1933,6 +1933,8 @@ manual_traits = ["TextBufferExtManual"]
 name = "Gtk.TextIter"
 status = "generate"
 boxed_inline = true
+    [[object.derive]]
+    name = "Debug"
 
 [[object]]
 name = "Gtk.TextTag"
@@ -2000,6 +2002,8 @@ status = "generate"
 name = "Gtk.TreeIter"
 status = "generate"
 boxed_inline = true
+    [[object.derive]]
+    name = "Debug"
 
 [[object]]
 name = "Gtk.TreeListRow"

--- a/gtk4/src/auto/text_iter.rs
+++ b/gtk4/src/auto/text_iter.rs
@@ -12,6 +12,7 @@ use glib::translate::*;
 use std::cmp;
 
 glib::wrapper! {
+    #[derive(Debug)]
     pub struct TextIter(BoxedInline<ffi::GtkTextIter>);
 
     match fn {

--- a/gtk4/src/auto/tree_iter.rs
+++ b/gtk4/src/auto/tree_iter.rs
@@ -5,6 +5,7 @@
 use glib::translate::*;
 
 glib::wrapper! {
+    #[derive(Debug)]
     pub struct TreeIter(BoxedInline<ffi::GtkTreeIter>);
 
     match fn {


### PR DESCRIPTION
So that a `struct` using these types can also auto derive `Debug`.

Another solution could be to add a `Debug` `impl` in manual code,
but since these are iterators, there's not much we can show.

Other `boxed_inline` candidates in `gtk4-rs` use manual `Debug` `impl` AFAICT.