### PR TITLE
gtk4: Add an `unsafe-assume-initialized` feature

### DIFF
--- a/gtk4/Cargo.toml
+++ b/gtk4/Cargo.toml
@@ -21,6 +21,7 @@ v4_2 = ["ffi/v4_2", "gdk/v4_2", "gsk/v4_2"]
 v4_4 = ["ffi/v4_4", "v4_2", "gdk/v4_4", "gsk/v4_4"]
 v4_6 = ["ffi/v4_6", "v4_4", "gdk/v4_6", "gsk/v4_6", "pango/v1_50"]
 v4_8 = ["ffi/v4_8", "v4_6", "gdk/v4_8"]
+unsafe-assume-initialized = []
 
 [package.metadata.docs.rs]
 features = ["dox"]

--- a/gtk4/README.md
+++ b/gtk4/README.md
@@ -186,6 +186,7 @@ gtk = { git = "https://github.com/gtk-rs/gtk4-rs.git", package = "gtk4" }
 | `v4_6` | Enable the new APIs part of GTK 4.6 |
 | `v4_4` | Enable the new APIs part of GTK 4.4 |
 | `v4_2` | Enable the new APIs part of GTK 4.2 |
+| `unsafe-assume-initialized` | Disable checks that gtk is initialized, for use in C ABI libraries |
 
 ### See Also
 

--- a/gtk4/src/rt.rs
+++ b/gtk4/src/rt.rs
@@ -51,14 +51,22 @@ macro_rules! assert_not_initialized {
 #[inline]
 pub fn is_initialized() -> bool {
     skip_assert_initialized!();
-    INITIALIZED.load(Ordering::Acquire)
+    if cfg!(not(feature = "unsafe-assume-initialized")) {
+        INITIALIZED.load(Ordering::Acquire)
+    } else {
+        true
+    }
 }
 
 /// Returns `true` if GTK has been initialized and this is the main thread.
 #[inline]
 pub fn is_initialized_main_thread() -> bool {
     skip_assert_initialized!();
-    IS_MAIN_THREAD.with(|c| c.get())
+    if cfg!(not(feature = "unsafe-assume-initialized")) {
+        IS_MAIN_THREAD.with(|c| c.get())
+    } else {
+        true
+    }
 }
 
 /// Informs this crate that GTK has been initialized and the current thread is the main one.


### PR DESCRIPTION
This is useful for building a `cdylib`/`staticlib` with C ABI bindings, where `gtk_init()` will be called from outside Rust.

See also https://github.com/gtk-rs/gtk3-rs/pull/762 for GTK3.