### PR TITLE
gtk: Manually implement FileChooser::set_current_folder

### DIFF
--- a/gtk4/Gir.toml
+++ b/gtk4/Gir.toml
@@ -1161,6 +1161,9 @@ manual_traits = ["FileChooserExtManual"]
     [[object.function]]
     name = "add_choice"
     manual = true # rust-ify the options param
+    [[object.function]]
+    name = "set_current_folder"
+    manual = true # Drops the error assertion as it is not always correct
 
 [[object]]
 name = "Gtk.FileChooserDialog"

--- a/gtk4/src/auto/file_chooser.rs
+++ b/gtk4/src/auto/file_chooser.rs
@@ -96,9 +96,6 @@ pub trait FileChooserExt: 'static {
     #[doc(alias = "gtk_file_chooser_set_create_folders")]
     fn set_create_folders(&self, create_folders: bool);
 
-    #[doc(alias = "gtk_file_chooser_set_current_folder")]
-    fn set_current_folder(&self, file: Option<&impl IsA<gio::File>>) -> Result<(), glib::Error>;
-
     #[doc(alias = "gtk_file_chooser_set_current_name")]
     fn set_current_name(&self, name: &str);
 
@@ -303,23 +300,6 @@ impl<O: IsA<FileChooser>> FileChooserExt for O {
                 self.as_ref().to_glib_none().0,
                 create_folders.into_glib(),
             );
-        }
-    }
-
-    fn set_current_folder(&self, file: Option<&impl IsA<gio::File>>) -> Result<(), glib::Error> {
-        unsafe {
-            let mut error = ptr::null_mut();
-            let is_ok = ffi::gtk_file_chooser_set_current_folder(
-                self.as_ref().to_glib_none().0,
-                file.map(|p| p.as_ref()).to_glib_none().0,
-                &mut error,
-            );
-            assert_eq!(is_ok == glib::ffi::GFALSE, !error.is_null());
-            if error.is_null() {
-                Ok(())
-            } else {
-                Err(from_glib_full(error))
-            }
         }
     }
 

--- a/gtk4/src/file_chooser.rs
+++ b/gtk4/src/file_chooser.rs
@@ -9,6 +9,9 @@ use glib::IsA;
 pub trait FileChooserExtManual: 'static {
     #[doc(alias = "gtk_file_chooser_add_choice")]
     fn add_choice(&self, id: &str, label: &str, options: &[(&str, &str)]);
+
+    #[doc(alias = "gtk_file_chooser_set_current_folder")]
+    fn set_current_folder(&self, file: Option<&impl IsA<gio::File>>) -> Result<bool, glib::Error>;
 }
 
 impl<O: IsA<FileChooser>> FileChooserExtManual for O {
@@ -42,6 +45,22 @@ impl<O: IsA<FileChooser>> FileChooserExtManual for O {
                 mut_override(options_ids),
                 mut_override(options_labels),
             );
+        }
+    }
+
+    fn set_current_folder(&self, file: Option<&impl IsA<gio::File>>) -> Result<bool, glib::Error> {
+        unsafe {
+            let mut error = std::ptr::null_mut();
+            let result = from_glib(ffi::gtk_file_chooser_set_current_folder(
+                self.as_ref().to_glib_none().0,
+                file.map(|p| p.as_ref()).to_glib_none().0,
+                &mut error,
+            ));
+            if error.is_null() {
+                Ok(result)
+            } else {
+                Err(from_glib_full(error))
+            }
         }
     }
 }


### PR DESCRIPTION
To drop the assertion as the folder might not be set correctly in some cases without an error being returned Which causes the panic described in #1049.

Note, that upstream code has to be changed as well in order to fix passing a NULL folder which is the cause of the critical mentioned in the issue above.

Fixes #1049