### PR TITLE
fix vendoring by removing include from gdk4/Cargo.toml

### DIFF
--- a/gdk4/Cargo.toml
+++ b/gdk4/Cargo.toml
@@ -9,7 +9,6 @@ license = "MIT"
 name = "gdk4"
 readme = "README.md"
 repository = "https://github.com/gtk-rs/gtk4-rs"
-include = ["../LICENSE"]
 version = "0.5.0"
 rust-version = "1.57"
 [lib]


### PR DESCRIPTION
With that line, nothing in gdk4 gets vendored. See this explanation: https://github.com/rust-lang/cargo/issues/10617#issuecomment-1114361442

I've decided to just remove that line, because other crates in gtk4 don't have it. 