### PR TITLE
gtk: mark Snapshot::to_(node|paintable) as nullable

### DIFF
--- a/gtk4/Gir.toml
+++ b/gtk4/Gir.toml
@@ -1808,6 +1808,12 @@ status = "generate"
     [[object.function]]
     name = "push_debug"
     manual = true # ignore format args
+    [[object.function]]
+    # Drop once https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/4413 is merged
+    # on the next gir-files update
+    pattern = "to_(node|paintable)"
+        [object.function.return]
+        nullable = true
 
 [[object]]
 name = "Gtk.SpinButton"

--- a/gtk4/src/auto/snapshot.rs
+++ b/gtk4/src/auto/snapshot.rs
@@ -502,12 +502,12 @@ impl Snapshot {
     }
 
     #[doc(alias = "gtk_snapshot_to_node")]
-    pub fn to_node(&self) -> gsk::RenderNode {
+    pub fn to_node(&self) -> Option<gsk::RenderNode> {
         unsafe { from_glib_full(ffi::gtk_snapshot_to_node(self.to_glib_none().0)) }
     }
 
     #[doc(alias = "gtk_snapshot_to_paintable")]
-    pub fn to_paintable(&self, size: Option<&graphene::Size>) -> gdk::Paintable {
+    pub fn to_paintable(&self, size: Option<&graphene::Size>) -> Option<gdk::Paintable> {
         unsafe {
             from_glib_full(ffi::gtk_snapshot_to_paintable(
                 self.to_glib_none().0,


### PR DESCRIPTION
Fixes #845