### PR TITLE
gtk4: CompositeTemplate set_template fixes

### DIFF
--- a/gtk4-macros/src/composite_template_derive.rs
+++ b/gtk4-macros/src/composite_template_derive.rs
@@ -13,8 +13,7 @@ use crate::util::*;
 fn gen_set_template(source: TemplateSource) -> TokenStream {
     match source {
         TemplateSource::File(file) => quote! {
-            let t = include_bytes!(#file);
-            klass.set_template(t);
+            klass.set_template_static(include_bytes!(#file));
         },
         TemplateSource::Resource(resource) => quote! {
             klass.set_template_from_resource(&#resource);

--- a/gtk4-macros/src/composite_template_derive.rs
+++ b/gtk4-macros/src/composite_template_derive.rs
@@ -20,7 +20,7 @@ fn gen_set_template(source: TemplateSource) -> TokenStream {
             klass.set_template_from_resource(&#resource);
         },
         TemplateSource::String(template) => quote! {
-            klass.set_template(&#template);
+            klass.set_template_static(#template.as_bytes());
         },
     }
 }

--- a/gtk4-macros/tests/template-string.rs
+++ b/gtk4-macros/tests/template-string.rs
@@ -1,0 +1,48 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use gtk::prelude::*;
+use gtk::subclass::prelude::*;
+use gtk::{glib, CompositeTemplate};
+
+mod imp {
+    use super::*;
+
+    #[derive(Debug, Default, CompositeTemplate)]
+    #[template(string = r#"
+    <interface>
+       <template class="MyWidget" parent="GtkWidget">
+          <child>
+            <object class="GtkLabel" id="label"/>
+          </child>
+       </template>
+    </interface>
+    "#)]
+    pub struct MyWidget {
+        #[template_child]
+        pub label: TemplateChild<gtk::Label>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for MyWidget {
+        const NAME: &'static str = "MyWidget";
+        type Type = super::MyWidget;
+        fn class_init(klass: &mut Self::Class) {
+            Self::bind_template(klass);
+        }
+        fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for MyWidget {}
+    impl WidgetImpl for MyWidget {}
+}
+
+glib::wrapper! {
+    pub struct MyWidget(ObjectSubclass<imp::MyWidget>) @extends gtk::Widget;
+}
+
+fn main() {
+    gtk::init().unwrap();
+    let _: MyWidget = glib::Object::new(&[]).unwrap();
+}


### PR DESCRIPTION
`#[template(string)]` never worked before, I guess not many people have tried to use it.