### PR TITLE
book: Add nix to linux installation guide

### DIFF
--- a/book/src/installation_linux.md
+++ b/book/src/installation_linux.md
@@ -24,8 +24,9 @@ Arch and derivatives:
 sudo pacman -S gtk4 base-devel
 ```
 
-Nix (with nix-command)
+Nix:  
+Add the following inputs to your derivation:
 
 ```
-nix shell nixpkgs#{gtk4, gcc}
+gtk4, gcc
 ```

--- a/book/src/installation_linux.md
+++ b/book/src/installation_linux.md
@@ -23,3 +23,9 @@ Arch and derivatives:
 ```
 sudo pacman -S gtk4 base-devel
 ```
+
+Nix (with nix-command)
+
+```
+nix shell nixpkgs#{gtk4, gcc}
+```


### PR DESCRIPTION
Adds instructions to start a new shell with gtk4 and gcc using [Nix](https://nixos.org/guides/how-nix-works.html) with [nix-command](https://nixos.wiki/wiki/Nix_command) enabled