### PR TITLE
no need to move in the hello world exercise

### DIFF
--- a/book/listings/hello_world/3/main.rs
+++ b/book/listings/hello_world/3/main.rs
@@ -32,7 +32,7 @@ fn build_ui(app: &Application) {
 
     // ANCHOR: callback
     // Connect to "clicked" signal of `button`
-    button.connect_clicked(move |button| {
+    button.connect_clicked(|button| {
         // Set the label to "Hello World!" after the button has been clicked on
         button.set_label("Hello World!");
     });


### PR DESCRIPTION
As far as I understand, `move` tries to move the current environment into the closure. However, since we are only using the closure's parameter(`|button|`) in its body, we don't need to `move`. Removing `move` could make the code clearer for first-time readers (like me).

The updated code seems to compile without issues.

Thank you for this book; I am so grateful.