### PR TITLE
gdk: implement conversions for Rectangle

### DIFF
--- a/gdk4/src/rectangle.rs
+++ b/gdk4/src/rectangle.rs
@@ -54,8 +54,51 @@ impl AsRef<RectangleInt> for Rectangle {
 }
 
 impl From<RectangleInt> for Rectangle {
-    fn from(r: RectangleInt) -> Rectangle {
+    fn from(r: RectangleInt) -> Self {
         skip_assert_initialized!();
         unsafe { *(&r as *const _ as *const _) }
+    }
+}
+
+impl From<Rectangle> for RectangleInt {
+    fn from(r: Rectangle) -> Self {
+        skip_assert_initialized!();
+        unsafe { *(&r as *const _ as *const _) }
+    }
+}
+
+impl From<cairo::Rectangle> for Rectangle {
+    // rustdoc-stripper-ignore-next
+    /// Note that converting between a [`cairo::Rectangle`] and [`Rectangle`]
+    /// will probably lead to precisison errors. Use cautiously.
+    fn from(r: cairo::Rectangle) -> Self {
+        skip_assert_initialized!();
+        Self::new(r.x as i32, r.y as i32, r.width as i32, r.height as i32)
+    }
+}
+
+impl From<Rectangle> for cairo::Rectangle {
+    fn from(r: Rectangle) -> Self {
+        skip_assert_initialized!();
+        Self {
+            x: r.x() as f64,
+            y: r.y() as f64,
+            width: r.width() as f64,
+            height: r.height() as f64,
+        }
+    }
+}
+
+impl From<pango::Rectangle> for Rectangle {
+    fn from(r: pango::Rectangle) -> Self {
+        skip_assert_initialized!();
+        Self::new(r.x(), r.y(), r.width(), r.height())
+    }
+}
+
+impl From<Rectangle> for pango::Rectangle {
+    fn from(r: Rectangle) -> Self {
+        skip_assert_initialized!();
+        Self::new(r.x(), r.y(), r.width(), r.height())
     }
 }

--- a/gdk4/src/rectangle.rs
+++ b/gdk4/src/rectangle.rs
@@ -23,16 +23,32 @@ impl Rectangle {
         self.inner.x
     }
 
+    pub fn set_x(&mut self, x: i32) {
+        self.inner.x = x;
+    }
+
     pub fn y(&self) -> i32 {
         self.inner.y
+    }
+
+    pub fn set_y(&mut self, y: i32) {
+        self.inner.y = y;
     }
 
     pub fn width(&self) -> i32 {
         self.inner.width
     }
 
+    pub fn set_width(&mut self, width: i32) {
+        self.inner.width = width;
+    }
+
     pub fn height(&self) -> i32 {
         self.inner.height
+    }
+
+    pub fn set_height(&mut self, height: i32) {
+        self.inner.height = height;
     }
 }
 

--- a/gsk4/src/rounded_rect.rs
+++ b/gsk4/src/rounded_rect.rs
@@ -48,34 +48,6 @@ impl RoundedRect {
         }
     }
 
-    #[doc(alias = "gsk_rounded_rect_init")]
-    pub fn init(
-        &mut self,
-        bounds: Rect,
-        top_left: Size,
-        top_right: Size,
-        bottom_right: Size,
-        bottom_left: Size,
-    ) {
-        unsafe {
-            ffi::gsk_rounded_rect_init(
-                &mut self.inner,
-                bounds.to_glib_none().0,
-                top_left.to_glib_none().0,
-                top_right.to_glib_none().0,
-                bottom_right.to_glib_none().0,
-                bottom_left.to_glib_none().0,
-            );
-        }
-    }
-
-    #[doc(alias = "gsk_rounded_rect_init_from_rect")]
-    pub fn init_from_rect(&mut self, bounds: Rect, radius: f32) {
-        unsafe {
-            ffi::gsk_rounded_rect_init_from_rect(&mut self.inner, bounds.to_glib_none().0, radius);
-        }
-    }
-
     #[doc(alias = "gsk_rounded_rect_normalize")]
     pub fn normalize(&mut self) {
         unsafe {


### PR DESCRIPTION
From cairo::Rectangle and pango::Rectangle. gdk doesn't depend on graphene otherwise would have added that one as well

Fixes #836 