### PR TITLE
gtk: mark some of TextIter methods as nullable

### DIFF
--- a/gtk4/Gir.toml
+++ b/gtk4/Gir.toml
@@ -1900,6 +1900,10 @@ status = "generate"
 boxed_inline = true
     [[object.derive]]
     name = "Debug"
+    [[object.function]]
+    pattern = "(get_child_anchor|get_paintable)"
+        [object.function.return]
+        nullable = true # Drop on next gir-files update, see https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/4401/
 
 [[object]]
 name = "Gtk.TextTag"

--- a/gtk4/src/auto/text_iter.rs
+++ b/gtk4/src/auto/text_iter.rs
@@ -553,7 +553,7 @@ impl TextIter {
 
     #[doc(alias = "gtk_text_iter_get_child_anchor")]
     #[doc(alias = "get_child_anchor")]
-    pub fn child_anchor(&self) -> TextChildAnchor {
+    pub fn child_anchor(&self) -> Option<TextChildAnchor> {
         unsafe { from_glib_none(ffi::gtk_text_iter_get_child_anchor(self.to_glib_none().0)) }
     }
 
@@ -599,7 +599,7 @@ impl TextIter {
 
     #[doc(alias = "gtk_text_iter_get_paintable")]
     #[doc(alias = "get_paintable")]
-    pub fn paintable(&self) -> gdk::Paintable {
+    pub fn paintable(&self) -> Option<gdk::Paintable> {
         unsafe { from_glib_none(ffi::gtk_text_iter_get_paintable(self.to_glib_none().0)) }
     }
 


### PR DESCRIPTION
Needs to be backported before next release for fractal port to 0.4