### PR TITLE
examples: list_box_model: Use `im-rc::Vector` instead of `Vec`

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -13,6 +13,7 @@ glium = { version = "0.32", optional = true, default-features = false }
 glow = { version = "0.12.0", optional = true }
 epoxy = { version = "0.1.0", optional = true }
 libloading = { version = "0.7.0", optional = true }
+im-rc = { version = "15", optional = true }
 
 [dependencies.gtk]
 path = "../gtk4"
@@ -141,6 +142,7 @@ path = "gtk_builder/main.rs"
 [[bin]]
 name = "list_box_model"
 path = "list_box_model/main.rs"
+required-features = ["im-rc"]
 
 [[bin]]
 name = "list_view_apps_launcher"

--- a/examples/list_box_model/model/imp.rs
+++ b/examples/list_box_model/model/imp.rs
@@ -5,10 +5,13 @@ use gtk::{gio, glib, prelude::*};
 
 use std::cell::RefCell;
 
+// Use `im-rc::Vector` here as it has much better insert/delete performance than a plain `Vec`.
+use im_rc::Vector;
+
 use crate::row_data::RowData;
 
 #[derive(Debug, Default)]
-pub struct Model(pub(super) RefCell<Vec<RowData>>);
+pub struct Model(pub(super) RefCell<Vector<RowData>>);
 
 /// Basic declaration of our type for the GObject type system
 #[glib::object_subclass]

--- a/examples/list_box_model/model/mod.rs
+++ b/examples/list_box_model/model/mod.rs
@@ -25,7 +25,7 @@ impl Model {
             // before we emit the items_changed signal because the view
             // could call get_item / get_n_item from the signal handler to update its state
             let mut data = imp.0.borrow_mut();
-            data.push(obj.clone());
+            data.push_back(obj.clone());
             data.len() - 1
         };
         // Emits a signal that 1 item was added, 0 removed at the position index


### PR DESCRIPTION
It has much better insert/delete performance compared to `Vec` and should be preferred (or the thread-safe variant from `im`) when creating custom, mutable models.