### PR TITLE
Fix typos and deprecations in the book for CSS chapter (14th).

### DIFF
--- a/book/listings/css/1/main.rs
+++ b/book/listings/css/1/main.rs
@@ -48,6 +48,6 @@ fn build_ui(app: &Application) {
         .title("My GTK App")
         .child(&button)
         .build();
-    window.show();
+    window.present();
 }
 // ANCHOR_END: main

--- a/book/listings/css/2/main.rs
+++ b/book/listings/css/2/main.rs
@@ -47,5 +47,5 @@ fn build_ui(app: &Application) {
         .title("My GTK App")
         .child(&button)
         .build();
-    window.show();
+    window.present();
 }

--- a/book/listings/css/3/main.rs
+++ b/book/listings/css/3/main.rs
@@ -38,7 +38,7 @@ fn build_ui(app: &Application) {
     let button_1 = Button::with_label("Press me!");
     let button_2 = Button::with_label("Press me!");
 
-    button_1.add_css_class("button_1");
+    button_1.add_css_class("button-1");
     // ANCHOR_END: buttons
 
     // Create `gtk_box` and add buttons

--- a/book/listings/css/3/main.rs
+++ b/book/listings/css/3/main.rs
@@ -58,6 +58,6 @@ fn build_ui(app: &Application) {
         .title("My GTK App")
         .child(&gtk_box)
         .build();
-    window.show();
+    window.present();
 }
 // ANCHOR_END: build_ui

--- a/book/listings/css/4/main.rs
+++ b/book/listings/css/4/main.rs
@@ -58,6 +58,6 @@ fn build_ui(app: &Application) {
         .title("My GTK App")
         .child(&gtk_box)
         .build();
-    window.show();
+    window.present();
 }
 // ANCHOR_END: build_ui

--- a/book/listings/css/5/main.rs
+++ b/book/listings/css/5/main.rs
@@ -42,5 +42,5 @@ fn build_ui(app: &Application) {
         .title("My GTK App")
         .child(&gtk_box)
         .build();
-    window.show();
+    window.present();
 }

--- a/book/listings/css/6/main.rs
+++ b/book/listings/css/6/main.rs
@@ -21,5 +21,5 @@ fn main() -> glib::ExitCode {
 fn build_ui(app: &Application) {
     // Create a new window and show it
     let window = Window::new(app);
-    window.show();
+    window.present();
 }

--- a/book/listings/css/7/main.rs
+++ b/book/listings/css/7/main.rs
@@ -36,5 +36,5 @@ fn load_css() {
 fn build_ui(app: &Application) {
     // Create a new window and show it
     let window = Window::new(app);
-    window.show();
+    window.present();
 }

--- a/book/listings/css/8/main.rs
+++ b/book/listings/css/8/main.rs
@@ -36,5 +36,5 @@ fn load_css() {
 fn build_ui(app: &Application) {
     // Create a new window and show it
     let window = Window::new(app);
-    window.show();
+    window.present();
 }

--- a/book/listings/css/9/main.rs
+++ b/book/listings/css/9/main.rs
@@ -36,5 +36,5 @@ fn load_css() {
 fn build_ui(app: &Application) {
     // Create a new window and show it
     let window = Window::new(app);
-    window.show();
+    window.present();
 }


### PR DESCRIPTION
# Overview

Fix typos and deprecations in the book for CSS chapter (14th).

# Changes:
- Fix deprecation warnings in listings for CSS chapter of the book by replacing usage of `Widget::show` method with `Window::present` like it was done in other chapters.
- Change used CSS class name from `button_1` to `button-1` in listing 3 of 14th chapter (CSS).

_**NOTE:** `StyleContext` was also deprecated in GTK 4.10 and I found [this discussion](https://discourse.gnome.org/t/what-good-is-gtkcssprovider-without-gtkstylecontext/12621/2) about moving `gtk_style_context_add_provider` to `gtkstyleprovider.h` but I haven't figured out how that change is reflected in `gtk4-rs` and how to use `StyleProvider`. So I left deprecations warnings about usage of `StyleContext` and it's functions unfixed._