### PR TITLE
book: Use glib Priority enum

### DIFF
--- a/book/listings/main_event_loop/3/main.rs
+++ b/book/listings/main_event_loop/3/main.rs
@@ -1,7 +1,7 @@
 use std::thread;
 use std::time::Duration;
 
-use glib::{clone, Continue, MainContext, PRIORITY_DEFAULT};
+use glib::{clone, Continue, MainContext, Priority};
 use gtk::prelude::*;
 use gtk::{glib, Application, ApplicationWindow, Button};
 
@@ -29,7 +29,7 @@ fn build_ui(app: &Application) {
         .build();
 
     // ANCHOR: callback
-    let (sender, receiver) = MainContext::channel(PRIORITY_DEFAULT);
+    let (sender, receiver) = MainContext::channel(Priority::DEFAULT);
     // Connect to "clicked" signal of `button`
     button.connect_clicked(move |_| {
         let sender = sender.clone();

--- a/book/listings/main_event_loop/3/main.rs
+++ b/book/listings/main_event_loop/3/main.rs
@@ -29,7 +29,7 @@ fn build_ui(app: &Application) {
         .build();
 
     // ANCHOR: callback
-    let (sender, receiver) = MainContext::channel(Priority::DEFAULT);
+    let (sender, receiver) = MainContext::channel(Priority::default());
     // Connect to "clicked" signal of `button`
     button.connect_clicked(move |_| {
         let sender = sender.clone();

--- a/book/listings/main_event_loop/4/main.rs
+++ b/book/listings/main_event_loop/4/main.rs
@@ -26,7 +26,7 @@ fn build_ui(app: &Application) {
         .build();
 
     // ANCHOR: callback
-    let (sender, receiver) = MainContext::channel(Priority::DEFAULT);
+    let (sender, receiver) = MainContext::channel(Priority::default());
     // Connect to "clicked" signal of `button`
     button.connect_clicked(move |_| {
         let main_context = MainContext::default();

--- a/book/listings/main_event_loop/4/main.rs
+++ b/book/listings/main_event_loop/4/main.rs
@@ -1,4 +1,4 @@
-use glib::{clone, timeout_future_seconds, Continue, MainContext, PRIORITY_DEFAULT};
+use glib::{clone, timeout_future_seconds, Continue, MainContext, Priority};
 use gtk::prelude::*;
 use gtk::{glib, Application, ApplicationWindow, Button};
 
@@ -26,7 +26,7 @@ fn build_ui(app: &Application) {
         .build();
 
     // ANCHOR: callback
-    let (sender, receiver) = MainContext::channel(PRIORITY_DEFAULT);
+    let (sender, receiver) = MainContext::channel(Priority::DEFAULT);
     // Connect to "clicked" signal of `button`
     button.connect_clicked(move |_| {
         let main_context = MainContext::default();


### PR DESCRIPTION
Update to work with gtk-rs-core commit f32fd06
"glib: Move priority constants to associated ones"

https://github.com/gtk-rs/gtk-rs-core/commit/f32fd0608a7066366eef9e8aca63ba01752adf1c

I was following along with the book and these two examples wouldn't compile with Cargo until I made this change; I tested in a new Cargo package and it works as expected from what it says on the chapter. using `Priority::default()` also works and returns the same value, but seemed like a less clear way of writing it.