### PR TITLE
gtk4: use impl_offset() for calculating template child offset

### DIFF
--- a/gtk4/src/subclass/widget.rs
+++ b/gtk4/src/subclass/widget.rs
@@ -1216,7 +1216,7 @@ pub unsafe trait WidgetClassSubclassExt: ClassStruct {
         let widget_class = self as *mut _ as *mut ffi::GtkWidgetClass;
         let private_offset = <Self::Type as ObjectSubclassType>::type_data()
             .as_ref()
-            .private_offset;
+            .impl_offset();
         ffi::gtk_widget_class_bind_template_child_full(
             widget_class,
             name.to_glib_none().0,


### PR DESCRIPTION
Since the #[repr(rust)] layout of PrivateStruct could change, this was failing to take the offset of `imp` into account.