### PR TITLE
gtk: Subclass BuilderCScope for the BuilderRustScope

### DIFF
--- a/gtk4/src/builder_cscope.rs
+++ b/gtk4/src/builder_cscope.rs
@@ -1,0 +1,12 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::BuilderScope;
+
+glib::wrapper! {
+    #[doc(alias = "GtkBuilderCScope")]
+    pub struct BuilderCScope(Object<ffi::GtkBuilderCScope, ffi::GtkBuilderCScopeClass>) @implements BuilderScope;
+
+    match fn {
+        type_ => || ffi::gtk_builder_cscope_get_type(),
+    }
+}

--- a/gtk4/src/builder_rust_scope.rs
+++ b/gtk4/src/builder_rust_scope.rs
@@ -1,7 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::subclass::prelude::*;
-use crate::BuilderScope;
+use crate::{subclass::prelude::*, BuilderCScope, BuilderScope};
 use std::rc::Rc;
 
 glib::wrapper! {
@@ -36,6 +35,7 @@ glib::wrapper! {
     /// # }
     /// ```
     pub struct BuilderRustScope(ObjectSubclass<imp::BuilderRustScope>)
+        @extends BuilderCScope,
         @implements BuilderScope;
 }
 
@@ -66,12 +66,10 @@ impl BuilderRustScope {
 }
 
 mod imp {
-    use crate::prelude::*;
-    use crate::subclass::prelude::*;
-    use crate::{Builder, BuilderClosureFlags, BuilderError, BuilderScope};
-    use glib::translate::*;
-    use glib::{Closure, RustClosure};
-    use std::{cell::RefCell, collections::HashMap, rc::Rc};
+    use super::*;
+    use crate::{prelude::*, Builder, BuilderClosureFlags, BuilderError};
+    use glib::{translate::*, Closure, RustClosure};
+    use std::{cell::RefCell, collections::HashMap};
 
     type Callback = dyn Fn(&[glib::Value]) -> Option<glib::Value>;
 
@@ -84,12 +82,20 @@ mod imp {
     impl ObjectSubclass for BuilderRustScope {
         const NAME: &'static str = "GtkBuilderRustScope";
         type Type = super::BuilderRustScope;
+        type ParentType = BuilderCScope;
         type Interfaces = (BuilderScope,);
     }
 
     impl ObjectImpl for BuilderRustScope {}
+    impl BuilderCScopeImpl for BuilderRustScope {}
 
     impl BuilderScopeImpl for BuilderRustScope {
+        fn type_from_function(&self, _builder: &Builder, _function_name: &str) -> glib::Type {
+            // Override the implementation provided by BuilderCScope and default to the interface
+            // default implementation
+            glib::Type::INVALID
+        }
+
         fn create_closure(
             &self,
             builder: &Builder,

--- a/gtk4/src/lib.rs
+++ b/gtk4/src/lib.rs
@@ -121,6 +121,7 @@ mod bitset_iter;
 mod bookmark_list;
 mod border;
 mod builder;
+mod builder_cscope;
 mod builder_rust_scope;
 mod cell_area;
 mod cell_layout;
@@ -206,6 +207,7 @@ mod widget;
 
 pub use bitset_iter::BitsetIter;
 pub use border::Border;
+pub use builder_cscope::BuilderCScope;
 pub use builder_rust_scope::BuilderRustScope;
 pub use css_location::CssLocation;
 pub use expression_watch::ExpressionWatch;

--- a/gtk4/src/subclass/builder_scope.rs
+++ b/gtk4/src/subclass/builder_scope.rs
@@ -3,8 +3,14 @@
 // rustdoc-stripper-ignore-next
 //! Traits intended for implementing the [`BuilderScope`](crate::BuilderScope) interface.
 
-use crate::{prelude::*, subclass::prelude::*, Builder, BuilderClosureFlags, BuilderScope};
+use crate::{
+    prelude::*, subclass::prelude::*, Builder, BuilderCScope, BuilderClosureFlags, BuilderScope,
+};
 use glib::{translate::*, GString};
+
+pub trait BuilderCScopeImpl: BuilderScopeImpl {}
+
+unsafe impl<T: BuilderCScopeImpl> IsSubclassable<T> for BuilderCScope {}
 
 pub trait BuilderScopeImpl: ObjectImpl {
     #[doc(alias = "get_type_from_name")]

--- a/gtk4/src/subclass/mod.rs
+++ b/gtk4/src/subclass/mod.rs
@@ -100,7 +100,7 @@ pub mod prelude {
     pub use super::application_window::ApplicationWindowImpl;
     pub use super::box_::BoxImpl;
     pub use super::buildable::{BuildableImpl, BuildableImplExt};
-    pub use super::builder_scope::{BuilderScopeImpl, BuilderScopeImplExt};
+    pub use super::builder_scope::{BuilderCScopeImpl, BuilderScopeImpl, BuilderScopeImplExt};
     pub use super::button::{ButtonImpl, ButtonImplExt};
     pub use super::cell_area::{CellAreaClassSubclassExt, CellAreaImpl, CellAreaImplExt};
     pub use super::cell_area_context::{CellAreaContextImpl, CellAreaContextImplExt};


### PR DESCRIPTION
Apprently, it is needed for keeping the get_type_from_name working properly Should fix #1207