### PR TITLE
Fixes #1114 by passing a null ptr when `colors` is empty

### DIFF
--- a/gtk4/src/color_chooser.rs
+++ b/gtk4/src/color_chooser.rs
@@ -21,7 +21,11 @@ impl<O: IsA<ColorChooser>> ColorChooserExtManual for O {
                 orientation.into_glib(),
                 colors_per_line,
                 colors.len() as c_int,
-                colors.as_ptr() as *mut gdk::ffi::GdkRGBA,
+                if colors.is_empty() {
+                    std::ptr::null_mut()
+                } else {
+                    colors.as_ptr() as *mut gdk::ffi::GdkRGBA
+                },
             )
         }
     }


### PR DESCRIPTION
[According to the documentation,](https://gtk-rs.org/gtk4-rs/git/docs/gtk4/prelude/trait.ColorChooserExtManual.html#tymethod.add_palette) passing in `NULL`/`None` for the `colors`argument should clear the previously added palettes of the color chooser. This is not possible since `colors` has to be a `&[RGBA]` slice. 

This pull request fixes this by checking if the slice is empty and if so passing on a null pointer instead.