### PR TITLE
gtk: Add gnome_43 feature

### DIFF
--- a/gtk4/Cargo.toml
+++ b/gtk4/Cargo.toml
@@ -25,6 +25,11 @@ v4_10 = ["ffi/v4_10", "v4_8"]
 xml_validation = ["gtk4-macros/xml_validation"]
 unsafe-assume-initialized = []
 
+# Versions from https://gitlab.gnome.org/GNOME/gnome-build-meta/-/tree/gnome-43/elements/sdk
+# gtk takes care of setting the versions of gsk and gdk
+# gio takes care of setting the version of glib
+gnome_43 = ["v4_8", "cairo-rs/v1_16", "gdk-pixbuf/v2_42", "gio/v2_74", "pango/v1_50"]
+
 [package.metadata.docs.rs]
 features = ["dox"]
 

--- a/gtk4/Cargo.toml
+++ b/gtk4/Cargo.toml
@@ -29,6 +29,7 @@ unsafe-assume-initialized = []
 # gtk takes care of setting the versions of gsk and gdk
 # gio takes care of setting the version of glib
 gnome_43 = ["v4_8", "cairo-rs/v1_16", "gdk-pixbuf/v2_42", "gio/v2_74", "pango/v1_50"]
+gnome_42 = ["v4_6", "cairo-rs/v1_16", "gdk-pixbuf/v2_42", "gio/v2_72", "pango/v1_50"]
 
 [package.metadata.docs.rs]
 features = ["dox"]

--- a/gtk4/README.md
+++ b/gtk4/README.md
@@ -188,6 +188,7 @@ gtk = { git = "https://github.com/gtk-rs/gtk4-rs.git", package = "gtk4" }
 | `v4_6` | Enable the new APIs part of GTK 4.6 |
 | `v4_4` | Enable the new APIs part of GTK 4.4 |
 | `v4_2` | Enable the new APIs part of GTK 4.2 |
+| `gnome_43` | Enable all version feature flags of this crate and its dependencies to match the GNOME 43 SDK |
 | `unsafe-assume-initialized` | Disable checks that gtk is initialized, for use in C ABI libraries |
 | `xml_validation` | Enable `xml_validation` feature of gtk4-macros 
 

--- a/gtk4/README.md
+++ b/gtk4/README.md
@@ -189,6 +189,7 @@ gtk = { git = "https://github.com/gtk-rs/gtk4-rs.git", package = "gtk4" }
 | `v4_4` | Enable the new APIs part of GTK 4.4 |
 | `v4_2` | Enable the new APIs part of GTK 4.2 |
 | `gnome_43` | Enable all version feature flags of this crate and its dependencies to match the GNOME 43 SDK |
+| `gnome_42` | Enable all version feature flags of this crate and its dependencies to match the GNOME 42 SDK |
 | `unsafe-assume-initialized` | Disable checks that gtk is initialized, for use in C ABI libraries |
 | `xml_validation` | Enable `xml_validation` feature of gtk4-macros 
 


### PR DESCRIPTION
Fixes #1156

This only adds the feature for GNOME 43, but I think going with the latest SDK version is fine.
Of course, new features should be added as soon as newer GNOME versions become available. 