### PR TITLE
macros: Allow using re-exports of gtk

### DIFF
--- a/gtk4-macros/src/util.rs
+++ b/gtk4-macros/src/util.rs
@@ -6,9 +6,11 @@ use proc_macro_crate::crate_name;
 pub fn crate_ident_new() -> Ident {
     use proc_macro_crate::FoundCrate;
 
-    let crate_name = match crate_name("gtk4").expect("missing gtk4 dependency in `Cargo.toml`") {
-        FoundCrate::Name(name) => name,
-        FoundCrate::Itself => "gtk4".to_owned(),
+    // Use crate name detected from Cargo.toml or "gtk" for use in re-exports
+    let crate_name = match crate_name("gtk4") {
+        Ok(FoundCrate::Name(name)) => name,
+        Ok(FoundCrate::Itself) => "gtk4".to_owned(),
+        Err(_) => "gtk".to_owned(),
     };
 
     Ident::new(&crate_name, Span::call_site())


### PR DESCRIPTION
I don't think it's a great idea to simply panic if there's no gtk4 dependency in Cargo.toml because crates like libadwaita or Relm4 re-export gtk. Instead, I suggest to fallback to "gtk" for re-exports which still results in a good error message when the dependency is missing. 
This shouldn't be a semver breaking change because existing code will compile as usual.