### PR TITLE
gtk4: Add convenience traits for binding template callbacks to classes

### DIFF
--- a/book/listings/actions/5/window/imp.rs
+++ b/book/listings/actions/5/window/imp.rs
@@ -22,7 +22,7 @@ impl ObjectSubclass for Window {
     type ParentType = gtk::ApplicationWindow;
 
     fn class_init(klass: &mut Self::Class) {
-        Self::bind_template(klass);
+        klass.bind_template();
     }
 
     fn instance_init(obj: &InitializingObject<Self>) {

--- a/book/listings/actions/6/window/imp.rs
+++ b/book/listings/actions/6/window/imp.rs
@@ -25,7 +25,7 @@ impl ObjectSubclass for Window {
     type ParentType = gtk::ApplicationWindow;
 
     fn class_init(klass: &mut Self::Class) {
-        Self::bind_template(klass);
+        klass.bind_template();
     }
 
     fn instance_init(obj: &InitializingObject<Self>) {

--- a/book/listings/actions/7/window/imp.rs
+++ b/book/listings/actions/7/window/imp.rs
@@ -40,7 +40,7 @@ impl ObjectSubclass for Window {
     type ParentType = gtk::ApplicationWindow;
 
     fn class_init(klass: &mut Self::Class) {
-        Self::bind_template(klass);
+        klass.bind_template();
     }
 
     fn instance_init(obj: &InitializingObject<Self>) {

--- a/book/listings/composite_templates/1/window/imp.rs
+++ b/book/listings/composite_templates/1/window/imp.rs
@@ -24,7 +24,7 @@ impl ObjectSubclass for Window {
     type ParentType = gtk::ApplicationWindow;
 
     fn class_init(klass: &mut Self::Class) {
-        Self::bind_template(klass);
+        klass.bind_template();
     }
 
     fn instance_init(obj: &InitializingObject<Self>) {

--- a/book/listings/composite_templates/2/window/imp.rs
+++ b/book/listings/composite_templates/2/window/imp.rs
@@ -26,7 +26,7 @@ impl ObjectSubclass for Window {
     type ParentType = gtk::ApplicationWindow;
 
     fn class_init(klass: &mut Self::Class) {
-        Self::bind_template(klass);
+        klass.bind_template();
     }
 
     fn instance_init(obj: &InitializingObject<Self>) {

--- a/book/listings/composite_templates/3/window/imp.rs
+++ b/book/listings/composite_templates/3/window/imp.rs
@@ -26,8 +26,8 @@ impl ObjectSubclass for Window {
     type ParentType = gtk::ApplicationWindow;
 
     fn class_init(klass: &mut Self::Class) {
-        Self::bind_template(klass);
-        Self::bind_template_callbacks(klass);
+        klass.bind_template();
+        klass.bind_template_callbacks();
     }
 
     fn instance_init(obj: &InitializingObject<Self>) {

--- a/book/listings/composite_templates/4/window/imp.rs
+++ b/book/listings/composite_templates/4/window/imp.rs
@@ -29,8 +29,8 @@ impl ObjectSubclass for Window {
     type ParentType = gtk::ApplicationWindow;
 
     fn class_init(klass: &mut Self::Class) {
-        Self::bind_template(klass);
-        Self::bind_template_callbacks(klass);
+        klass.bind_template();
+        klass.bind_template_callbacks();
     }
 
     fn instance_init(obj: &InitializingObject<Self>) {

--- a/book/listings/composite_templates/5/window/imp.rs
+++ b/book/listings/composite_templates/5/window/imp.rs
@@ -27,8 +27,8 @@ impl ObjectSubclass for Window {
     type ParentType = gtk::ApplicationWindow;
 
     fn class_init(klass: &mut Self::Class) {
-        Self::bind_template(klass);
-        Self::bind_template_callbacks(klass);
+        klass.bind_template();
+        klass.bind_template_callbacks();
     }
 
     fn instance_init(obj: &InitializingObject<Self>) {

--- a/book/listings/composite_templates/6/window/imp.rs
+++ b/book/listings/composite_templates/6/window/imp.rs
@@ -30,8 +30,8 @@ impl ObjectSubclass for Window {
         // Register `CustomButton`
         CustomButton::ensure_type();
 
-        Self::bind_template(klass);
-        Self::bind_template_callbacks(klass);
+        klass.bind_template();
+        klass.bind_template_callbacks();
     }
 
     fn instance_init(obj: &InitializingObject<Self>) {

--- a/book/listings/css/6/window/imp.rs
+++ b/book/listings/css/6/window/imp.rs
@@ -18,7 +18,7 @@ impl ObjectSubclass for Window {
     type ParentType = gtk::ApplicationWindow;
 
     fn class_init(klass: &mut Self::Class) {
-        Self::bind_template(klass);
+        klass.bind_template();
     }
 
     fn instance_init(obj: &InitializingObject<Self>) {

--- a/book/listings/css/7/window/imp.rs
+++ b/book/listings/css/7/window/imp.rs
@@ -18,7 +18,7 @@ impl ObjectSubclass for Window {
     type ParentType = gtk::ApplicationWindow;
 
     fn class_init(klass: &mut Self::Class) {
-        Self::bind_template(klass);
+        klass.bind_template();
     }
 
     fn instance_init(obj: &InitializingObject<Self>) {

--- a/book/listings/css/8/window/imp.rs
+++ b/book/listings/css/8/window/imp.rs
@@ -18,7 +18,7 @@ impl ObjectSubclass for Window {
     type ParentType = gtk::ApplicationWindow;
 
     fn class_init(klass: &mut Self::Class) {
-        Self::bind_template(klass);
+        klass.bind_template();
     }
 
     fn instance_init(obj: &InitializingObject<Self>) {

--- a/book/listings/css/9/window/imp.rs
+++ b/book/listings/css/9/window/imp.rs
@@ -18,7 +18,7 @@ impl ObjectSubclass for Window {
     type ParentType = gtk::ApplicationWindow;
 
     fn class_init(klass: &mut Self::Class) {
-        Self::bind_template(klass);
+        klass.bind_template();
     }
 
     fn instance_init(obj: &InitializingObject<Self>) {

--- a/book/listings/todo_app/1/todo_row/imp.rs
+++ b/book/listings/todo_app/1/todo_row/imp.rs
@@ -26,7 +26,7 @@ impl ObjectSubclass for TodoRow {
     type ParentType = gtk::Box;
 
     fn class_init(klass: &mut Self::Class) {
-        Self::bind_template(klass);
+        klass.bind_template();
     }
 
     fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {

--- a/book/listings/todo_app/1/window/imp.rs
+++ b/book/listings/todo_app/1/window/imp.rs
@@ -26,7 +26,7 @@ impl ObjectSubclass for Window {
     type ParentType = gtk::ApplicationWindow;
 
     fn class_init(klass: &mut Self::Class) {
-        Self::bind_template(klass);
+        klass.bind_template();
     }
 
     fn instance_init(obj: &InitializingObject<Self>) {

--- a/book/listings/todo_app/2/todo_row/imp.rs
+++ b/book/listings/todo_app/2/todo_row/imp.rs
@@ -25,7 +25,7 @@ impl ObjectSubclass for TodoRow {
     type ParentType = gtk::Box;
 
     fn class_init(klass: &mut Self::Class) {
-        Self::bind_template(klass);
+        klass.bind_template();
     }
 
     fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {

--- a/book/listings/todo_app/2/window/imp.rs
+++ b/book/listings/todo_app/2/window/imp.rs
@@ -49,7 +49,7 @@ impl ObjectSubclass for Window {
     type ParentType = gtk::ApplicationWindow;
 
     fn class_init(klass: &mut Self::Class) {
-        Self::bind_template(klass);
+        klass.bind_template();
     }
 
     fn instance_init(obj: &InitializingObject<Self>) {

--- a/book/listings/todo_app/3/todo_row/imp.rs
+++ b/book/listings/todo_app/3/todo_row/imp.rs
@@ -26,7 +26,7 @@ impl ObjectSubclass for TodoRow {
     type ParentType = gtk::Box;
 
     fn class_init(klass: &mut Self::Class) {
-        Self::bind_template(klass);
+        klass.bind_template();
         klass.set_css_name("todo-row");
     }
 

--- a/book/listings/todo_app/3/window/imp.rs
+++ b/book/listings/todo_app/3/window/imp.rs
@@ -47,7 +47,7 @@ impl ObjectSubclass for Window {
     type ParentType = gtk::ApplicationWindow;
 
     fn class_init(klass: &mut Self::Class) {
-        Self::bind_template(klass);
+        klass.bind_template();
     }
 
     fn instance_init(obj: &InitializingObject<Self>) {

--- a/book/listings/todo_app/4/todo_row/imp.rs
+++ b/book/listings/todo_app/4/todo_row/imp.rs
@@ -26,7 +26,7 @@ impl ObjectSubclass for TodoRow {
     type ParentType = gtk::Box;
 
     fn class_init(klass: &mut Self::Class) {
-        Self::bind_template(klass);
+        klass.bind_template();
     }
 
     fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {

--- a/book/listings/todo_app/4/window/imp.rs
+++ b/book/listings/todo_app/4/window/imp.rs
@@ -47,7 +47,7 @@ impl ObjectSubclass for Window {
     type ParentType = gtk::ApplicationWindow;
 
     fn class_init(klass: &mut Self::Class) {
-        Self::bind_template(klass);
+        klass.bind_template();
     }
 
     fn instance_init(obj: &InitializingObject<Self>) {

--- a/book/src/composite_templates.md
+++ b/book/src/composite_templates.md
@@ -170,7 +170,7 @@ This means that `handle_button_clicked` has a single parameter of type `&CustomB
 {{#rustdoc_include ../listings/composite_templates/3/window/imp.rs:template_callbacks}}
 ```
 
-Then we have to bind the template callbacks with [`bind_template_callbacks`](../docs/gtk4/subclass/widget/trait.CompositeTemplateCallbacks.html#method.bind_template_callbacks).
+Then we have to bind the template callbacks with [`bind_template_callbacks`](../docs/gtk4/subclass/widget/trait.CompositeTemplateCallbacksClass.html#tymethod.bind_template_callbacks).
 
 <span class="filename">Filename: listings/composite_templates/3/window/imp.rs</span>
 ```rust ,no_run,noplayground

--- a/examples/composite_template/ex_application_window/imp.rs
+++ b/examples/composite_template/ex_application_window/imp.rs
@@ -32,7 +32,7 @@ impl ObjectSubclass for ExApplicationWindow {
     // The CompositeTemplate derive macro provides a convenience function
     // bind_template() to set the template and bind all children at once.
     fn class_init(klass: &mut Self::Class) {
-        Self::bind_template(klass);
+        klass.bind_template();
         UtilityCallbacks::bind_template_callbacks(klass);
     }
 

--- a/examples/composite_template/ex_menu_button/imp.rs
+++ b/examples/composite_template/ex_menu_button/imp.rs
@@ -18,8 +18,8 @@ impl ObjectSubclass for ExMenuButton {
     type ParentType = gtk::Widget;
 
     fn class_init(klass: &mut Self::Class) {
-        Self::bind_template(klass);
-        Self::bind_template_callbacks(klass);
+        klass.bind_template();
+        klass.bind_template_callbacks();
     }
 
     fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {

--- a/examples/custom_buildable/custom_buildable/imp.rs
+++ b/examples/custom_buildable/custom_buildable/imp.rs
@@ -21,7 +21,7 @@ impl ObjectSubclass for CustomBuildable {
     type Interfaces = (gtk::Buildable,);
 
     fn class_init(klass: &mut Self::Class) {
-        Self::bind_template(klass);
+        klass.bind_template();
 
         // The layout manager determines how child widgets are laid out.
         klass.set_layout_manager_type::<gtk::BinLayout>();

--- a/examples/list_view_apps_launcher/application_row/imp.rs
+++ b/examples/list_view_apps_launcher/application_row/imp.rs
@@ -22,7 +22,7 @@ impl ObjectSubclass for ApplicationRow {
     type ParentType = gtk::Box;
 
     fn class_init(klass: &mut Self::Class) {
-        Self::bind_template(klass);
+        klass.bind_template();
     }
 
     fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {

--- a/examples/video_player/video_player_window/imp.rs
+++ b/examples/video_player/video_player_window/imp.rs
@@ -43,7 +43,7 @@ impl ObjectSubclass for VideoPlayerWindow {
     }
 
     fn class_init(klass: &mut Self::Class) {
-        Self::bind_template(klass);
+        klass.bind_template();
         klass.install_action(
             "win.open",
             None,

--- a/gtk4/src/subclass/mod.rs
+++ b/gtk4/src/subclass/mod.rs
@@ -152,6 +152,9 @@ pub mod prelude {
     pub use super::tree_view::{TreeViewImpl, TreeViewImplExt};
     pub use super::widget::CompositeTemplate;
     pub use super::widget::CompositeTemplateCallbacks;
+    pub use super::widget::CompositeTemplateCallbacksClass;
+    pub use super::widget::CompositeTemplateClass;
+    pub use super::widget::CompositeTemplateInstanceCallbacksClass;
     pub use super::widget::TemplateChild;
     pub use super::widget::WidgetClassSubclassExt;
     pub use super::widget::{WidgetImpl, WidgetImplExt};

--- a/gtk4/src/subclass/widget.rs
+++ b/gtk4/src/subclass/widget.rs
@@ -1337,12 +1337,40 @@ where
     }
 }
 
+// rustdoc-stripper-ignore-next
+/// A trait for setting up template children inside
+/// [`class_init`](glib::subclass::types::ObjectSubclass::class_init). This trait is implemented
+/// automatically by the [`CompositeTemplate`](crate::CompositeTemplate) macro.
 pub trait CompositeTemplate: WidgetImpl {
     fn bind_template(klass: &mut Self::Class);
 }
 
+// rustdoc-stripper-ignore-next
+/// An extension trait for [`ClassStruct`](glib::subclass::types::ClassStruct) types to allow
+/// binding a composite template directly on `self`. This is a convenience wrapper around
+/// the [`CompositeTemplate`] trait.
+pub trait CompositeTemplateClass {
+    // rustdoc-stripper-ignore-next
+    /// Binds the template callbacks from this type into the default template scope for `self`.
+    fn bind_template(&mut self);
+}
+
+impl<T, U> CompositeTemplateClass for T
+where
+    T: ClassStruct<Type = U>,
+    U: ObjectSubclass<Class = T> + CompositeTemplate,
+{
+    fn bind_template(&mut self) {
+        <U as CompositeTemplate>::bind_template(self);
+    }
+}
+
 pub type TemplateCallback = (&'static str, fn(&[glib::Value]) -> Option<glib::Value>);
 
+// rustdoc-stripper-ignore-next
+/// A trait for setting up template callbacks inside
+/// [`class_init`](glib::subclass::types::ObjectSubclass::class_init). This trait is implemented
+/// automatically by the [`template_callbacks`](crate::template_callbacks) macro.
 pub trait CompositeTemplateCallbacks {
     const CALLBACKS: &'static [TemplateCallback];
 
@@ -1371,5 +1399,46 @@ pub trait CompositeTemplateCallbacks {
         for (name, func) in Self::CALLBACKS {
             scope.add_callback(format!("{}{}", prefix, name), func);
         }
+    }
+}
+
+// rustdoc-stripper-ignore-next
+/// An extension trait for [`ClassStruct`](glib::subclass::types::ClassStruct) types to allow
+/// binding private template callbacks directly on `self`. This is a convenience wrapper around
+/// the [`CompositeTemplateCallbacks`] trait.
+pub trait CompositeTemplateCallbacksClass {
+    // rustdoc-stripper-ignore-next
+    /// Binds the template callbacks from the subclass type into the default template scope for `self`.
+    fn bind_template_callbacks(&mut self);
+}
+
+impl<T, U> CompositeTemplateCallbacksClass for T
+where
+    T: ClassStruct<Type = U> + WidgetClassSubclassExt,
+    U: ObjectSubclass<Class = T> + CompositeTemplateCallbacks,
+{
+    fn bind_template_callbacks(&mut self) {
+        <U as CompositeTemplateCallbacks>::bind_template_callbacks(self);
+    }
+}
+
+// rustdoc-stripper-ignore-next
+/// An extension trait for [`ClassStruct`](glib::subclass::types::ClassStruct) types to allow
+/// binding the instance template callbacks directly on `self`. This is a convenience wrapper around
+/// the [`CompositeTemplateCallbacks`] trait.
+pub trait CompositeTemplateInstanceCallbacksClass {
+    // rustdoc-stripper-ignore-next
+    /// Binds the template callbacks from the instance type into the default template scope for `self`.
+    fn bind_template_instance_callbacks(&mut self);
+}
+
+impl<T, U, V> CompositeTemplateInstanceCallbacksClass for T
+where
+    T: ClassStruct<Type = U> + WidgetClassSubclassExt,
+    U: ObjectSubclass<Class = T, Type = V>,
+    V: CompositeTemplateCallbacks,
+{
+    fn bind_template_instance_callbacks(&mut self) {
+        <V as CompositeTemplateCallbacks>::bind_template_callbacks(self);
     }
 }


### PR DESCRIPTION
Finishes out the last part of #77

The old way of `Self::bind_template(klass)` still works, this PR shouldn't break any existing code