### PR TITLE
gtk: Implement convenience traits for StringObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+Bilal Elmoussaoui:
+- gtk: Implement convenience traits for StringObject
+
 ## [0.6.5]
 
 Fabio Valentini:

--- a/gtk4/src/lib.rs
+++ b/gtk4/src/lib.rs
@@ -183,6 +183,7 @@ mod signal_list_item_factory;
 mod snapshot;
 mod spin_button;
 mod string_list;
+mod string_object;
 mod text;
 mod text_buffer;
 mod tree_model;

--- a/gtk4/src/string_object.rs
+++ b/gtk4/src/string_object.rs
@@ -1,0 +1,97 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::StringObject;
+use glib::{GStr, GString};
+
+impl From<StringObject> for String {
+    #[inline]
+    fn from(value: StringObject) -> Self {
+        skip_assert_initialized!();
+        Self::from(&value)
+    }
+}
+
+impl From<StringObject> for GString {
+    #[inline]
+    fn from(value: StringObject) -> Self {
+        skip_assert_initialized!();
+        Self::from(&value)
+    }
+}
+
+impl<'a> From<&'a StringObject> for String {
+    #[inline]
+    fn from(value: &'a StringObject) -> Self {
+        skip_assert_initialized!();
+        value.string().to_string()
+    }
+}
+
+impl<'a> From<&'a StringObject> for GString {
+    #[inline]
+    fn from(value: &'a StringObject) -> Self {
+        skip_assert_initialized!();
+        value.string()
+    }
+}
+
+impl From<String> for StringObject {
+    #[inline]
+    fn from(value: String) -> Self {
+        skip_assert_initialized!();
+        Self::new(&value)
+    }
+}
+
+impl<'a> From<&'a String> for StringObject {
+    #[inline]
+    fn from(value: &'a String) -> Self {
+        skip_assert_initialized!();
+        Self::new(value)
+    }
+}
+
+impl<'a> From<&'a GStr> for StringObject {
+    #[inline]
+    fn from(v: &'a GStr) -> Self {
+        skip_assert_initialized!();
+        Self::new(v)
+    }
+}
+
+impl From<GString> for StringObject {
+    #[inline]
+    fn from(value: GString) -> Self {
+        skip_assert_initialized!();
+        Self::new(&value)
+    }
+}
+
+impl<'a> From<&'a GString> for StringObject {
+    #[inline]
+    fn from(value: &'a GString) -> Self {
+        skip_assert_initialized!();
+        Self::new(value)
+    }
+}
+
+impl From<&str> for StringObject {
+    #[inline]
+    fn from(value: &str) -> Self {
+        skip_assert_initialized!();
+        Self::new(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StringObject;
+    use crate as gtk4;
+
+    #[test]
+    fn from_into() {
+        let obj = StringObject::new("some_str");
+        assert_eq!(String::from(&obj), obj.string());
+        assert_eq!(String::from(obj), "some_str");
+    }
+}


### PR DESCRIPTION
Sadly we can't have AsRef/Deref implemented as well :(

Fixes #1360