### PR TITLE
gsk: Handle nullable Transform

### DIFF
--- a/examples/rotation_bin/rotation_bin/imp.rs
+++ b/examples/rotation_bin/rotation_bin/imp.rs
@@ -177,12 +177,11 @@ impl WidgetImpl for RotationBin {
         // center, instead of a corner, by taking half of width and height.
         let transform = transform
             .translate(&Point::new(width as f32 / 2.0, height as f32 / 2.0))
-            .unwrap();
-        // Rotate by the desired angle
-        let transform = transform.rotate(self.rotation(widget).into()).unwrap();
-        // Revert the move of the origin point once our rotation is done.
-        let transform = transform.translate(&Point::new(-w as f32 / 2.0, -h as f32 / 2.0));
-        child.allocate(w, h, baseline, transform.as_ref())
+            // Rotate by the desired angle
+            .rotate(self.rotation(widget).into())
+            // Revert the move of the origin point once our rotation is done.
+            .translate(&Point::new(-w as f32 / 2.0, -h as f32 / 2.0));
+        child.allocate(w, h, baseline, Some(&transform))
     }
 }
 

--- a/examples/scale_bin/scale_bin/imp.rs
+++ b/examples/scale_bin/scale_bin/imp.rs
@@ -76,7 +76,7 @@ impl WidgetImpl for ScaleBin {
             (width as f32 / zoom) as i32,
             (height as f32 / zoom) as i32,
             baseline,
-            transform.as_ref(),
+            Some(&transform),
         );
     }
 }

--- a/examples/squeezer_bin/squeezer_bin/imp.rs
+++ b/examples/squeezer_bin/squeezer_bin/imp.rs
@@ -101,9 +101,7 @@ impl WidgetImpl for SqueezerBin {
                 }
             }
 
