### PR TITLE
Use mold as default linker in gtk-rs image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,6 @@ RUN dnf update -y
 RUN dnf install git xorg-x11-server-Xvfb procps-ng wget libjpeg-turbo-devel expat-devel mold 'dnf-command(builddep)' -y
 RUN dnf builddep gtk4 -y
 
-# setup mold as default linker
-RUN ln -sf $(which mold) $(realpath /usr/bin/ld)
-
 # build gtk4
 RUN git clone https://gitlab.gnome.org/gnome/gtk.git --depth=1
 WORKDIR gtk
@@ -14,6 +11,9 @@ RUN meson setup builddir --prefix=/usr -Dgtk_doc=false -Dintrospection=disabled 
 RUN meson install -C builddir
 WORKDIR /
 RUN rm -rf gtk
+
+# setup mold as default linker
+RUN ln -sf $(which mold) $(realpath /usr/bin/ld)
 
 # build libadwaita
 RUN git clone https://gitlab.gnome.org/GNOME/libadwaita.git -b 1.1.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 FROM fedora:latest
 
 RUN dnf update -y
-RUN dnf install git xorg-x11-server-Xvfb procps-ng wget libjpeg-turbo-devel expat-devel 'dnf-command(builddep)' -y
+RUN dnf install git xorg-x11-server-Xvfb procps-ng wget libjpeg-turbo-devel expat-devel mold 'dnf-command(builddep)' -y
 RUN dnf builddep gtk4 -y
+
+# setup mold as default linker
+RUN ln -sf $(which mold) $(realpath /usr/bin/ld)
 
 # build gtk4
 RUN git clone https://gitlab.gnome.org/gnome/gtk.git --depth=1


### PR DESCRIPTION
Mold should yield better performance for linking while building the docker image and running gtk-rs CI jobs.

I already tested this with Relm4 and it seems to perform slightly better although the actual numbers are hard to estimate due to high deviations in general. Probably, GitLab runners will profit more from this because GitHub actions are limited to just two cores AFAIK. In any case, there shouldn't be any regressions caused by this change.