### PR TITLE
image: Rebuild once every week

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,6 +1,9 @@
 name: github packages
 
 on:
+  # Rebuild the container once every week
+  schedule:
+  - cron: '0 1 * * 1'
   push:
     branches:
       - "master"


### PR DESCRIPTION
Same as https://github.com/gtk-rs/gtk-rs-core/pull/817, but for the gtk4-rs image.

This will likely fix the Relm4 CI and the Relm4 docs build so merging both PRs fast would be highly appreciated (please merge the gtk-rs-core PR first so the gtk4-rs image can then pick up the freshly built core image).