### PR TITLE
Change xml code block to diff in "Adapt Todo App".

### DIFF
--- a/book/src/css.md
+++ b/book/src/css.md
@@ -265,14 +265,14 @@ We can change that by adding the `frame` and the `separators` style class to our
 
 Filename: <a class=file-link href="https://github.com/gtk-rs/gtk4-rs/blob/master/book/listings/todo/4/resources/task_row.ui">listings/todo/4/resources/window.ui</a>
 
-```xml
-<object class="GtkListView" id="tasks_list">
-  <property name="valign">start</property>
-  <style>
-    <class name="frame"/>
-    <class name="separators"/>
-  </style>
-</object>
+```diff
+ <object class="GtkListView" id="tasks_list">
+   <property name="valign">start</property>
++  <style>
++    <class name="frame"/>
++    <class name="separators"/>
++  </style>
+ </object>
 ```
 
 <div style="text-align:center"><img src="img/todo_4.png" alt="To-Do app with borders for its task widget"/></div>


### PR DESCRIPTION
# Overview

In order to signify addition of styles in [Adapt Todo App](https://gtk-rs.org/gtk4-rs/stable/latest/book/css.html#adapt-todo-app) of 14th chapter it probably worth to change code block type from `xml` to `diff` like it was done in other places e.g. [chapter 13](https://github.com/gtk-rs/gtk4-rs/blame/master/book/src/todo_2.md#L26).