### PR TITLE
gtk: Fix missing version guards

### DIFF
--- a/gtk4/Gir.toml
+++ b/gtk4/Gir.toml
@@ -73,7 +73,6 @@ generate = [
     "Gtk.ColorDialogButton",
     "Gtk.ColumnView",
     "Gtk.ColumnViewColumn",
-    "Gtk.ColumnViewSorter",
     "Gtk.ComboBoxText",
     "Gtk.Constraint",
     "Gtk.ConstraintAttribute",
@@ -118,7 +117,6 @@ generate = [
     "Gtk.FontChooserDialog",
     "Gtk.FontChooserLevel",
     "Gtk.FontChooserWidget",
-    "Gtk.FontLevel",
     "Gtk.Frame",
     "Gtk.GestureDrag",
     "Gtk.GestureLongPress",
@@ -845,6 +843,11 @@ manual_traits = ["ColorChooserExtManual"]
     doc_trait_name = "ColorChooserExtManual"
 
 [[object]]
+name = "Gtk.ColumnViewSorter"
+status = "generate"
+version = "4.10"
+
+[[object]]
 name = "Gtk.ComboBox"
 status = "generate"
 manual_traits = ["ComboBoxExtManual"]
@@ -1263,6 +1266,11 @@ status = "generate"
         [[object.function.parameter]]
         name = "language"
         const = true
+
+[[object]]
+name = "Gtk.FontLevel"
+status = "generate"
+version = "4.10"
 
 [[object]]
 name = "Gtk.Gesture"

--- a/gtk4/src/auto/column_view_sorter.rs
+++ b/gtk4/src/auto/column_view_sorter.rs
@@ -2,34 +2,16 @@
 // from gir-files (https://github.com/gtk-rs/gir-files)
 // DO NOT EDIT
 
-#[cfg(any(feature = "v4_10", feature = "dox"))]
-#[cfg_attr(feature = "dox", doc(cfg(feature = "v4_10")))]
 use crate::ColumnViewColumn;
-#[cfg(any(feature = "v4_10", feature = "dox"))]
-#[cfg_attr(feature = "dox", doc(cfg(feature = "v4_10")))]
 use crate::SortType;
 use crate::Sorter;
-#[cfg(any(feature = "v4_10", feature = "dox"))]
-#[cfg_attr(feature = "dox", doc(cfg(feature = "v4_10")))]
 use glib::object::ObjectType as ObjectType_;
-#[cfg(any(feature = "v4_10", feature = "dox"))]
-#[cfg_attr(feature = "dox", doc(cfg(feature = "v4_10")))]
 use glib::signal::connect_raw;
-#[cfg(any(feature = "v4_10", feature = "dox"))]
-#[cfg_attr(feature = "dox", doc(cfg(feature = "v4_10")))]
 use glib::signal::SignalHandlerId;
-#[cfg(any(feature = "v4_10", feature = "dox"))]
-#[cfg_attr(feature = "dox", doc(cfg(feature = "v4_10")))]
 use glib::translate::*;
-#[cfg(any(feature = "v4_10", feature = "dox"))]
-#[cfg_attr(feature = "dox", doc(cfg(feature = "v4_10")))]
 use std::boxed::Box as Box_;
 use std::fmt;
-#[cfg(any(feature = "v4_10", feature = "dox"))]
-#[cfg_attr(feature = "dox", doc(cfg(feature = "v4_10")))]
 use std::mem;
-#[cfg(any(feature = "v4_10", feature = "dox"))]
-#[cfg_attr(feature = "dox", doc(cfg(feature = "v4_10")))]
 use std::mem::transmute;
 
 glib::wrapper! {
@@ -42,16 +24,12 @@ glib::wrapper! {
 }
 
 impl ColumnViewSorter {
-    #[cfg(any(feature = "v4_10", feature = "dox"))]
-    #[cfg_attr(feature = "dox", doc(cfg(feature = "v4_10")))]
     #[doc(alias = "gtk_column_view_sorter_get_n_sort_columns")]
     #[doc(alias = "get_n_sort_columns")]
     pub fn n_sort_columns(&self) -> u32 {
         unsafe { ffi::gtk_column_view_sorter_get_n_sort_columns(self.to_glib_none().0) }
     }
 
-    #[cfg(any(feature = "v4_10", feature = "dox"))]
-    #[cfg_attr(feature = "dox", doc(cfg(feature = "v4_10")))]
     #[doc(alias = "gtk_column_view_sorter_get_nth_sort_column")]
     #[doc(alias = "get_nth_sort_column")]
     pub fn nth_sort_column(&self, position: u32) -> (Option<ColumnViewColumn>, SortType) {
@@ -66,8 +44,6 @@ impl ColumnViewSorter {
         }
     }
 
-    #[cfg(any(feature = "v4_10", feature = "dox"))]
-    #[cfg_attr(feature = "dox", doc(cfg(feature = "v4_10")))]
     #[doc(alias = "gtk_column_view_sorter_get_primary_sort_column")]
     #[doc(alias = "get_primary_sort_column")]
     pub fn primary_sort_column(&self) -> Option<ColumnViewColumn> {
@@ -78,8 +54,6 @@ impl ColumnViewSorter {
         }
     }
 
-    #[cfg(any(feature = "v4_10", feature = "dox"))]
-    #[cfg_attr(feature = "dox", doc(cfg(feature = "v4_10")))]
     #[doc(alias = "gtk_column_view_sorter_get_primary_sort_order")]
     #[doc(alias = "get_primary_sort_order")]
     pub fn primary_sort_order(&self) -> SortType {

--- a/gtk4/src/auto/enums.rs
+++ b/gtk4/src/auto/enums.rs
@@ -4500,6 +4500,8 @@ impl From<FilterMatch> for glib::Value {
     }
 }
 
+#[cfg(any(feature = "v4_10", feature = "dox"))]
+#[cfg_attr(feature = "dox", doc(cfg(feature = "v4_10")))]
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone, Copy)]
 #[non_exhaustive]
 #[doc(alias = "GtkFontLevel")]
@@ -4516,6 +4518,8 @@ pub enum FontLevel {
     __Unknown(i32),
 }
 
+#[cfg(any(feature = "v4_10", feature = "dox"))]
+#[cfg_attr(feature = "dox", doc(cfg(feature = "v4_10")))]
 impl fmt::Display for FontLevel {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
@@ -4532,6 +4536,8 @@ impl fmt::Display for FontLevel {
     }
 }
 
+#[cfg(any(feature = "v4_10", feature = "dox"))]
+#[cfg_attr(feature = "dox", doc(cfg(feature = "v4_10")))]
 #[doc(hidden)]
 impl IntoGlib for FontLevel {
     type GlibType = ffi::GtkFontLevel;
@@ -4547,6 +4553,8 @@ impl IntoGlib for FontLevel {
     }
 }
 
+#[cfg(any(feature = "v4_10", feature = "dox"))]
+#[cfg_attr(feature = "dox", doc(cfg(feature = "v4_10")))]
 #[doc(hidden)]
 impl FromGlib<ffi::GtkFontLevel> for FontLevel {
     unsafe fn from_glib(value: ffi::GtkFontLevel) -> Self {
@@ -4561,16 +4569,22 @@ impl FromGlib<ffi::GtkFontLevel> for FontLevel {
     }
 }
 
+#[cfg(any(feature = "v4_10", feature = "dox"))]
+#[cfg_attr(feature = "dox", doc(cfg(feature = "v4_10")))]
 impl StaticType for FontLevel {
     fn static_type() -> Type {
         unsafe { from_glib(ffi::gtk_font_level_get_type()) }
     }
 }
 
+#[cfg(any(feature = "v4_10", feature = "dox"))]
+#[cfg_attr(feature = "dox", doc(cfg(feature = "v4_10")))]
 impl glib::value::ValueType for FontLevel {
     type Type = Self;
 }
 
+#[cfg(any(feature = "v4_10", feature = "dox"))]
+#[cfg_attr(feature = "dox", doc(cfg(feature = "v4_10")))]
 unsafe impl<'a> FromValue<'a> for FontLevel {
     type Checker = glib::value::GenericValueTypeChecker<Self>;
 
@@ -4580,6 +4594,8 @@ unsafe impl<'a> FromValue<'a> for FontLevel {
     }
 }
 
+#[cfg(any(feature = "v4_10", feature = "dox"))]
+#[cfg_attr(feature = "dox", doc(cfg(feature = "v4_10")))]
 impl ToValue for FontLevel {
     fn to_value(&self) -> glib::Value {
         let mut value = glib::Value::for_value_type::<Self>();
@@ -4594,6 +4610,8 @@ impl ToValue for FontLevel {
     }
 }
 
+#[cfg(any(feature = "v4_10", feature = "dox"))]
+#[cfg_attr(feature = "dox", doc(cfg(feature = "v4_10")))]
 impl From<FontLevel> for glib::Value {
     #[inline]
     fn from(v: FontLevel) -> Self {

--- a/gtk4/src/auto/mod.rs
+++ b/gtk4/src/auto/mod.rs
@@ -239,7 +239,11 @@ pub use self::column_view::ColumnView;
 mod column_view_column;
 pub use self::column_view_column::ColumnViewColumn;
 
+#[cfg(any(feature = "v4_10", feature = "dox"))]
+#[cfg_attr(feature = "dox", doc(cfg(feature = "v4_10")))]
 mod column_view_sorter;
+#[cfg(any(feature = "v4_10", feature = "dox"))]
+#[cfg_attr(feature = "dox", doc(cfg(feature = "v4_10")))]
 pub use self::column_view_sorter::ColumnViewSorter;
 
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
@@ -1061,6 +1065,8 @@ pub use self::enums::FileChooserAction;
 pub use self::enums::FileChooserError;
 pub use self::enums::FilterChange;
 pub use self::enums::FilterMatch;
+#[cfg(any(feature = "v4_10", feature = "dox"))]
+#[cfg_attr(feature = "dox", doc(cfg(feature = "v4_10")))]
 pub use self::enums::FontLevel;
 pub use self::enums::IconSize;
 pub use self::enums::IconThemeError;

--- a/gtk4/sys/Gir.toml
+++ b/gtk4/sys/Gir.toml
@@ -29,8 +29,23 @@ gdk4 = "Gdk"
 gsk4 = "Gsk"
 
 [[object]]
+name = "Gtk.ColumnViewSorter"
+status = "generate"
+    [[object.function]]
+    name = "get_type"
+    version = "4.10"
+
+[[object]]
 name = "Gtk.ExpressionWatch"
 status = "generate"
     [[object.function]]
     name = "get_type"
     version = "4.2"
+
+[[object]]
+name = "Gtk.FontLevel"
+status = "generate"
+    [[object.function]]
+    name = "get_type"
+    version = "4.10"
+    

--- a/gtk4/sys/src/lib.rs
+++ b/gtk4/sys/src/lib.rs
@@ -9210,6 +9210,8 @@ extern "C" {
     //=========================================================================
     // GtkFontLevel
     //=========================================================================
+    #[cfg(any(feature = "v4_10", feature = "dox"))]
+    #[cfg_attr(feature = "dox", doc(cfg(feature = "v4_10")))]
     pub fn gtk_font_level_get_type() -> GType;
 
     //=========================================================================
@@ -11774,6 +11776,8 @@ extern "C" {
     //=========================================================================
     // GtkColumnViewSorter
     //=========================================================================
+    #[cfg(any(feature = "v4_10", feature = "dox"))]
+    #[cfg_attr(feature = "dox", doc(cfg(feature = "v4_10")))]
     pub fn gtk_column_view_sorter_get_type() -> GType;
     #[cfg(any(feature = "v4_10", feature = "dox"))]
     #[cfg_attr(feature = "dox", doc(cfg(feature = "v4_10")))]


### PR DESCRIPTION
We should look at adding the missing since annotations upstream for next release