### PR TITLE
Fix library name for epoxy on Windows.

### DIFF
--- a/examples/glium_gl_area/main.rs
+++ b/examples/glium_gl_area/main.rs
@@ -13,8 +13,7 @@ fn main() {
         #[cfg(all(unix, not(target_os = "macos")))]
         let library = unsafe { libloading::os::unix::Library::new("libepoxy.so.0") }.unwrap();
         #[cfg(windows)]
-        let library =
-            libloading::os::windows::Library::open_already_loaded("libepoxy-0.dll").unwrap();
+        let library = libloading::os::windows::Library::open_already_loaded("epoxy-0.dll").unwrap();
 
         epoxy::load_with(|name| {
             unsafe { library.get::<_>(name.as_bytes()) }


### PR DESCRIPTION
Fixes #854