### PR TITLE
Fix docs.rs builds

### DIFF
--- a/examples/custom_buildable/custom_buildable/imp.rs
+++ b/examples/custom_buildable/custom_buildable/imp.rs
@@ -59,7 +59,7 @@ impl BuildableImpl for CustomBuildable {
         } else if Some("prefix") == type_ {
             // Check if the child was added using `<child type="prefix">`
             buildable.add_prefix(child.downcast_ref::<gtk::Widget>().unwrap());
-        } else if None == type_ {
+        } else if type_.is_none() {
             // Normal children
             buildable.add_suffix(child.downcast_ref::<gtk::Widget>().unwrap());
         };

--- a/examples/text_viewer/main.rs
+++ b/examples/text_viewer/main.rs
@@ -45,7 +45,7 @@ pub fn build_ui(application: &Application) {
                 let file = d.file().expect("Couldn't get file");
 
                 let filename = file.path().expect("Couldn't get file path");
-                let file = File::open(&filename.as_path()).expect("Couldn't open file");
+                let file = File::open(filename.as_path()).expect("Couldn't open file");
 
                 let mut reader = BufReader::new(file);
                 let mut contents = String::new();

--- a/gdk4-wayland/Cargo.toml
+++ b/gdk4-wayland/Cargo.toml
@@ -14,7 +14,15 @@ rust-version = "1.63"
 
 [features]
 v4_4 = ["ffi/v4_4"]
-dox = ["ffi/dox", "xkb_crate", "wayland_crate", "egl"]
+dox = [
+    "ffi/dox",
+    "gdk/dox",
+    "gio/dox",
+    "glib/dox",
+    "xkb_crate",
+    "wayland_crate",
+    "egl",
+]
 wayland_crate = ["wayland-client"]
 egl = ["khronos-egl"]
 xkb_crate = ["xkb"]
@@ -23,14 +31,20 @@ xkb_crate = ["xkb"]
 features = ["dox"]
 
 [dependencies]
-ffi = {path = "./sys", package = "gdk4-wayland-sys", version = "0.5.0"}
-gdk = {path = "../gdk4", package = "gdk4", version = "0.5.0"}
-gio = {git = "https://github.com/gtk-rs/gtk-rs-core", version = "0.16", features = ["v2_66"]}
-glib = {git = "https://github.com/gtk-rs/gtk-rs-core", version = "0.16", features = ["v2_66"]}
+ffi = { path = "./sys", package = "gdk4-wayland-sys", version = "0.5.0" }
+gdk = { path = "../gdk4", package = "gdk4", version = "0.5.0" }
+gio = { git = "https://github.com/gtk-rs/gtk-rs-core", version = "0.16", features = [
+    "v2_66",
+] }
+glib = { git = "https://github.com/gtk-rs/gtk-rs-core", version = "0.16", features = [
+    "v2_66",
+] }
 libc = "0.2"
-wayland-client = {version = "0.29", features = ["use_system_lib"], optional = true}
-khronos-egl = {version = "4.1.0", optional = true}
-xkb = {version = "0.2.1", optional = true}
+wayland-client = { version = "0.29", features = [
+    "use_system_lib",
+], optional = true }
+khronos-egl = { version = "4.1.0", optional = true }
+xkb = { version = "0.2.1", optional = true }
 
 [dev-dependencies]
 gir-format-check = "^0.1"

--- a/gdk4-wayland/sys/Cargo.toml
+++ b/gdk4-wayland/sys/Cargo.toml
@@ -24,7 +24,7 @@ features = ["dox"]
 name = "gdk4_wayland_sys"
 
 [features]
-dox = []
+dox = ["glib/dox"]
 v4_4 = []
 
 [dependencies]

--- a/gdk4-x11/Cargo.toml
+++ b/gdk4-x11/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.5.0"
 rust-version = "1.63"
 [features]
 v4_4 = ["ffi/v4_4"]
-dox = ["ffi/dox", "egl", "xlib"]
+dox = ["ffi/dox", "gdk/dox", "gio/dox", "glib/dox", "egl", "xlib"]
 egl = ["khronos-egl"]
 xlib = ["x11"]
 
@@ -21,13 +21,17 @@ xlib = ["x11"]
 features = ["dox"]
 
 [dependencies]
-ffi = {path = "./sys", package = "gdk4-x11-sys", version = "0.5.0"}
-gdk = {path = "../gdk4", package = "gdk4", version = "0.5.0"}
-gio = {git = "https://github.com/gtk-rs/gtk-rs-core", version = "0.16", features = ["v2_66"]}
-glib = {git = "https://github.com/gtk-rs/gtk-rs-core", version = "0.16", features = ["v2_66"]}
+ffi = { path = "./sys", package = "gdk4-x11-sys", version = "0.5.0" }
+gdk = { path = "../gdk4", package = "gdk4", version = "0.5.0" }
+gio = { git = "https://github.com/gtk-rs/gtk-rs-core", version = "0.16", features = [
+    "v2_66",
+] }
+glib = { git = "https://github.com/gtk-rs/gtk-rs-core", version = "0.16", features = [
+    "v2_66",
+] }
 libc = "0.2"
-x11 = {version = "2.18", optional = true }
-khronos-egl = {version = "4.1.0", optional = true}
+x11 = { version = "2.18", optional = true }
+khronos-egl = { version = "4.1.0", optional = true }
 
 [dev-dependencies]
 gir-format-check = "^0.1"

--- a/gdk4-x11/sys/Cargo.toml
+++ b/gdk4-x11/sys/Cargo.toml
@@ -24,7 +24,7 @@ features = ["dox"]
 name = "gdk4_x11_sys"
 
 [features]
-dox = []
+dox = ["gdk/dox", "glib/dox"]
 v4_4 = []
 
 [dependencies]

--- a/gdk4/sys/Cargo.toml
+++ b/gdk4/sys/Cargo.toml
@@ -33,7 +33,14 @@ version = "4.7"
 name = "gdk4_sys"
 
 [features]
-dox = []
+dox = [
+    "cairo/dox",
+    "gdk-pixbuf/dox",
+    "gio/dox",
+    "glib/dox",
+    "gobject/dox",
+    "pango/dox",
+]
 v4_2 = []
 v4_4 = ["v4_2"]
 v4_6 = ["v4_4"]

--- a/gsk4/sys/Cargo.toml
+++ b/gsk4/sys/Cargo.toml
@@ -30,7 +30,14 @@ version = "4.6"
 name = "gsk4_sys"
 
 [features]
-dox = []
+dox = [
+    "cairo/dox",
+    "gdk/dox",
+    "glib/dox",
+    "gobject/dox",
+    "graphene/dox",
+    "pango/dox",
+]
 v4_2 = []
 v4_4 = ["v4_2"]
 v4_6 = ["v4_4"]

--- a/gtk4-macros/src/attribute_parser.rs
+++ b/gtk4-macros/src/attribute_parser.rs
@@ -35,7 +35,7 @@ pub fn parse_template_source(input: &DeriveInput) -> Result<Template> {
             if p.is_ident("file") || p.is_ident("resource") || p.is_ident("string") {
                 if source.is_some() {
                     bail!(Error::new_spanned(
-                        &p,
+                        p,
                         "Specify only one of 'file', 'resource', or 'string'"
                     ));
                 }
@@ -43,18 +43,18 @@ pub fn parse_template_source(input: &DeriveInput) -> Result<Template> {
             }
             if p.is_ident("allow_template_child_without_attribute") {
                 if !matches!(m, Meta::Path(_)) {
-                    bail!(Error::new_spanned(&m, "Wrong meta"));
+                    bail!(Error::new_spanned(m, "Wrong meta"));
                 }
                 if allow_template_child_without_attribute {
                     bail!(Error::new_spanned(
-                        &p,
+                        p,
                         "Duplicate 'allow_template_child_without_attribute'"
                     ));
                 }
                 allow_template_child_without_attribute = true;
             }
         } else {
-            bail!(Error::new_spanned(&n, "wrong meta type"));
+            bail!(Error::new_spanned(n, "wrong meta type"));
         }
     }
     let source = match source {

--- a/gtk4/Cargo.toml
+++ b/gtk4/Cargo.toml
@@ -16,7 +16,16 @@ rust-version = "1.63"
 name = "gtk4"
 
 [features]
-dox = ["gdk/dox", "gsk/dox", "ffi/dox"]
+dox = [
+    "ffi/dox",
+    "cairo-rs/dox",
+    "gdk/dox",
+    "gdk-pixbuf/dox",
+    "gio/dox",
+    "glib/dox",
+    "graphene/dox",
+    "gsk/dox",
+]
 v4_2 = ["ffi/v4_2", "gdk/v4_2", "gsk/v4_2"]
 v4_4 = ["ffi/v4_4", "v4_2", "gdk/v4_4", "gsk/v4_4"]
 v4_6 = ["ffi/v4_6", "v4_4", "gdk/v4_6", "gsk/v4_6", "pango/v1_50"]
@@ -29,20 +38,26 @@ features = ["dox"]
 
 [dependencies]
 bitflags = "1.0"
-cairo-rs = {git = "https://github.com/gtk-rs/gtk-rs-core", version = "0.16"}
-ffi = {package = "gtk4-sys", path = "./sys", version = "0.5.0"}
+cairo-rs = { git = "https://github.com/gtk-rs/gtk-rs-core", version = "0.16" }
+ffi = { package = "gtk4-sys", path = "./sys", version = "0.5.0" }
 field-offset = "0.3"
 futures-channel = "0.3"
-gdk = {package = "gdk4", path = "../gdk4", version = "0.5.0"}
-gdk-pixbuf = {git = "https://github.com/gtk-rs/gtk-rs-core", version = "0.16"}
-gio = {git = "https://github.com/gtk-rs/gtk-rs-core", version = "0.16", features = ["v2_66"]}
-glib = {git = "https://github.com/gtk-rs/gtk-rs-core", version = "0.16", features = ["v2_66"]}
-graphene = {package = "graphene-rs", git = "https://github.com/gtk-rs/gtk-rs-core", version = "0.16"}
-gsk = {package = "gsk4", path = "../gsk4", version = "0.5.0"}
-gtk4-macros = {path = "../gtk4-macros", version = "0.5.0"}
+gdk = { package = "gdk4", path = "../gdk4", version = "0.5.0" }
+gdk-pixbuf = { git = "https://github.com/gtk-rs/gtk-rs-core", version = "0.16" }
+gio = { git = "https://github.com/gtk-rs/gtk-rs-core", version = "0.16", features = [
+    "v2_66",
+] }
+glib = { git = "https://github.com/gtk-rs/gtk-rs-core", version = "0.16", features = [
+    "v2_66",
+] }
+graphene = { package = "graphene-rs", git = "https://github.com/gtk-rs/gtk-rs-core", version = "0.16" }
+gsk = { package = "gsk4", path = "../gsk4", version = "0.5.0" }
+gtk4-macros = { path = "../gtk4-macros", version = "0.5.0" }
 libc = "0.2"
 once_cell = "1.0"
-pango = {git = "https://github.com/gtk-rs/gtk-rs-core", version = "0.16", features = ["v1_46"]}
+pango = { git = "https://github.com/gtk-rs/gtk-rs-core", version = "0.16", features = [
+    "v1_46",
+] }
 
 [dev-dependencies]
 gir-format-check = "^0.1"

--- a/gtk4/src/expression.rs
+++ b/gtk4/src/expression.rs
@@ -126,7 +126,7 @@ impl Expression {
     where
         R: glib::value::ValueType,
     {
-        crate::ClosureExpression::new::<R>(&[self], closure)
+        crate::ClosureExpression::new::<R>([self], closure)
     }
 
     // rustdoc-stripper-ignore-next
@@ -137,7 +137,7 @@ impl Expression {
         F: Fn(&[glib::Value]) -> R + 'static,
         R: glib::value::ValueType,
     {
-        crate::ClosureExpression::with_callback(&[self], f)
+        crate::ClosureExpression::with_callback([self], f)
     }
 }
 


### PR DESCRIPTION
Analogous to: https://github.com/gtk-rs/gtk-rs-core/pull/778

Whenever a crate is published on crates.io, its documentation is automatically built on docs.rs regardless of the documentation field in the Cargo.toml file. On docs.rs it is possible to look at all previous versions. This is why there is value in having working builds on docs.rs. Having broken builds on docs.rs also prevents crates using that library from providing their own documentation on docs.rs. I enabled the dox feature wherever it is available to ensure the docs always build, even if the dependencies are not available.

In order to pass the build Actions, I also fixed some clippy lints.