### PR TITLE
Skip init assertion for gdk::set_allowed_backends

### DIFF
--- a/gdk4/Gir.toml
+++ b/gdk4/Gir.toml
@@ -215,7 +215,9 @@ status = "generate"
     [[object.function]]
     name = "toplevel_size_get_type"
     ignore = true # used directly in gdk::ToplevelSize
-
+    [[object.function]]
+    name = "set_allowed_backends"
+    assertion = "skip"
 
 [[object]]
 name = "Gdk.AppLaunchContext"

--- a/gdk4/src/auto/functions.rs
+++ b/gdk4/src/auto/functions.rs
@@ -44,7 +44,7 @@ pub fn pixbuf_get_from_texture(texture: &impl IsA<Texture>) -> Option<gdk_pixbuf
 
 #[doc(alias = "gdk_set_allowed_backends")]
 pub fn set_allowed_backends(backends: &str) {
-    assert_initialized_main_thread!();
+    skip_assert_initialized!();
     unsafe {
         ffi::gdk_set_allowed_backends(backends.to_glib_none().0);
     }


### PR DESCRIPTION
Similar to https://github.com/gtk-rs/gtk3-rs/pull/791

>To my understanding gdk::set_allowed_backends() should be called (when needed) before the init()
>
>https://docs.gtk.org/gdk3/func.set_allowed_backends.html
>
> >This call must happen prior to gdk_display_open(), gtk_init(), gtk_init_with_args() or gtk_init_check() in order to take effect.
>
>The way I added the assertion skip might not be the way intended.
>Please let me know.