### PR TITLE
Fix typos

### DIFF
--- a/gtk4-macros/README.md
+++ b/gtk4-macros/README.md
@@ -20,7 +20,7 @@ Currently, the minimum supported Rust version is `1.63.0`.
 
 | Feature | Description |
 | ---     | ----------- |
-| `xml_validation` | Check the existance of `#[template_child]` fields in the UI file. Only works with `#[template(string = "")]` |
+| `xml_validation` | Check the existence of `#[template_child]` fields in the UI file. Only works with `#[template(string = "")]` |
 
 ### See Also
 

--- a/gtk4/src/subclass/tree_view.rs
+++ b/gtk4/src/subclass/tree_view.rs
@@ -145,7 +145,7 @@ impl<T: TreeViewImpl> TreeViewImplExt for T {
         unsafe {
             let data = T::type_data();
             let parent_class = data.as_ref().parent_class() as *mut ffi::GtkTreeViewClass;
-            // cursor-changed is a sigal
+            // cursor-changed is a signal
             if let Some(f) = (*parent_class).cursor_changed {
                 f(tree_view.unsafe_cast_ref::<TreeView>().to_glib_none().0)
             }

--- a/gtk4/src/tree_row_reference.rs
+++ b/gtk4/src/tree_row_reference.rs
@@ -17,7 +17,7 @@ impl TreeRowReference {
         assert_eq!(
             new_order.len() as i32,
             self.model().iter_n_children(Some(iter)),
-            "TreeRowReference got passed a `new_order` bigger than the total childrens in the model for the passed iter"
+            "TreeRowReference got passed a `new_order` bigger than the total children in the model for the passed iter"
         );
         assert_initialized_main_thread!();
         unsafe {


### PR DESCRIPTION
Found via `codespell -L crate,gir,inout,rightt,doubleclick,fof,nd,ot`