### PR TITLE
Update docker image to Ubuntu 22.04

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ name: CI
 jobs:
   check:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/gtk-rs/gtk4-rs/gtk4:latest
     strategy:
@@ -50,7 +50,7 @@ jobs:
 
   examples:
     name: examples
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/gtk-rs/gtk4-rs/gtk4:latest
     steps:
@@ -68,7 +68,7 @@ jobs:
 
   fmt:
     name: rustfmt
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -84,7 +84,7 @@ jobs:
 
   regen_check:
     name: regen checker
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -116,7 +116,7 @@ jobs:
 
   checker:
     name: gtk-rs checker
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         crate:

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: listings build
     container:
       image: ghcr.io/gtk-rs/gtk4-rs/gtk4:latest
@@ -36,7 +36,7 @@ jobs:
         working-directory: book/listings
 
   build-deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: build
     steps:
       - uses: actions/checkout@v2
@@ -62,7 +62,7 @@ jobs:
           destination_dir: stable/latest/book
 
   codespell:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: codespell-project/actions-codespell@master

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: build
     container:
       image: ghcr.io/gtk-rs/gtk4-rs/gtk4:latest

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   docker:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Push to GitHub Packages


### PR DESCRIPTION
Relm4 optionally supports libpanel-rs and therefore installs libpanel in it's docs CI job (which uses the gtk-rs container to reduce build times). However, libpanel requires meson 0.60 but Ubuntu 20.04 only has meson 0.59. 
Upgrading the docker image to Ubuntu 22.04 would probably solve the issue and sounds like a reasonable step anyway since it's been out for a few months already. 

It's not a big deal though, so feel free to reject this PR.