### PR TITLE
Add a note to the book 

### DIFF
--- a/book/src/composite_templates.md
+++ b/book/src/composite_templates.md
@@ -167,6 +167,7 @@ Filename: <a class=file-link href="https://github.com/gtk-rs/gtk4-rs/blob/master
 ```
 
 Then we have to bind the template callbacks with [`bind_template_callbacks`](../docs/gtk4/subclass/widget/trait.CompositeTemplateCallbacksClass.html#tymethod.bind_template_callbacks).
+We alse need to remove the `button` clicked callback implemented in `window/imp.rs` for this callback to work.
 
 Filename: <a class=file-link href="https://github.com/gtk-rs/gtk4-rs/blob/master/book/listings/composite_templates/3/window/imp.rs">listings/composite_templates/3/window/imp.rs</a>
 ```rust ,no_run,noplayground


### PR DESCRIPTION
about removing clicked callback in ObjectImpl when using template callback