### PR TITLE
Recommend (with instructions) building with `gvsbuild`

### DIFF
--- a/book/src/installation_windows.md
+++ b/book/src/installation_windows.md
@@ -21,29 +21,42 @@ Also set the rust toolchain back to msvc by executing:
 rustup default stable-msvc
 ```
 
-### Visual Studio
+### Build GTK 4
+
+1. Follow [the `gvsbuild` docs to build GTK4](https://github.com/wingtk/gvsbuild#development-environment)
+   * When choosing the GTK version to build, select `gtk4` instead of `gtk3`: `gvsbuild build gtk4`
+2. Update your `Path` environment variable to include the GTK4 libraries:
+   1. Go to settings -> Search and open `Advanced system settings` -> Click on `Environment variables`
+   2. Select `Path` -> Click on `Edit` -> Add `C:\gtk-build\gtk\x64\release\bin`
+
+#### Build GTK 4 manually instead
+
+If it's not possible to build with `gvsbuild` (or you want to customize your build), you
+can build GTK 4 and the minimum dependencies you need manually:
+
+##### Visual Studio
 
 Install Visual Studio Community from [visualstudio.microsoft.com](https://visualstudio.microsoft.com/de/vs/community/).
 Make sure to check the box "Desktop development with C++" during the installation process.
 
 <div style="text-align:center"><img src="img/vs-install.png" /></div>
 
-### Git
+##### Git
 
 Download git from [gitforwindows.org](https://gitforwindows.org/).
 
 
-### CMake
+##### CMake
 Download CMake from [https://cmake.org/download/](https://cmake.org/download/)
 
 
-### Python
+##### Python
 
 Download python from [python.org](https://www.python.org/downloads).
 Make sure to opt-in to adding Python to your Path during the installation process.
 
 
-### Meson
+##### Meson
 
 Install meson by executing:
 
@@ -52,38 +65,37 @@ pip install meson ninja
 ```
 
 
-### Gettext 0.21
+##### Gettext 0.21
 
 > **Warning**
 > **To avoid any potential problems, we strongly recommend the static version.**
-
 Download Gettext 0.21 from [mlocati.github.io](https://mlocati.github.io/articles/gettext-iconv-windows.html).
 
 
-### Pkg-config
+##### Pkg-config
 
 Download pkg-config-lite from [sourceforge.net](https://sourceforge.net/projects/pkgconfiglite/).
 Then extract and unpack it in `C:/`, so that the executable is in `C:\pkg-config-lite-0.28-1\bin`.
 
 
-### Update environment variables
+##### Update environment variables
 
 1. Go to settings -> Search and open `Advanced system settings` -> Click on `Environment variables`
 2. Select `Path` -> Click on `Edit` -> Add the following entries:
- 
+
 ```
 C:\pkg-config-lite-0.28-1\bin
 C:\gnome\bin
 ```
 
-3. Go back to `Environment variables` 
+3. Go back to `Environment variables`
 4. Under `User variables` click on `New` and add:
 
 - Variable name: `PKG_CONFIG_PATH`
 - Variable value: `C:\gnome\lib\pkgconfig`
 
 
-### Compile and install GTK 4
+##### Compile and install GTK 4
 
 From the Windows start menu, search for `x64 Native Tools Command Prompt for VS 2019`.
 That will open a terminal configured to use MSVC x64 tools.
@@ -113,7 +125,6 @@ xcopy /s C:\gnome\include\cairo C:\gnome\include
 nmake /f Makefile.vc CFG=release install PREFIX=C:\gnome
 cd /
 ```
-
 
 ## GNU toolchain
 

--- a/book/src/libadwaita.md
+++ b/book/src/libadwaita.md
@@ -51,6 +51,27 @@ brew install libadwaita
 
 ## Windows
 
+If you used `gvsbuild` to build GTK 4:
+
+```
+gvsbuild build libadwaita librsvg
+```
+
+##### Work around missing icons
+
+[This workaround is needed for GTK < 4.10](https://gitlab.gnome.org/GNOME/gtk/-/blob/34b9ec5be2f3a38e1e72c4d96f130a2b14734121/NEWS#L60)
+due to [this issue](https://gitlab.gnome.org/GNOME/gtk/-/issues/5303).
+
+From a command prompt:
+
+```
+xcopy /s /i C:\gtk-build\gtk\x64\release\share\icons\hicolor\scalable\apps C:\gtk-build\gtk\x64\release\share\icons\hicolor\scalable\actions
+# NOTE: The cache must be rebuilt every time you add new icons. 
+gtk4-update-icon-cache.exe -t -f C:\gtk-build\gtk\x64\release\share\icons\hicolor
+```
+
+### If you built GTK 4 manually:
+
 From the Windows start menu, search for `x64 Native Tools Command Prompt for VS 2019`.
 That will open a terminal configured to use MSVC x64 tools.
 From there, run the following commands:
@@ -61,9 +82,6 @@ git clone https://gitlab.gnome.org/GNOME/libadwaita.git --depth 1
 cd libadwaita
 meson setup builddir -Dprefix=C:/gnome -Dintrospection=disabled -Dvapi=false
 meson install -C builddir
-
-# This is a workaround for https://gitlab.gnome.org/GNOME/gtk/-/issues/5303.
-# NOTE: The cache must be rebuilt every time you add new icons. 
 
 xcopy /s /i C:\gnome\share\icons\hicolor\scalable\apps C:\gnome\share\icons\hicolor\scalable\actions
 gtk4-update-icon-cache.exe -t -f C:\gnome\share\icons\hicolor


### PR DESCRIPTION
Updates Windows build instructions for `libadwaita` as well.

Keep manual `Path`-modification steps because
the `gvsbuild` docs only mention how to change the `Path` for the
current shell.

This workflow has a few advantages:
* It's more closely synced with upstream GTK docs (which recommends
  `gvsbuild`)
* There's less steps for users to follow, so there should be less
  risk-of-error
* We get the "stable version combination management" provided by
  `gvsbuild` for free. Before, there was risk of instability
  due to the usage of the tips of `gtk`/`libxml2`/`librsvg`. Now,
  new users get new code based on releases of `gvsbuild`, yet
  aren't too close to the cutting edge
* There's no less directories cluttering `C:\` (just `C:\gtk-build`)
  and less `Path` modifications

Fixes #1199