### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @bilelmoussaoui
+/book/ @Hofer-Julian


### PR DESCRIPTION
This will result in me being requested as reviewer when the book has been touched.
@bilelmoussaoui  will be requested in all other cases.
We can of course still request for more reviewers manually.
The docs can be found here: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

@sdroege: Not sure if you should be code owner of a part of the repo.
Or if something similar would make sense for gtk-rs-core 
