### PR TITLE
ci: Only run book job if book was modified

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -2,9 +2,13 @@ name: book
 
 on:
   pull_request:
+    paths:
+      - "book/**"
   push:
     branches:
       - "master"
+    paths:
+      - "book/**"
   release:
     types: [published]
 


### PR DESCRIPTION
Avoid running unnecessary jobs as the book depends on stable release instead nowadays