### PR TITLE
More checks for composite template children

### DIFF
--- a/gtk4-macros/Cargo.toml
+++ b/gtk4-macros/Cargo.toml
@@ -16,6 +16,7 @@ proc-macro = true
 
 [dependencies]
 anyhow = "1.0"
+quick-xml = "0.22.0"
 proc-macro-crate = "1.0"
 proc-macro-error = "1.0"
 proc-macro2 = "1.0"

--- a/gtk4-macros/src/attribute_parser.rs
+++ b/gtk4-macros/src/attribute_parser.rs
@@ -9,37 +9,74 @@ use syn::{
     Type,
 };
 
+pub struct Template {
+    pub source: TemplateSource,
+    pub allow_template_child_without_attribute: bool,
+}
+
 pub enum TemplateSource {
     File(String),
     Resource(String),
     String(String),
 }
 
-pub fn parse_template_source(input: &DeriveInput) -> Result<TemplateSource> {
+pub fn parse_template_source(input: &DeriveInput) -> Result<Template> {
     let meta = match find_attribute_meta(&input.attrs, "template")? {
         Some(meta) => meta,
         _ => bail!("Missing 'template' attribute"),
     };
 
-    let meta = match meta.nested.iter().find(|n| match n {
-        NestedMeta::Meta(m) => {
+    let mut allow_template_child_without_attribute = false;
+    let mut source = None;
+
+    for n in meta.nested.iter() {
+        if let NestedMeta::Meta(m) = n {
             let p = m.path();
-            p.is_ident("file") || p.is_ident("resource") || p.is_ident("string")
+            if p.is_ident("file") || p.is_ident("resource") || p.is_ident("string") {
+                if source.is_some() {
+                    bail!(Error::new_spanned(
+                        &p,
+                        "Specify only one of 'file', 'resource', or 'string'"
+                    ));
+                }
+                source.replace(n);
+            }
+            if p.is_ident("allow_template_child_without_attribute") {
+                if !matches!(m, Meta::Path(_)) {
+                    bail!(Error::new_spanned(&m, "Wrong meta"));
+                }
+                if allow_template_child_without_attribute {
+                    bail!(Error::new_spanned(
+                        &p,
+                        "Duplicate 'allow_template_child_without_attribute'"
+                    ));
+                }
+                allow_template_child_without_attribute = true;
+            }
+        } else {
+            bail!(Error::new_spanned(&n, "wrong meta type"));
         }
-        _ => false,
-    }) {
-        Some(meta) => meta,
-        _ => bail!("Invalid meta, specify one of 'file', 'resource', or 'string'"),
+    }
+    let source = match source {
+        Some(source) => source,
+        None => bail!(Error::new_spanned(
+            &meta,
+            "Invalid meta, specify one of 'file', 'resource', or 'string'"
+        )),
     };
 
-    let (ident, v) = parse_attribute(meta)?;
+    let (ident, v) = parse_attribute(source)?;
 
-    match ident.as_ref() {
-        "file" => Ok(TemplateSource::File(v)),
-        "resource" => Ok(TemplateSource::Resource(v)),
-        "string" => Ok(TemplateSource::String(v)),
+    let source = match ident.as_ref() {
+        "file" => TemplateSource::File(v),
+        "resource" => TemplateSource::Resource(v),
+        "string" => TemplateSource::String(v),
         s => bail!("Unknown enum meta {}", s),
-    }
+    };
+    Ok(Template {
+        source,
+        allow_template_child_without_attribute,
+    })
 }
 
 // find the #[@attr_name] attribute in @attrs
@@ -269,13 +306,53 @@ fn parse_field(field: &Field) -> Result<Option<AttributedField>, Error> {
     }
 }
 
-pub fn parse_fields(fields: &Fields) -> Result<Vec<AttributedField>, Error> {
+fn path_is_template_child(path: &syn::Path) -> bool {
+    if path.leading_colon.is_none()
+        && path.segments.len() == 1
+        && matches!(
+            &path.segments[0].arguments,
+            syn::PathArguments::AngleBracketed(_)
+        )
+        && path.segments[0].ident == "TemplateChild"
+    {
+        return true;
+    }
+    if path.segments.len() == 2
+        && (path.segments[0].ident == "gtk" || path.segments[0].ident == "gtk4")
+        && matches!(
+            &path.segments[1].arguments,
+            syn::PathArguments::AngleBracketed(_)
+        )
+        && path.segments[1].ident == "TemplateChild"
+    {
+        return true;
+    }
+    false
+}
+
+pub fn parse_fields(
+    fields: &Fields,
+    allow_missing_attribute: bool,
+) -> Result<Vec<AttributedField>, Error> {
     let mut attributed_fields = Vec::new();
 
     for field in fields {
+        let mut has_attr = false;
         if !field.attrs.is_empty() {
             if let Some(attributed_field) = parse_field(field)? {
-                attributed_fields.push(attributed_field)
+                attributed_fields.push(attributed_field);
+                has_attr = true;
+            }
+        }
+        if !has_attr && !allow_missing_attribute {
+            if let syn::Type::Path(syn::TypePath { path, .. }) = &field.ty {
+                if path_is_template_child(path) {
+                    proc_macro_error::emit_error!(
+                        field,
+                        "field `{}` with type `TemplateChild` possibly missing #[template_child] attribute. Use a meta attribute on the struct to suppress this error: '#[template(string|file|resource = \"...\", allow_template_child_without_attribute)]'",
+                        field.ident.as_ref().unwrap().to_string(),
+                    );
+                }
             }
         }
     }

--- a/gtk4-macros/src/composite_template_derive.rs
+++ b/gtk4-macros/src/composite_template_derive.rs
@@ -5,6 +5,7 @@ use proc_macro_error::{emit_call_site_error, emit_error};
 use quote::quote;
 use syn::Data;
 
+use std::collections::HashMap;
 use std::string::ToString;
 
 use crate::attribute_parser::*;
@@ -24,6 +25,65 @@ fn gen_set_template(source: &TemplateSource) -> TokenStream {
     }
 }
 
+fn check_template_fields(source: &TemplateSource, fields: &[AttributedField]) {
+    #[allow(unused_assignments)]
+    let xml = match source {
+        TemplateSource::String(template) => template,
+        _ => return,
+    };
+
+    let mut reader = quick_xml::Reader::from_str(xml);
+    let mut buf = Vec::new();
+    let mut ids_left = fields
+        .iter()
+        .map(|field| match field.attr.ty {
+            FieldAttributeType::TemplateChild => (field.id(), field.id_span()),
+        })
+        .collect::<HashMap<_, _>>();
+
+    loop {
+        use quick_xml::events::Event;
+
+        let event = reader.read_event(&mut buf);
+        let elem = match &event {
+            Ok(Event::Start(e)) => Some(e),
+            Ok(Event::Empty(e)) => Some(e),
+            Ok(Event::Eof) => break,
+            Err(e) => {
+                emit_call_site_error!(
+                    "Failed reading template XML at position {}: {:?}",
+                    reader.buffer_position(),
+                    e
+                );
+                break;
+            }
+            _ => None,
+        };
+        if let Some(e) = elem {
+            let name = e.name();
+            if name == b"object" || name == b"template" {
+                let id = e
+                    .attributes()
+                    .find_map(|a| a.ok().and_then(|a| (a.key == b"id").then(|| a)));
+                let id = id.as_ref().and_then(|a| std::str::from_utf8(&a.value).ok());
+                if let Some(id) = id {
+                    ids_left.remove(id);
+                }
+            }
+        }
+
+        buf.clear();
+    }
+
+    if let Some((name, span)) = ids_left.iter().next() {
+        emit_error!(
+            span,
+            "Template child with id `{}` not found in template XML",
+            name
+        );
+    }
+}
+
 fn gen_template_child_bindings(fields: &[AttributedField]) -> TokenStream {
     let crate_ident = crate_ident_new();
 
@@ -33,7 +93,7 @@ fn gen_template_child_bindings(fields: &[AttributedField]) -> TokenStream {
             let ident = &field.ident;
             let mut value_internal = false;
             field.attr.args.iter().for_each(|arg| match arg {
-                FieldAttributeArg::Id(value) => {
+                FieldAttributeArg::Id(value, _) => {
                     value_id = value;
                 }
                 FieldAttributeArg::Internal(internal) => {
@@ -112,6 +172,10 @@ pub fn impl_composite_template(input: &syn::DeriveInput) -> TokenStream {
         }
         None => vec![],
     };
+
+    if let Some(source) = &source {
+        check_template_fields(source, &attributed_fields);
+    }
 
     let template_children = gen_template_child_bindings(&attributed_fields);
     let checks = gen_template_child_type_checks(&attributed_fields);

--- a/gtk4-macros/tests/compile-fail/composite-template-bad-xml.rs
+++ b/gtk4-macros/tests/compile-fail/composite-template-bad-xml.rs
@@ -1,0 +1,41 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use gtk::prelude::*;
+use gtk::glib;
+
+mod imp {
+    use super::*;
+    use gtk::subclass::prelude::*;
+    use gtk::CompositeTemplate;
+
+    #[derive(Debug, Default, CompositeTemplate)]
+    #[template(string = r#"
+    <interface>
+       <template class="MyWidget" parent="GtkWidget">
+    </interface>
+    "#)]
+    pub struct MyWidget {}
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for MyWidget {
+        const NAME: &'static str = "MyWidget";
+        type Type = super::MyWidget;
+        type ParentType = gtk::Widget;
+        fn class_init(klass: &mut Self::Class) {
+            klass.bind_template();
+        }
+        fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for MyWidget {}
+    impl WidgetImpl for MyWidget {}
+}
+
+glib::wrapper! {
+    pub struct MyWidget(ObjectSubclass<imp::MyWidget>) @extends gtk::Widget;
+}
+
+fn main() {}
+

--- a/gtk4-macros/tests/compile-fail/composite-template-missing-child-attr.rs
+++ b/gtk4-macros/tests/compile-fail/composite-template-missing-child-attr.rs
@@ -1,0 +1,54 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use gtk::prelude::*;
+use gtk::glib;
+
+mod imp {
+    use super::*;
+    use gtk::subclass::prelude::*;
+    use gtk::CompositeTemplate;
+
+    #[derive(Debug, Default, CompositeTemplate)]
+    #[template(string = r#"
+    <interface>
+      <template class="MyWidget" parent="GtkWidget">
+        <child>
+          <object class="GtkLabel" id="label"/>
+        </child>
+      </template>
+    </interface>
+    "#)]
+    #[allow(dead_code)]
+    pub struct MyWidget {
+        label: TemplateChild<gtk::Label>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for MyWidget {
+        const NAME: &'static str = "MyWidget";
+        type Type = super::MyWidget;
+        type ParentType = gtk::Widget;
+        fn class_init(klass: &mut Self::Class) {
+            klass.bind_template();
+        }
+        fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for MyWidget {
+        fn dispose(&self, obj: &Self::Type) {
+            while let Some(child) = obj.first_child() {
+                child.unparent();
+            }
+        }
+    }
+    impl WidgetImpl for MyWidget {}
+}
+
+glib::wrapper! {
+    pub struct MyWidget(ObjectSubclass<imp::MyWidget>) @extends gtk::Widget;
+}
+
+fn main() {}
+

--- a/gtk4-macros/tests/compile-fail/composite-template-missing-fq-child-attr.rs
+++ b/gtk4-macros/tests/compile-fail/composite-template-missing-fq-child-attr.rs
@@ -1,0 +1,54 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use gtk::prelude::*;
+use gtk::glib;
+
+mod imp {
+    use super::*;
+    use gtk::subclass::prelude::*;
+    use gtk::CompositeTemplate;
+
+    #[derive(Debug, Default, CompositeTemplate)]
+    #[template(string = r#"
+    <interface>
+      <template class="MyWidget" parent="GtkWidget">
+        <child>
+          <object class="GtkLabel" id="label"/>
+        </child>
+      </template>
+    </interface>
+    "#)]
+    #[allow(dead_code)]
+    pub struct MyWidget {
+        label: gtk::TemplateChild<gtk::Label>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for MyWidget {
+        const NAME: &'static str = "MyWidget";
+        type Type = super::MyWidget;
+        type ParentType = gtk::Widget;
+        fn class_init(klass: &mut Self::Class) {
+            klass.bind_template();
+        }
+        fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for MyWidget {
+        fn dispose(&self, obj: &Self::Type) {
+            while let Some(child) = obj.first_child() {
+                child.unparent();
+            }
+        }
+    }
+    impl WidgetImpl for MyWidget {}
+}
+
+glib::wrapper! {
+    pub struct MyWidget(ObjectSubclass<imp::MyWidget>) @extends gtk::Widget;
+}
+
+fn main() {}
+

--- a/gtk4-macros/tests/compile-fail/composite-template-missing-id.rs
+++ b/gtk4-macros/tests/compile-fail/composite-template-missing-id.rs
@@ -1,0 +1,54 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use gtk::prelude::*;
+use gtk::glib;
+
+mod imp {
+    use super::*;
+    use gtk::subclass::prelude::*;
+    use gtk::CompositeTemplate;
+
+    #[derive(Debug, Default, CompositeTemplate)]
+    #[template(string = r#"
+    <interface>
+       <template class="MyWidget" parent="GtkWidget">
+          <child>
+            <object class="GtkLabel" id="other_label"/>
+          </child>
+       </template>
+    </interface>
+    "#)]
+    pub struct MyWidget {
+        #[template_child]
+        pub label: TemplateChild<gtk::Label>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for MyWidget {
+        const NAME: &'static str = "MyWidget";
+        type Type = super::MyWidget;
+        type ParentType = gtk::Widget;
+        fn class_init(klass: &mut Self::Class) {
+            klass.bind_template();
+        }
+        fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for MyWidget {
+        fn dispose(&self, obj: &Self::Type) {
+            if let Some(child) = obj.first_child() {
+                child.unparent();
+            }
+        }
+    }
+    impl WidgetImpl for MyWidget {}
+}
+
+glib::wrapper! {
+    pub struct MyWidget(ObjectSubclass<imp::MyWidget>) @extends gtk::Widget;
+}
+
+fn main() {}
+

--- a/gtk4-macros/tests/compile.rs
+++ b/gtk4-macros/tests/compile.rs
@@ -12,6 +12,14 @@ fn failures() {
         "error: two instances of the same attribute argument, each argument must be specified only once",
     );
     t.compile_fail_check_sub(
+        "tests/compile-fail/composite-template-missing-child-attr.rs",
+        "error: field `label` with type `TemplateChild` possibly missing #[template_child] attribute",
+    );
+    t.compile_fail_check_sub(
+        "tests/compile-fail/composite-template-missing-fq-child-attr.rs",
+        "error: field `label` with type `TemplateChild` possibly missing #[template_child] attribute",
+    );
+    t.compile_fail_check_sub(
         "tests/compile-fail/composite-template-missing-id.rs",
         "error: Template child with id `label` not found in template XML",
     );

--- a/gtk4-macros/tests/compile.rs
+++ b/gtk4-macros/tests/compile.rs
@@ -4,8 +4,16 @@
 fn failures() {
     let t = trybuild2::TestCases::new();
     t.compile_fail_check_sub(
+        "tests/compile-fail/composite-template-bad-xml.rs",
+        "error: Failed reading template XML",
+    );
+    t.compile_fail_check_sub(
         "tests/compile-fail/composite-template-duplicate-id-attr.rs",
         "error: two instances of the same attribute argument, each argument must be specified only once",
+    );
+    t.compile_fail_check_sub(
+        "tests/compile-fail/composite-template-missing-id.rs",
+        "error: Template child with id `label` not found in template XML",
     );
     t.compile_fail_check_sub(
         "tests/compile-fail/template-callback-async-ret-value.rs",

--- a/gtk4-macros/tests/templates.rs
+++ b/gtk4-macros/tests/templates.rs
@@ -16,12 +16,19 @@ mod imp {
             <property name="label">foobar</property>
           </object>
         </child>
+        <child>
+          <object class="GtkLabel" id="my_label2">
+            <property name="label">foobaz</property>
+          </object>
+        </child>
       </template>
     </interface>
     "#)]
     pub struct MyWidget {
         #[template_child]
         pub label: TemplateChild<gtk::Label>,
+        #[template_child(id = "my_label2")]
+        pub label2: TemplateChild<gtk::Label>,
     }
 
     #[glib::object_subclass]
@@ -39,7 +46,7 @@ mod imp {
 
     impl ObjectImpl for MyWidget {
         fn dispose(&self, obj: &Self::Type) {
-            if let Some(child) = obj.first_child() {
+            while let Some(child) = obj.first_child() {
                 child.unparent();
             }
         }
@@ -55,6 +62,7 @@ glib::wrapper! {
 fn template_string() {
     let widget: MyWidget = glib::Object::new(&[]).unwrap();
     assert_eq!(widget.imp().label.label(), "foobar");
+    assert_eq!(widget.imp().label2.label(), "foobaz");
 }
 
 mod imp2 {

--- a/gtk4/src/lib.rs
+++ b/gtk4/src/lib.rs
@@ -211,5 +211,6 @@ pub use pad_action_entry::PadActionEntry;
 pub use page_range::PageRange;
 pub use recent_data::RecentData;
 pub use response_type::ResponseType;
+pub use subclass::widget::TemplateChild;
 pub use tree_sortable::SortColumn;
 pub use widget::TickCallbackId;


### PR DESCRIPTION
To finish out the last part of https://github.com/gtk-rs/gtk4-rs/issues/179#issuecomment-1046256441:

- Try to parse the XML inside the macro and check for the existence of the ids. For now this only works for `#[template(string = "...")]` but could support `file = "..."` eventually if `proc_macro_span` is stabilized. Not sure if there is ever going to be a way to support `resource = "..."`
- Check for fields with type `TemplateChild<...>` and emit a warning if the `#[template_child]` attribute is missing. I don't want to make this an error because it's only really a heuristic for the common case. It only works on nightly. This is probably the best we'll get with #179 for now.