### PR TITLE
Add a #[gtk::test] attribute for unit tests

### DIFF
--- a/gtk4-macros/tests/template-string.rs
+++ b/gtk4-macros/tests/template-string.rs
@@ -26,6 +26,7 @@ mod imp {
     impl ObjectSubclass for MyWidget {
         const NAME: &'static str = "MyWidget";
         type Type = super::MyWidget;
+        type ParentType = gtk::Widget;
         fn class_init(klass: &mut Self::Class) {
             Self::bind_template(klass);
         }
@@ -42,7 +43,7 @@ glib::wrapper! {
     pub struct MyWidget(ObjectSubclass<imp::MyWidget>) @extends gtk::Widget;
 }
 
-fn main() {
-    gtk::init().unwrap();
+#[gtk::test]
+fn template_string() {
     let _: MyWidget = glib::Object::new(&[]).unwrap();
 }

--- a/gtk4/Cargo.toml
+++ b/gtk4/Cargo.toml
@@ -42,5 +42,4 @@ once_cell = "1.0"
 pango = {git = "https://github.com/gtk-rs/gtk-rs-core", version = "0.16", features = ["v1_46"]}
 
 [dev-dependencies]
-futures-executor = "0.3"
 gir-format-check = "^0.1"

--- a/gtk4/src/accessible.rs
+++ b/gtk4/src/accessible.rs
@@ -261,81 +261,75 @@ impl State {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_synced, Button};
+    use crate::{self as gtk4, Button};
 
     #[test]
     fn test_accessible_update_property() {
-        test_synced(move || {
-            let widget = glib::Object::new::<Button>(&[]).unwrap();
-            widget.update_property(&[
-                Property::Autocomplete(AccessibleAutocomplete::Inline),
-                Property::Description("Test"),
-                Property::HasPopup(true),
-                Property::KeyShortcuts("Test"),
-                Property::Label("Test"),
-                Property::Level(123),
-                Property::Modal(true),
-                Property::MultiLine(true),
-                Property::MultiSelectable(true),
-                Property::Orientation(Orientation::Horizontal),
-                Property::Placeholder("Test"),
-                Property::ReadOnly(true),
-                Property::Required(true),
-                Property::RoleDescription("Test"),
-                Property::Sort(AccessibleSort::Ascending),
-                Property::ValueMax(1.0),
-                Property::ValueMin(1.0),
-                Property::ValueNow(1.0),
-                Property::ValueText("Test"),
-            ]);
-        });
+        let widget = glib::Object::new::<Button>(&[]).unwrap();
+        widget.update_property(&[
+            Property::Autocomplete(AccessibleAutocomplete::Inline),
+            Property::Description("Test"),
+            Property::HasPopup(true),
+            Property::KeyShortcuts("Test"),
+            Property::Label("Test"),
+            Property::Level(123),
+            Property::Modal(true),
+            Property::MultiLine(true),
+            Property::MultiSelectable(true),
+            Property::Orientation(Orientation::Horizontal),
+            Property::Placeholder("Test"),
+            Property::ReadOnly(true),
+            Property::Required(true),
+            Property::RoleDescription("Test"),
+            Property::Sort(AccessibleSort::Ascending),
+            Property::ValueMax(1.0),
+            Property::ValueMin(1.0),
+            Property::ValueNow(1.0),
+            Property::ValueText("Test"),
+        ]);
     }
 
     #[test]
     fn test_accessible_update_relation() {
-        test_synced(move || {
-            use crate::prelude::*;
+        use crate::prelude::*;
 
-            let widget = glib::Object::new::<Button>(&[]).unwrap();
-            let other1 = glib::Object::new::<Button>(&[]).unwrap();
-            let other2 = glib::Object::new::<Button>(&[]).unwrap();
-            widget.update_relation(&[
-                Relation::ActiveDescendant(other1.upcast_ref()),
-                Relation::ColCount(123),
-                Relation::ColIndex(123),
-                Relation::ColIndexText("Test"),
-                Relation::ColSpan(123),
-                Relation::Controls(&[other1.upcast_ref(), other2.upcast_ref()]),
-                Relation::DescribedBy(&[other1.upcast_ref(), other2.upcast_ref()]),
-                Relation::Details(&[other1.upcast_ref(), other2.upcast_ref()]),
-                Relation::ErrorMessage(other1.upcast_ref()),
-                Relation::FlowTo(&[other1.upcast_ref(), other2.upcast_ref()]),
-                Relation::LabelledBy(&[other1.upcast_ref(), other2.upcast_ref()]),
-                Relation::Owns(&[other1.upcast_ref(), other2.upcast_ref()]),
-                Relation::PosInSet(123),
-                Relation::RowCount(123),
-                Relation::RowIndex(123),
-                Relation::RowIndexText("Test"),
-                Relation::RowSpan(123),
-                Relation::SetSize(123),
-            ]);
-        });
+        let widget = glib::Object::new::<Button>(&[]).unwrap();
+        let other1 = glib::Object::new::<Button>(&[]).unwrap();
+        let other2 = glib::Object::new::<Button>(&[]).unwrap();
+        widget.update_relation(&[
+            Relation::ActiveDescendant(other1.upcast_ref()),
+            Relation::ColCount(123),
+            Relation::ColIndex(123),
+            Relation::ColIndexText("Test"),
+            Relation::ColSpan(123),
+            Relation::Controls(&[other1.upcast_ref(), other2.upcast_ref()]),
+            Relation::DescribedBy(&[other1.upcast_ref(), other2.upcast_ref()]),
+            Relation::Details(&[other1.upcast_ref(), other2.upcast_ref()]),
+            Relation::ErrorMessage(other1.upcast_ref()),
+            Relation::FlowTo(&[other1.upcast_ref(), other2.upcast_ref()]),
+            Relation::LabelledBy(&[other1.upcast_ref(), other2.upcast_ref()]),
+            Relation::Owns(&[other1.upcast_ref(), other2.upcast_ref()]),
+            Relation::PosInSet(123),
+            Relation::RowCount(123),
+            Relation::RowIndex(123),
+            Relation::RowIndexText("Test"),
+            Relation::RowSpan(123),
+            Relation::SetSize(123),
+        ]);
     }
 
     #[test]
     fn test_accessible_update_state() {
-        test_synced(move || {
-            let widget = glib::Object::new::<Button>(&[]).unwrap();
-            widget.update_state(&[
-                State::Busy(true),
-                State::Checked(AccessibleTristate::Mixed),
-                State::Disabled(true),
-                State::Expanded(Some(true)),
-                State::Hidden(true),
-                State::Invalid(AccessibleInvalidState::Grammar),
-                State::Pressed(AccessibleTristate::Mixed),
-                State::Selected(Some(true)),
-            ]);
-        });
+        let widget = glib::Object::new::<Button>(&[]).unwrap();
+        widget.update_state(&[
+            State::Busy(true),
+            State::Checked(AccessibleTristate::Mixed),
+            State::Disabled(true),
+            State::Expanded(Some(true)),
+            State::Hidden(true),
+            State::Invalid(AccessibleInvalidState::Grammar),
+            State::Pressed(AccessibleTristate::Mixed),
+            State::Selected(Some(true)),
+        ]);
     }
 }

--- a/gtk4/src/bitset_iter.rs
+++ b/gtk4/src/bitset_iter.rs
@@ -139,26 +139,24 @@ impl<'a> ToGlibPtr<'a, *const ffi::GtkBitsetIter> for BitsetIter<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_synced;
+    use crate as gtk4;
 
     #[test]
     fn test_bitset_iter() {
-        test_synced(move || {
-            let set = Bitset::new_range(0, 20);
-            let (mut iter, init_value) = BitsetIter::init_first(&set).unwrap();
-            assert_eq!(init_value, 0);
-            assert_eq!(iter.next(), Some(1));
-            assert_eq!(iter.previous(), Some(0));
+        let set = Bitset::new_range(0, 20);
+        let (mut iter, init_value) = BitsetIter::init_first(&set).unwrap();
+        assert_eq!(init_value, 0);
+        assert_eq!(iter.next(), Some(1));
+        assert_eq!(iter.previous(), Some(0));
 
-            let set2 = Bitset::new_range(0, 3);
-            let (mut iter, init_val) = BitsetIter::init_last(&set2).unwrap();
-            assert_eq!(init_val, 2);
-            assert_eq!(iter.previous(), Some(1));
-            assert_eq!(iter.previous(), Some(0));
-            assert_eq!(iter.previous(), None);
-            assert!(!iter.is_valid());
-            assert_eq!(iter.next(), Some(1));
-            assert!(iter.is_valid());
-        });
+        let set2 = Bitset::new_range(0, 3);
+        let (mut iter, init_val) = BitsetIter::init_last(&set2).unwrap();
+        assert_eq!(init_val, 2);
+        assert_eq!(iter.previous(), Some(1));
+        assert_eq!(iter.previous(), Some(0));
+        assert_eq!(iter.previous(), None);
+        assert!(!iter.is_valid());
+        assert_eq!(iter.next(), Some(1));
+        assert!(iter.is_valid());
     }
 }

--- a/gtk4/src/builder_rust_scope.rs
+++ b/gtk4/src/builder_rust_scope.rs
@@ -183,7 +183,7 @@ mod imp {
 #[cfg(test)]
 mod tests {
     use super::BuilderRustScope;
-    use crate::{self as gtk4, prelude::*, subclass::prelude::*, test_synced, Builder};
+    use crate::{self as gtk4, prelude::*, subclass::prelude::*, Builder};
 
     const SIGNAL_XML: &str = r##"
     <?xml version="1.0" encoding="UTF-8"?>
@@ -195,31 +195,29 @@ mod tests {
     </interface>
     "##;
 
-    #[test]
+    #[crate::test]
     fn test_rust_builder_scope_signal_handler() {
-        test_synced(move || {
-            use crate::Button;
+        use crate::Button;
 
-            pub struct Callbacks {}
-            #[template_callbacks]
-            impl Callbacks {
-                #[template_callback]
-                fn button_clicked(button: &Button) {
-                    skip_assert_initialized!();
-                    assert_eq!(button.label().unwrap().as_str(), "Hello World");
-                    button.set_label("Clicked");
-                }
+        pub struct Callbacks {}
+        #[template_callbacks]
+        impl Callbacks {
+            #[template_callback]
+            fn button_clicked(button: &Button) {
+                skip_assert_initialized!();
+                assert_eq!(button.label().unwrap().as_str(), "Hello World");
+                button.set_label("Clicked");
             }
+        }
 
-            let builder = Builder::new();
-            let scope = BuilderRustScope::new();
-            Callbacks::add_callbacks_to_scope(&scope);
-            builder.set_scope(Some(&scope));
-            builder.add_from_string(SIGNAL_XML).unwrap();
-            let button = builder.object::<Button>("button").unwrap();
-            button.emit_clicked();
-            assert_eq!(button.label().unwrap().as_str(), "Clicked");
-        });
+        let builder = Builder::new();
+        let scope = BuilderRustScope::new();
+        Callbacks::add_callbacks_to_scope(&scope);
+        builder.set_scope(Some(&scope));
+        builder.add_from_string(SIGNAL_XML).unwrap();
+        let button = builder.object::<Button>("button").unwrap();
+        button.emit_clicked();
+        assert_eq!(button.label().unwrap().as_str(), "Clicked");
     }
 
     const CLOSURE_XML: &str = r##"
@@ -236,59 +234,55 @@ mod tests {
     </interface>
     "##;
 
-    #[test]
+    #[crate::test]
     fn test_rust_builder_scope_closure() {
-        test_synced(move || {
-            use crate::Entry;
+        use crate::Entry;
 
-            pub struct StringCallbacks {}
-            #[template_callbacks]
-            impl StringCallbacks {
-                #[template_callback(function)]
-                fn uppercase(s: &str) -> String {
-                    skip_assert_initialized!();
-                    s.to_uppercase()
-                }
+        pub struct StringCallbacks {}
+        #[template_callbacks]
+        impl StringCallbacks {
+            #[template_callback(function)]
+            fn uppercase(s: &str) -> String {
+                skip_assert_initialized!();
+                s.to_uppercase()
             }
+        }
 
-            let builder = Builder::new();
-            let scope = BuilderRustScope::new();
-            StringCallbacks::add_callbacks_to_scope_prefixed(&scope, "string_");
-            builder.set_scope(Some(&scope));
-            builder.add_from_string(CLOSURE_XML).unwrap();
-            let entry_a = builder.object::<Entry>("entry_a").unwrap();
-            let entry_b = builder.object::<Entry>("entry_b").unwrap();
-            entry_a.set_text("Hello World");
-            assert_eq!(entry_b.text().as_str(), "HELLO WORLD");
-        });
+        let builder = Builder::new();
+        let scope = BuilderRustScope::new();
+        StringCallbacks::add_callbacks_to_scope_prefixed(&scope, "string_");
+        builder.set_scope(Some(&scope));
+        builder.add_from_string(CLOSURE_XML).unwrap();
+        let entry_a = builder.object::<Entry>("entry_a").unwrap();
+        let entry_b = builder.object::<Entry>("entry_b").unwrap();
+        entry_a.set_text("Hello World");
+        assert_eq!(entry_b.text().as_str(), "HELLO WORLD");
     }
 
-    #[test]
+    #[crate::test]
     #[should_panic(
         expected = "Closure returned a value of type guint64 but caller expected gchararray"
     )]
     fn test_rust_builder_scope_closure_return_mismatch() {
-        test_synced(move || {
-            use crate::Entry;
+        use crate::Entry;
 
-            pub struct StringCallbacks {}
-            #[template_callbacks]
-            impl StringCallbacks {
-                #[template_callback(function, name = "uppercase")]
-                fn to_u64(s: &str) -> u64 {
-                    skip_assert_initialized!();
-                    s.parse().unwrap_or(0)
-                }
+        pub struct StringCallbacks {}
+        #[template_callbacks]
+        impl StringCallbacks {
+            #[template_callback(function, name = "uppercase")]
+            fn to_u64(s: &str) -> u64 {
+                skip_assert_initialized!();
+                s.parse().unwrap_or(0)
             }
+        }
 
-            let builder = Builder::new();
-            let scope = BuilderRustScope::new();
-            StringCallbacks::add_callbacks_to_scope_prefixed(&scope, "string_");
-            builder.set_scope(Some(&scope));
-            builder.add_from_string(CLOSURE_XML).unwrap();
-            let entry_a = builder.object::<Entry>("entry_a").unwrap();
-            entry_a.set_text("Hello World");
-        });
+        let builder = Builder::new();
+        let scope = BuilderRustScope::new();
+        StringCallbacks::add_callbacks_to_scope_prefixed(&scope, "string_");
+        builder.set_scope(Some(&scope));
+        builder.add_from_string(CLOSURE_XML).unwrap();
+        let entry_a = builder.object::<Entry>("entry_a").unwrap();
+        entry_a.set_text("Hello World");
     }
 
     const DISPOSE_XML: &str = r##"
@@ -300,7 +294,7 @@ mod tests {
     </interface>
     "##;
 
-    #[test]
+    #[crate::test]
     fn test_rust_builder_scope_object_during_dispose() {
         use glib::subclass::Signal;
         use once_cell::sync::Lazy;
@@ -337,18 +331,16 @@ mod tests {
             }
         }
 
-        test_synced(move || {
-            let counter = {
-                MyObject::static_type();
-                let builder = Builder::new();
-                let scope = BuilderRustScope::new();
-                MyObject::add_callbacks_to_scope(&scope);
-                builder.set_scope(Some(&scope));
-                builder.add_from_string(DISPOSE_XML).unwrap();
-                let obj = builder.object::<MyObject>("obj").unwrap();
-                obj.imp().counter.clone()
-            };
-            assert_eq!(counter.get(), 1);
-        });
+        let counter = {
+            MyObject::static_type();
+            let builder = Builder::new();
+            let scope = BuilderRustScope::new();
+            MyObject::add_callbacks_to_scope(&scope);
+            builder.set_scope(Some(&scope));
+            builder.add_from_string(DISPOSE_XML).unwrap();
+            let obj = builder.object::<MyObject>("obj").unwrap();
+            obj.imp().counter.clone()
+        };
+        assert_eq!(counter.get(), 1);
     }
 }

--- a/gtk4/src/constant_expression.rs
+++ b/gtk4/src/constant_expression.rs
@@ -43,21 +43,19 @@ impl std::fmt::Debug for ConstantExpression {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_synced;
+    use crate as gtk4;
 
     #[test]
     fn test_expressions() {
-        test_synced(move || {
-            let expr1 = ConstantExpression::new(&23);
-            assert_eq!(expr1.value().get::<i32>().unwrap(), 23);
-            let expr2 = ConstantExpression::for_value(&"hello".to_value());
-            assert_eq!(expr2.value().get::<String>().unwrap(), "hello");
-            let expr1 = ConstantExpression::new(&23);
-            assert_eq!(expr1.value().get::<i32>().unwrap(), 23);
-            assert_eq!(expr1.value_as::<i32>(), 23);
-            let expr2 = ConstantExpression::for_value(&"hello".to_value());
-            assert_eq!(expr2.value().get::<String>().unwrap(), "hello");
-            assert_eq!(expr2.value_as::<String>(), "hello");
-        });
+        let expr1 = ConstantExpression::new(&23);
+        assert_eq!(expr1.value().get::<i32>().unwrap(), 23);
+        let expr2 = ConstantExpression::for_value(&"hello".to_value());
+        assert_eq!(expr2.value().get::<String>().unwrap(), "hello");
+        let expr1 = ConstantExpression::new(&23);
+        assert_eq!(expr1.value().get::<i32>().unwrap(), 23);
+        assert_eq!(expr1.value_as::<i32>(), 23);
+        let expr2 = ConstantExpression::for_value(&"hello".to_value());
+        assert_eq!(expr2.value().get::<String>().unwrap(), "hello");
+        assert_eq!(expr2.value_as::<String>(), "hello");
     }
 }

--- a/gtk4/src/dialog.rs
+++ b/gtk4/src/dialog.rs
@@ -139,3 +139,19 @@ impl<O: IsA<Dialog> + IsA<Widget>> DialogExtManual for O {
         self.show();
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate as gtk4;
+
+    #[test]
+    async fn dialog_future() {
+        let dialog = Dialog::new();
+        glib::idle_add_local_once(glib::clone!(@strong dialog => move || {
+            dialog.response(ResponseType::Ok);
+        }));
+        let response = dialog.run_future().await;
+        assert_eq!(response, ResponseType::Ok);
+    }
+}

--- a/gtk4/src/object_expression.rs
+++ b/gtk4/src/object_expression.rs
@@ -18,14 +18,12 @@ impl std::fmt::Debug for ObjectExpression {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_synced;
+    use crate as gtk4;
 
     #[test]
     fn test_object_expression() {
-        test_synced(move || {
-            let obj = crate::IconTheme::new();
-            let expr = ObjectExpression::new(&obj);
-            assert_eq!(expr.object().unwrap(), obj);
-        });
+        let obj = crate::IconTheme::new();
+        let expr = ObjectExpression::new(&obj);
+        assert_eq!(expr.object().unwrap(), obj);
     }
 }

--- a/gtk4/src/param_spec_expression.rs
+++ b/gtk4/src/param_spec_expression.rs
@@ -106,20 +106,18 @@ impl glib::value::ToValueOptional for ParamSpecExpression {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_synced;
+    use crate as gtk4;
 
     #[test]
     fn test_paramspec_expression() {
-        test_synced(move || {
-            let pspec = ParamSpecExpression::new(
-                "expression",
-                "Expression",
-                "Some Expression",
-                glib::ParamFlags::CONSTRUCT_ONLY | glib::ParamFlags::READABLE,
-            );
+        let pspec = ParamSpecExpression::new(
+            "expression",
+            "Expression",
+            "Some Expression",
+            glib::ParamFlags::CONSTRUCT_ONLY | glib::ParamFlags::READABLE,
+        );
 
-            let expr_pspec = pspec.downcast::<ParamSpecExpression>();
-            assert!(expr_pspec.is_ok());
-        });
+        let expr_pspec = pspec.downcast::<ParamSpecExpression>();
+        assert!(expr_pspec.is_ok());
     }
 }

--- a/gtk4/src/property_expression.rs
+++ b/gtk4/src/property_expression.rs
@@ -19,17 +19,15 @@ impl std::fmt::Debug for PropertyExpression {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_synced;
+    use crate as gtk4;
     use glib::StaticType;
 
     #[test]
     fn test_property_expression() {
-        test_synced(move || {
-            let _prop_expr = PropertyExpression::new(
-                crate::StringObject::static_type(),
-                crate::Expression::NONE,
-                "string",
-            );
-        });
+        let _prop_expr = PropertyExpression::new(
+            crate::StringObject::static_type(),
+            crate::Expression::NONE,
+            "string",
+        );
     }
 }

--- a/gtk4/src/rt.rs
+++ b/gtk4/src/rt.rs
@@ -118,7 +118,10 @@ pub fn init() -> Result<(), glib::BoolError> {
     if is_initialized_main_thread() {
         return Ok(());
     } else if is_initialized() {
+        #[cfg(not(test))]
         panic!("Attempted to initialize GTK from two different threads.");
+        #[cfg(test)]
+        panic!("Use #[gtk::test] instead of #[test]");
     }
 
     unsafe {
@@ -146,13 +149,11 @@ pub fn init() -> Result<(), glib::BoolError> {
 
 #[cfg(test)]
 mod tests {
-    use crate::test_synced;
+    use crate as gtk4;
 
     #[test]
     fn init_should_acquire_default_main_context() {
-        test_synced(move || {
-            let context = glib::MainContext::ref_thread_default();
-            assert!(context.is_owner());
-        });
+        let context = glib::MainContext::ref_thread_default();
+        assert!(context.is_owner());
     }
 }

--- a/gtk4/src/string_list.rs
+++ b/gtk4/src/string_list.rs
@@ -49,32 +49,28 @@ impl Default for StringList {
 #[cfg(test)]
 mod tests {
     use super::StringList;
-    use crate::test_synced;
+    use crate as gtk4;
 
     #[test]
     fn test_from_iter() {
-        test_synced(move || {
-            let strings = vec!["hello", "world", "stuff"]
-                .into_iter()
-                .collect::<StringList>();
-            assert_eq!(strings.string(1).unwrap(), "world");
+        let strings = vec!["hello", "world", "stuff"]
+            .into_iter()
+            .collect::<StringList>();
+        assert_eq!(strings.string(1).unwrap(), "world");
 
-            let strings2 = vec!["hello".to_string(), "world".to_string()]
-                .into_iter()
-                .collect::<StringList>();
+        let strings2 = vec!["hello".to_string(), "world".to_string()]
+            .into_iter()
+            .collect::<StringList>();
 
-            assert_eq!(strings2.string(1).unwrap(), "world");
-        });
+        assert_eq!(strings2.string(1).unwrap(), "world");
     }
 
     #[test]
     fn test_extend() {
-        test_synced(move || {
-            let mut strings = vec!["hello", "world", "stuff"]
-                .into_iter()
-                .collect::<StringList>();
-            strings.extend(["gtk-rs", "gtk4", "gnome"]);
-            assert_eq!(strings.string(4).unwrap(), "gtk4");
-        });
+        let mut strings = vec!["hello", "world", "stuff"]
+            .into_iter()
+            .collect::<StringList>();
+        strings.extend(["gtk-rs", "gtk4", "gnome"]);
+        assert_eq!(strings.string(4).unwrap(), "gtk4");
     }
 }

--- a/gtk4/src/subclass/entry_buffer.rs
+++ b/gtk4/src/subclass/entry_buffer.rs
@@ -312,19 +312,19 @@ fn text_n_chars(text: &str, n_chars: u32) -> &str {
 #[cfg(test)]
 mod test {
     use super::text_n_chars;
-    #[test]
+    #[std::prelude::v1::test]
     fn n_chars_max_length_ascii() {
         assert_eq!(text_n_chars("gtk-rs bindings", 6), "gtk-rs");
         assert_eq!(text_n_chars("gtk-rs bindings", u32::MAX), "gtk-rs bindings");
     }
 
-    #[test]
+    #[std::prelude::v1::test]
     #[should_panic]
     fn n_chars_max_length_ascii_panic() {
         assert_eq!(text_n_chars("gtk-rs", 7), "gtk-rs");
     }
 
-    #[test]
+    #[std::prelude::v1::test]
     fn n_chars_max_length_utf8() {
         assert_eq!(text_n_chars("👨👩👧👦", 2), "👨👩");
         assert_eq!(text_n_chars("👨👩👧👦", 0), "");
@@ -333,14 +333,14 @@ mod test {
         assert_eq!(text_n_chars("كتاب", 2), "كت");
     }
 
-    #[test]
+    #[std::prelude::v1::test]
     fn n_chars_max_length_utf8_ascii() {
         assert_eq!(text_n_chars("👨g👩t👧k👦", 2), "👨g");
         assert_eq!(text_n_chars("👨g👩t👧k👦", 5), "👨g👩t👧");
         assert_eq!(text_n_chars("كaتاب", 3), "كaت");
     }
 
-    #[test]
+    #[std::prelude::v1::test]
     #[should_panic]
     fn n_chars_max_length_utf8_panic() {
         assert_eq!(text_n_chars("👨👩👧👦", 5), "👨👩");


### PR DESCRIPTION
Related to #951. Some notes:

- This allows us to remove `test_synced` from the internal unit tests
  - Downside is all the internal tests (inside `#[cfg(test)] mod tests { }` blocks) must have `use crate as gtk4` at the top to avoid issues with proc_macro_crate. Not an issue externally or for tests in the tests folder
  - Makes it possible to have a unit test run correctly in the gtk4-macros crate
- Was trivial to add support for async functions as unit tests
- The macro shadows the prelude `test`, so internally we have to use `#[std::prelude::v1::test]` for the few tests that don't need to run on the main thread. Not an issue externally unless someone uses `macro_use`
- Maybe would have been nicer to put this in another crate, but couldn't figure out how to do that without creating a circular dependency on gtk4