### PR TITLE
Remove mention of "clear_button" in the book

### DIFF
--- a/book/src/todo_2.md
+++ b/book/src/todo_2.md
@@ -79,7 +79,7 @@ Filename: <a class=file-link href="https://github.com/gtk-rs/gtk4-rs/blob/master
 ```
 
 We install the schema as described in the settings [chapter](./settings.html)
-Then we add a reference to `settings` and a reference to `clear_button` to `imp::Window`.
+Then we add a reference to `settings` to `imp::Window`.
 
 Filename: <a class=file-link href="https://github.com/gtk-rs/gtk4-rs/blob/master/book/listings/todo/2/window/imp.rs">listings/todo/2/window/imp.rs</a>
 


### PR DESCRIPTION
I assume "clear_button" was used in some earlier iterations of "todo_2" application. At the moment menu item is used for this purpose.
So, it make sense to remove its mentions from the text.