### PR TITLE
Remove unneeded cfg(dox) condition

### DIFF
--- a/gdk4-wayland/src/wayland_display.rs
+++ b/gdk4-wayland/src/wayland_display.rs
@@ -74,7 +74,7 @@ impl WaylandDisplay {
         }
     }
 
-    #[cfg(any(feature = "wayland_crate", feature = "dox"))]
+    #[cfg(feature = "wayland_crate")]
     pub(crate) fn connection(&self) -> wayland_client::Connection {
         unsafe {
             match self


### PR DESCRIPTION
The method is private so there is no interest into having this `cfg` on it.