### PR TITLE
gtk4-macros: Improve error reporting, add failure tests

### DIFF
--- a/gtk4-macros/Cargo.toml
+++ b/gtk4-macros/Cargo.toml
@@ -24,3 +24,4 @@ syn = {version = "1.0", default-features = false, features = ["full"]}
 
 [dev-dependencies]
 gtk = { path = "../gtk4", package = "gtk4", version = "0.5.0" }
+trybuild2 = "1.0"

--- a/gtk4-macros/tests/compile-fail/composite-template-duplicate-id-attr.rs
+++ b/gtk4-macros/tests/compile-fail/composite-template-duplicate-id-attr.rs
@@ -1,0 +1,53 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use gtk::prelude::*;
+use gtk::glib;
+
+mod imp {
+    use super::*;
+    use gtk::subclass::prelude::*;
+    use gtk::CompositeTemplate;
+
+    #[derive(Debug, Default, CompositeTemplate)]
+    #[template(string = r#"
+    <interface>
+       <template class="MyWidget" parent="GtkWidget">
+          <child>
+            <object class="GtkLabel" id="the_label"/>
+          </child>
+       </template>
+    </interface>
+    "#)]
+    pub struct MyWidget {
+        #[template_child(id = "the_label", id = "the_label")]
+        pub label: TemplateChild<gtk::Label>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for MyWidget {
+        const NAME: &'static str = "MyWidget";
+        type Type = super::MyWidget;
+        type ParentType = gtk::Widget;
+        fn class_init(klass: &mut Self::Class) {
+            klass.bind_template();
+        }
+        fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for MyWidget {
+        fn dispose(&self, obj: &Self::Type) {
+            if let Some(child) = obj.first_child() {
+                child.unparent();
+            }
+        }
+    }
+    impl WidgetImpl for MyWidget {}
+}
+
+glib::wrapper! {
+    pub struct MyWidget(ObjectSubclass<imp::MyWidget>) @extends gtk::Widget;
+}
+
+fn main() {}

--- a/gtk4-macros/tests/compile-fail/template-callback-arg-after-rest.rs
+++ b/gtk4-macros/tests/compile-fail/template-callback-arg-after-rest.rs
@@ -1,0 +1,18 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use gtk::glib;
+use gtk::subclass::prelude::*;
+
+struct Functions {}
+
+#[gtk::template_callbacks]
+impl Functions {
+    #[template_callback(function)]
+    fn after_rest(#[rest] _values: &[glib::Value], bad: i32) {}
+}
+
+fn main() {
+    gtk::init().unwrap();
+    let scope = gtk::BuilderRustScope::new();
+    Functions::add_callbacks_to_scope(&scope);
+}

--- a/gtk4-macros/tests/compile-fail/template-callback-duplicate-rest.rs
+++ b/gtk4-macros/tests/compile-fail/template-callback-duplicate-rest.rs
@@ -1,0 +1,18 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use gtk::glib;
+use gtk::subclass::prelude::*;
+
+struct Functions {}
+
+#[gtk::template_callbacks]
+impl Functions {
+    #[template_callback(function)]
+    fn after_rest(#[rest] #[rest] _values: &[glib::Value]) {}
+}
+
+fn main() {
+    gtk::init().unwrap();
+    let scope = gtk::BuilderRustScope::new();
+    Functions::add_callbacks_to_scope(&scope);
+}

--- a/gtk4-macros/tests/compile-fail/template-callback-duplicate.rs
+++ b/gtk4-macros/tests/compile-fail/template-callback-duplicate.rs
@@ -1,0 +1,18 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+//
+use gtk::subclass::prelude::*;
+
+struct Functions {}
+
+#[gtk::template_callbacks]
+impl Functions {
+    #[template_callback]
+    #[template_callback]
+    fn the_duplicate() {}
+}
+
+fn main() {
+    gtk::init().unwrap();
+    let scope = gtk::BuilderRustScope::new();
+    Functions::add_callbacks_to_scope(&scope);
+}

--- a/gtk4-macros/tests/compile-fail/template-callback-mut-self.rs
+++ b/gtk4-macros/tests/compile-fail/template-callback-mut-self.rs
@@ -1,0 +1,36 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use gtk::glib;
+
+mod imp {
+    use super::*;
+    use gtk::subclass::prelude::*;
+
+    #[derive(Debug, Default)]
+    pub struct MyWidget {}
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for MyWidget {
+        const NAME: &'static str = "MyWidget";
+        type Type = super::MyWidget;
+        type ParentType = gtk::Widget;
+        fn class_init(klass: &mut Self::Class) {
+            klass.bind_template_instance_callbacks();
+        }
+    }
+
+    impl ObjectImpl for MyWidget {}
+    impl WidgetImpl for MyWidget {}
+}
+
+glib::wrapper! {
+    pub struct MyWidget(ObjectSubclass<imp::MyWidget>) @extends gtk::Widget;
+}
+
+#[gtk::template_callbacks]
+impl MyWidget {
+    #[template_callback]
+    pub fn invalid_callback(&mut self) {}
+}
+
+fn main() {}

--- a/gtk4-macros/tests/compile.rs
+++ b/gtk4-macros/tests/compile.rs
@@ -1,0 +1,26 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+#[test]
+fn failures() {
+    let t = trybuild2::TestCases::new();
+    t.compile_fail_check_sub(
+        "tests/compile-fail/composite-template-duplicate-id-attr.rs",
+        "error: two instances of the same attribute argument, each argument must be specified only once",
+    );
+    t.compile_fail_check_sub(
+        "tests/compile-fail/template-callback-arg-after-rest.rs",
+        "error: Arguments past argument with `rest` attribute",
+    );
+    t.compile_fail_check_sub(
+        "tests/compile-fail/template-callback-duplicate-rest.rs",
+        "error: Duplicate `rest` attribute",
+    );
+    t.compile_fail_check_sub(
+        "tests/compile-fail/template-callback-duplicate.rs",
+        "error: Duplicate `template_callback` attribute",
+    );
+    t.compile_fail_check_sub(
+        "tests/compile-fail/template-callback-mut-self.rs",
+        "error: Receiver must be `&self`",
+    );
+}

--- a/gtk4-macros/tests/template-string.rs
+++ b/gtk4-macros/tests/template-string.rs
@@ -35,7 +35,13 @@ mod imp {
         }
     }
 
-    impl ObjectImpl for MyWidget {}
+    impl ObjectImpl for MyWidget {
+        fn dispose(&self, obj: &Self::Type) {
+            if let Some(child) = obj.first_child() {
+                child.unparent();
+            }
+        }
+    }
     impl WidgetImpl for MyWidget {}
 }
 


### PR DESCRIPTION
The error messages here are quite spammy and fail the whole code generation step for non-fatal errors like duplicate attributes. So let's reduce the error reporting to only emit and then continue on, e.g. just generate an empty clause in the trait so as not to trigger any additional errors. This only works on nightly for now but will "just work" if and when `Diagnostic` gets stabilized because of proc_macro_error.

@GuillaumeGomez Could this be maybe improved in any way with trybuild2?