### PR TITLE
Handle empty slices correctly

### DIFF
--- a/gtk4/src/editable.rs
+++ b/gtk4/src/editable.rs
@@ -45,7 +45,9 @@ unsafe extern "C" fn insert_text_trampoline<T, F: Fn(&T, &str, &mut i32) + 'stat
 ) where
     T: IsA<Editable>,
 {
-    let buf = if new_text_length != -1 {
+    let buf = if new_text_length == 0 {
+        &[]
+    } else if new_text_length != -1 {
         slice::from_raw_parts(new_text as *mut c_uchar, new_text_length as usize)
     } else {
         CStr::from_ptr(new_text).to_bytes()

--- a/gtk4/src/subclass/color_chooser.rs
+++ b/gtk4/src/subclass/color_chooser.rs
@@ -157,7 +157,11 @@ unsafe extern "C" fn color_chooser_add_palette<T: ColorChooserImpl>(
     let instance = &*(color_chooser as *mut T::Instance);
     let imp = instance.imp();
 
-    let colors = std::slice::from_raw_parts(colorsptr as *const RGBA, total as usize);
+    let colors = if total == 0 {
+        &[]
+    } else {
+        std::slice::from_raw_parts(colorsptr as *const RGBA, total as usize)
+    };
     imp.add_palette(
         from_glib_borrow::<_, ColorChooser>(color_chooser).unsafe_cast_ref(),
         from_glib(orientation),

--- a/gtk4/src/subclass/symbolic_paintable.rs
+++ b/gtk4/src/subclass/symbolic_paintable.rs
@@ -94,6 +94,10 @@ unsafe extern "C" fn symbolic_paintable_snapshot_symbolic<T: SymbolicPaintableIm
         &snapshot,
         width,
         height,
-        std::slice::from_raw_parts(colors as *const gdk::RGBA, n_colors),
+        if n_colors == 0 {
+            &[]
+        } else {
+            std::slice::from_raw_parts(colors as *const gdk::RGBA, n_colors)
+        },
     )
 }

--- a/gtk4/src/text_buffer.rs
+++ b/gtk4/src/text_buffer.rs
@@ -93,10 +93,16 @@ impl<O: IsA<TextBuffer>> TextBufferExtManual for O {
             {
                 let mut location_copy = from_glib_none(location);
                 let f: &F = &*(f as *const F);
+                let text = if len <= 0 {
+                    &[]
+                } else {
+                    slice::from_raw_parts(text as *const u8, len as usize)
+                };
+
                 f(
                     TextBuffer::from_glib_borrow(this).unsafe_cast_ref(),
                     &mut location_copy,
-                    str::from_utf8(slice::from_raw_parts(text as *const u8, len as usize)).unwrap(),
+                    str::from_utf8(text).unwrap(),
                 )
             }
             let f: Box_<F> = Box_::new(f);

--- a/gtk4/src/tree_path.rs
+++ b/gtk4/src/tree_path.rs
@@ -14,7 +14,7 @@ impl TreePath {
                 mut_override(self.to_glib_none().0),
                 &mut count,
             );
-            if ptr.is_null() {
+            if ptr.is_null() || count == 0 {
                 vec![]
             } else {
                 slice::from_raw_parts(ptr, count as usize).to_owned()


### PR DESCRIPTION
Passing `NULL` to `slice::from_raw_parts` is invalid.