### PR TITLE
Fixed path to example image

### DIFF
--- a/examples/clipboard/main.rs
+++ b/examples/clipboard/main.rs
@@ -87,7 +87,7 @@ fn build_ui(application: &gtk::Application) {
         .spacing(24)
         .build();
 
-    let file = gio::File::for_path("./examples/clipboard/asset.png");
+    let file = gio::File::for_path("./clipboard/asset.png");
     let asset_paintable = gdk::Texture::from_file(&file).unwrap();
 
     let image_from = gtk::Image::builder()


### PR DESCRIPTION
Previous path didn't work if the working directory was the examples folder.