### PR TITLE
gtk4: Add runtime type checks for template children

### DIFF
--- a/gtk4-macros/src/attribute_parser.rs
+++ b/gtk4-macros/src/attribute_parser.rs
@@ -100,6 +100,18 @@ pub struct AttributedField {
     pub attr: FieldAttribute,
 }
 
+impl AttributedField {
+    pub fn id(&self) -> String {
+        let mut name = None;
+        for arg in &self.attr.args {
+            if let FieldAttributeArg::Id(value) = arg {
+                name = Some(value)
+            }
+        }
+        name.cloned().unwrap_or_else(|| self.ident.to_string())
+    }
+}
+
 fn parse_field_attr_value_str(name_value: &MetaNameValue) -> Result<String, Error> {
     match &name_value.lit {
         Lit::Str(s) => Ok(s.value()),

--- a/gtk4/src/subclass/widget.rs
+++ b/gtk4/src/subclass/widget.rs
@@ -1297,17 +1297,11 @@ where
 {
     type Target = T;
 
-    // rustdoc-stripper-ignore-next
-    /// # Safety
-    ///
-    /// Since the template child may not be properly bound,
-    /// this cast is potentially dangerous if, for example,
-    /// the template child isn't bound or is of the wrong type.
-    /// The caller is responsible for ensuring that the template
-    /// child is bound and of the right type.
     fn deref(&self) -> &Self::Target {
         unsafe {
-            assert!(!self.ptr.is_null());
+            if !self.is_bound() {
+                panic!("Failed to retrieve template child. Please check that it has been bound and has a #[template_child] attribute.");
+            }
             &*(&self.ptr as *const _ as *const T)
         }
     }
@@ -1320,7 +1314,7 @@ where
     #[track_caller]
     pub fn get(&self) -> T {
         self.try_get()
-            .expect("Failed to retrieve template child. Please check that it has been bound.")
+            .expect("Failed to retrieve template child. Please check that it has been bound and has a #[template_child] attribute.")
     }
 
     // rustdoc-stripper-ignore-next
@@ -1339,6 +1333,7 @@ where
 
 pub trait CompositeTemplate: WidgetImpl {
     fn bind_template(klass: &mut Self::Class);
+    fn check_template_children(widget: &<Self as ObjectSubclass>::Type);
 }
 
 pub type TemplateCallback = (&'static str, fn(&[glib::Value]) -> Option<glib::Value>);

--- a/gtk4/src/widget.rs
+++ b/gtk4/src/widget.rs
@@ -94,10 +94,17 @@ pub trait InitializingWidgetExt {
     fn init_template(&self);
 }
 
-impl<T: WidgetImpl> InitializingWidgetExt for glib::subclass::InitializingObject<T> {
+impl<T> InitializingWidgetExt for glib::subclass::InitializingObject<T>
+where
+    T: WidgetImpl + CompositeTemplate,
+    <T as ObjectSubclass>::Type: IsA<Widget>,
+{
     fn init_template(&self) {
-        unsafe {
-            self.as_ref().unsafe_cast_ref::<Widget>().init_template();
-        }
+        let widget = unsafe {
+            self.as_ref()
+                .unsafe_cast_ref::<<T as ObjectSubclass>::Type>()
+        };
+        widget.init_template();
+        <T as CompositeTemplate>::check_template_children(widget);
     }
 }


### PR DESCRIPTION
Maybe good enough for #179, the error message is better and we can type check everything on widget instantiation. But still we have no way to detect if a `TemplateChild` is missing the attribute before it gets derefed.