### PR TITLE
Update book

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -9,8 +9,6 @@ on:
       - "master"
     paths:
       - "book/**"
-  release:
-    types: [published]
 
 jobs:
   build-deploy:

--- a/book/listings/README.md
+++ b/book/listings/README.md
@@ -10,12 +10,12 @@ cargo xtask install
 
 Then execute the following to run one of the listings.
 
-```bash
+```
 cargo run --bin [example_name]_[number]
 ```
 
 For example, if you want to run the listing in subfolder "hello_world/3", execute:
 
-```bash
+```
 cargo run --bin hello_world_3
 ```


### PR DESCRIPTION
- Stop publishing book on release
- Small book change to trigger build

I suspect that the latest patch release is the reason why the book is outdated: https://gtk-rs.org/gtk4-rs/stable/latest/book/