### PR TITLE
Book: make memory management conclusion clearer.

### DIFF
--- a/book/listings/hello_world/3/main.rs
+++ b/book/listings/hello_world/3/main.rs
@@ -32,7 +32,7 @@ fn build_ui(app: &Application) {
 
     // ANCHOR: callback
     // Connect to "clicked" signal of `button`
-    button.connect_clicked(move |button| {
+    button.connect_clicked(|button| {
         // Set the label to "Hello World!" after the button has been clicked on
         button.set_label("Hello World!");
     });

--- a/book/src/g_object_memory_management.md
+++ b/book/src/g_object_memory_management.md
@@ -195,5 +195,4 @@ When we set `gtk_box` as child of `window`, `window` keeps a strong reference to
 Until we close the `window` it keeps `gtk_box` and with it the buttons alive.
 Since our application has only one window, closing it also means exiting the application.
 
-As long as you use weak references whenever possible you will find it perfectly doable to avoid memory cycles within your application.
-If that is ensured, you can rely on GTK to properly manage the memory of GObjects you pass to it.
+As long as you use weak references whenever possible, you will find it perfectly doable to avoid memory cycles within your application, and you can rely on GTK to properly manage the memory of GObjects you pass to it.

--- a/book/src/g_object_memory_management.md
+++ b/book/src/g_object_memory_management.md
@@ -195,4 +195,5 @@ When we set `gtk_box` as child of `window`, `window` keeps a strong reference to
 Until we close the `window` it keeps `gtk_box` and with it the buttons alive.
 Since our application has only one window, closing it also means exiting the application.
 
-As long as you use weak references whenever possible, you will find it perfectly doable to avoid memory cycles within your application, and you can rely on GTK to properly manage the memory of GObjects you pass to it.
+As long as you use weak references whenever possible, you will find it perfectly doable to avoid memory cycles within your application.
+Without memory cycles, you can rely on GTK to properly manage the memory of GObjects you pass to it.


### PR DESCRIPTION
In the last line, I am guessing that "If that is ensured" is refering to the "the use of weak references whenever possible", but it was not clear to me at first glance. We could connect the last line with the first using a comma and "and" connector (as shown in the proposed change). This could make the message clearer. 