-            let transform = gsk::Transform::new()
-                .scale(horizontal_zoom, vertical_zoom)
-                .unwrap();
+            let transform = gsk::Transform::new().scale(horizontal_zoom, vertical_zoom);
 
             child.allocate(
                 (width as f32 / horizontal_zoom) as i32,

--- a/gsk4/Gir.toml
+++ b/gsk4/Gir.toml
@@ -191,6 +191,9 @@ status = "generate"
             name = "second"
             nullable = false
     [[object.function]]
+    pattern = "(translate_3d|translate|transform|skew|scale_3d|scale|rotate_3d|rotate|invert)"
+    manual = true # those functions return NULL in C which represents an identity transform
+    [[object.function]]
     name = "print"
     ignore = true # Same as Transform::to_string
     [[object.function]]

--- a/gsk4/src/auto/transform.rs
+++ b/gsk4/src/auto/transform.rs
@@ -41,12 +41,6 @@ impl Transform {
         unsafe { from_glib(ffi::gsk_transform_get_category(self.to_glib_none().0)) }
     }
 
-    #[doc(alias = "gsk_transform_invert")]
-    #[must_use]
-    pub fn invert(&self) -> Option<Transform> {
-        unsafe { from_glib_full(ffi::gsk_transform_invert(self.to_glib_full())) }
-    }
-
     #[doc(alias = "gsk_transform_matrix")]
     #[must_use]
     pub fn matrix(&self, matrix: &graphene::Matrix) -> Transform {
@@ -62,57 +56,6 @@ impl Transform {
     #[must_use]
     pub fn perspective(&self, depth: f32) -> Transform {
         unsafe { from_glib_full(ffi::gsk_transform_perspective(self.to_glib_full(), depth)) }
-    }
-
-    #[doc(alias = "gsk_transform_rotate")]
-    #[must_use]
-    pub fn rotate(&self, angle: f32) -> Option<Transform> {
-        unsafe { from_glib_full(ffi::gsk_transform_rotate(self.to_glib_full(), angle)) }
-    }
-
-    #[doc(alias = "gsk_transform_rotate_3d")]
-    #[must_use]
-    pub fn rotate_3d(&self, angle: f32, axis: &graphene::Vec3) -> Option<Transform> {
-        unsafe {
-            from_glib_full(ffi::gsk_transform_rotate_3d(
-                self.to_glib_full(),
-                angle,
-                axis.to_glib_none().0,
-            ))
-        }
-    }
-
-    #[doc(alias = "gsk_transform_scale")]
-    #[must_use]
-    pub fn scale(&self, factor_x: f32, factor_y: f32) -> Option<Transform> {
-        unsafe {
-            from_glib_full(ffi::gsk_transform_scale(
-                self.to_glib_full(),
-                factor_x,
-                factor_y,
-            ))
-        }
-    }
-
-    #[doc(alias = "gsk_transform_scale_3d")]
-    #[must_use]
-    pub fn scale_3d(&self, factor_x: f32, factor_y: f32, factor_z: f32) -> Option<Transform> {
-        unsafe {
-            from_glib_full(ffi::gsk_transform_scale_3d(
-                self.to_glib_full(),
-                factor_x,
-                factor_y,
-                factor_z,
-            ))
-        }
-    }
-
-    #[cfg(any(feature = "v4_6", feature = "dox"))]
-    #[cfg_attr(feature = "dox", doc(cfg(feature = "v4_6")))]
-    #[doc(alias = "gsk_transform_skew")]
-    #[must_use]
-    pub fn skew(&self, skew_x: f32, skew_y: f32) -> Option<Transform> {
-        unsafe { from_glib_full(ffi::gsk_transform_skew(self.to_glib_full(), skew_x, skew_y)) }
     }
 
     #[doc(alias = "gsk_transform_to_2d")]
@@ -230,17 +173,6 @@ impl Transform {
         }
     }
 
-    #[doc(alias = "gsk_transform_transform")]
-    #[must_use]
-    pub fn transform(&self, other: Option<&Transform>) -> Option<Transform> {
-        unsafe {
-            from_glib_full(ffi::gsk_transform_transform(
-                self.to_glib_full(),
-                other.to_glib_none().0,
-            ))
-        }
-    }
-
     #[doc(alias = "gsk_transform_transform_bounds")]
     pub fn transform_bounds(&self, rect: &graphene::Rect) -> graphene::Rect {
         unsafe {
@@ -264,28 +196,6 @@ impl Transform {
                 out_point.to_glib_none_mut().0,
             );
             out_point
-        }
-    }
-
-    #[doc(alias = "gsk_transform_translate")]
-    #[must_use]
-    pub fn translate(&self, point: &graphene::Point) -> Option<Transform> {
-        unsafe {
-            from_glib_full(ffi::gsk_transform_translate(
-                self.to_glib_full(),
-                point.to_glib_none().0,
-            ))
-        }
-    }
-
-    #[doc(alias = "gsk_transform_translate_3d")]
-    #[must_use]
-    pub fn translate_3d(&self, point: &graphene::Point3D) -> Option<Transform> {
-        unsafe {
-            from_glib_full(ffi::gsk_transform_translate_3d(
-                self.to_glib_full(),
-                point.to_glib_none().0,
-            ))
         }
     }
 }

--- a/gsk4/src/lib.rs
+++ b/gsk4/src/lib.rs
@@ -66,6 +66,7 @@ mod rounded_clip_node;
 mod shadow_node;
 mod text_node;
 mod texture_node;
+mod transform;
 mod transform_node;
 
 pub use color_stop::ColorStop;

--- a/gsk4/src/transform.rs
+++ b/gsk4/src/transform.rs
@@ -5,10 +5,10 @@ use glib::translate::*;
 
 impl Transform {
     #[doc(alias = "gsk_transform_parse")]
-    pub fn parse(string: &str) -> Result<Transform, glib::BoolError> {
+    pub fn parse(string: &str) -> Result<Self, glib::BoolError> {
         assert_initialized_main_thread!();
         unsafe {
-            let mut out_transform = ptr::null_mut();
+            let mut out_transform = std::ptr::null_mut();
             let ret = from_glib(ffi::gsk_transform_parse(
                 string.to_glib_none().0,
                 &mut out_transform,
@@ -16,8 +16,119 @@ impl Transform {
             if ret {
                 Ok(from_glib_full(out_transform))
             } else {
-                glib::bool_error!("Can't parse Transform")
+                Err(glib::bool_error!("Can't parse Transform"))
             }
+        }
+    }
+
+    #[doc(alias = "gsk_transform_invert")]
+    pub fn invert(&self) -> Result<Self, glib::BoolError> {
+        unsafe {
+            let matrix = self.to_matrix();
+            if matrix == graphene::Matrix::new_identity() {
+                return Ok(self.clone());
+            }
+
+            let res: Option<Self> = from_glib_full(ffi::gsk_transform_invert(self.to_glib_full()));
+            res.ok_or_else(|| glib::bool_error!("Failed to invert the transform"))
+        }
+    }
+
+    #[doc(alias = "gsk_transform_rotate")]
+    #[must_use]
+    pub fn rotate(&self, angle: f32) -> Self {
+        unsafe {
+            let res: Option<Self> =
+                from_glib_full(ffi::gsk_transform_rotate(self.to_glib_full(), angle));
+            res.unwrap_or_else(Self::new)
+        }
+    }
+
+    #[doc(alias = "gsk_transform_rotate_3d")]
+    #[must_use]
+    pub fn rotate_3d(&self, angle: f32, axis: &graphene::Vec3) -> Self {
+        unsafe {
+            let res: Option<Self> = from_glib_full(ffi::gsk_transform_rotate_3d(
+                self.to_glib_full(),
+                angle,
+                axis.to_glib_none().0,
+            ));
+            res.unwrap_or_else(Self::new)
+        }
+    }
+
+    #[doc(alias = "gsk_transform_scale")]
+    #[must_use]
+    pub fn scale(&self, factor_x: f32, factor_y: f32) -> Self {
+        unsafe {
+            let res: Option<Self> = from_glib_full(ffi::gsk_transform_scale(
+                self.to_glib_full(),
+                factor_x,
+                factor_y,
+            ));
+            res.unwrap_or_else(Self::new)
+        }
+    }
+
+    #[doc(alias = "gsk_transform_scale_3d")]
+    #[must_use]
+    pub fn scale_3d(&self, factor_x: f32, factor_y: f32, factor_z: f32) -> Self {
+        unsafe {
+            let res: Option<Self> = from_glib_full(ffi::gsk_transform_scale_3d(
+                self.to_glib_full(),
+                factor_x,
+                factor_y,
+                factor_z,
+            ));
+            res.unwrap_or_else(Self::new)
+        }
+    }
+
+    #[cfg(any(feature = "v4_6", feature = "dox"))]
+    #[cfg_attr(feature = "dox", doc(cfg(feature = "v4_6")))]
+    #[doc(alias = "gsk_transform_skew")]
+    #[must_use]
+    pub fn skew(&self, skew_x: f32, skew_y: f32) -> Self {
+        unsafe {
+            let res: Option<Self> =
+                from_glib_full(ffi::gsk_transform_skew(self.to_glib_full(), skew_x, skew_y));
+            res.unwrap_or_else(Self::new)
+        }
+    }
+
+    #[doc(alias = "gsk_transform_transform")]
+    #[must_use]
+    pub fn transform(&self, other: Option<&Self>) -> Self {
+        unsafe {
+            let res: Option<Self> = from_glib_full(ffi::gsk_transform_transform(
+                self.to_glib_full(),
+                other.to_glib_none().0,
+            ));
+            res.unwrap_or_else(Self::new)
+        }
+    }
+
+    #[doc(alias = "gsk_transform_translate")]
+    #[must_use]
+    pub fn translate(&self, point: &graphene::Point) -> Self {
+        unsafe {
+            let res: Option<Self> = from_glib_full(ffi::gsk_transform_translate(
+                self.to_glib_full(),
+                point.to_glib_none().0,
+            ));
+            res.unwrap_or_else(Self::new)
+        }
+    }
+
+    #[doc(alias = "gsk_transform_translate_3d")]
+    #[must_use]
+    pub fn translate_3d(&self, point: &graphene::Point3D) -> Self {
+        unsafe {
+            let res: Option<Self> = from_glib_full(ffi::gsk_transform_translate_3d(
+                self.to_glib_full(),
+                point.to_glib_none().0,
+            ));
+            res.unwrap_or_else(Self::new)
         }
     }
 }
@@ -26,6 +137,13 @@ impl std::str::FromStr for Transform {
     type Err = glib::BoolError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         skip_assert_initialized!();
-        Transform::parse(s)
+        Self::parse(s)
     }
+}
+
+#[test]
+fn invert_identity_is_identity() {
+    let transform = Transform::new();
+    let output = transform.invert();
+    assert_eq!(output.unwrap(), transform);
 }


### PR DESCRIPTION
The C code uses NULL for representing an identity transform which we adapt the rust API for Fixes #817