### PR TITLE
gtk: Move provider related functions outside of StyleContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 Bilal Elmoussaoui:
 - gtk: Implement convenience traits for StringObject
+- gtk: Move `gtk::StyleContext::add_provider_for_display` & `gtk::StyleContext::remove_provider_for_display` functions
+outside of `gtk::StyleContext` type as it was deprecated in GTK 4.10 causing a wrong deprecation warning.
+Switch to `gtk::style_context_add_provider_for_display` & `gtk::style_context_remove_provider_for_display` instead.
 
 ## [0.6.5]
 

--- a/examples/css/main.rs
+++ b/examples/css/main.rs
@@ -4,7 +4,7 @@ use gtk::prelude::*;
 use gtk::gdk::Display;
 use gtk::{
     Application, ApplicationWindow, Box as Box_, Button, ComboBoxText, CssProvider, Entry,
-    Orientation, StyleContext, STYLE_PROVIDER_PRIORITY_APPLICATION,
+    Orientation, STYLE_PROVIDER_PRIORITY_APPLICATION,
 };
 
 fn main() -> glib::ExitCode {
@@ -15,7 +15,7 @@ fn main() -> glib::ExitCode {
         provider.load_from_data(include_str!("style.css"));
         // We give the CssProvided to the default screen so the CSS rules we added
         // can be applied to our window.
-        StyleContext::add_provider_for_display(
+        gtk::style_context_add_provider_for_display(
             &Display::default().expect("Could not connect to a display."),
             &provider,
             STYLE_PROVIDER_PRIORITY_APPLICATION,

--- a/examples/custom_editable/main.rs
+++ b/examples/custom_editable/main.rs
@@ -17,7 +17,7 @@ fn main() -> glib::ExitCode {
     application.connect_startup(|_| {
         let provider = gtk::CssProvider::new();
         provider.load_from_data(include_str!("style.css"));
-        gtk::StyleContext::add_provider_for_display(
+        gtk::style_context_add_provider_for_display(
             &gdk::Display::default().unwrap(),
             &provider,
             800,

--- a/gtk4/Gir.toml
+++ b/gtk4/Gir.toml
@@ -2080,6 +2080,11 @@ generate_builder = false
 name = "Gtk.StyleContext"
 status = "generate"
 generate_builder = false
+    [[object.function]]
+    pattern = "(add|remove)_provider_for_display"
+    # To avoid them being marked as deprecated along with StyleContext
+    # see https://github.com/gtk-rs/gtk4-rs/issues/1317
+    manual = true
 
 [[object]]
 name = "Gtk.Switch"

--- a/gtk4/src/auto/style_context.rs
+++ b/gtk4/src/auto/style_context.rs
@@ -22,36 +22,6 @@ glib::wrapper! {
 
 impl StyleContext {
     pub const NONE: Option<&'static StyleContext> = None;
-
-    #[doc(alias = "gtk_style_context_add_provider_for_display")]
-    pub fn add_provider_for_display(
-        display: &impl IsA<gdk::Display>,
-        provider: &impl IsA<StyleProvider>,
-        priority: u32,
-    ) {
-        skip_assert_initialized!();
-        unsafe {
-            ffi::gtk_style_context_add_provider_for_display(
-                display.as_ref().to_glib_none().0,
-                provider.as_ref().to_glib_none().0,
-                priority,
-            );
-        }
-    }
-
-    #[doc(alias = "gtk_style_context_remove_provider_for_display")]
-    pub fn remove_provider_for_display(
-        display: &impl IsA<gdk::Display>,
-        provider: &impl IsA<StyleProvider>,
-    ) {
-        skip_assert_initialized!();
-        unsafe {
-            ffi::gtk_style_context_remove_provider_for_display(
-                display.as_ref().to_glib_none().0,
-                provider.as_ref().to_glib_none().0,
-            );
-        }
-    }
 }
 
 pub trait StyleContextExt: 'static {

--- a/gtk4/src/functions.rs
+++ b/gtk4/src/functions.rs
@@ -1,6 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::{prelude::*, AboutDialog, Window};
+use crate::{prelude::*, AboutDialog, StyleProvider, Window};
 use glib::{translate::*, IntoGStr, Quark, Slice, ToValue};
 use once_cell::sync::Lazy;
 use std::{boxed::Box as Box_, mem, pin::Pin, ptr};
@@ -252,5 +252,37 @@ pub fn test_list_all_types() -> Slice<glib::Type> {
         let mut n_types = std::mem::MaybeUninit::uninit();
         let types = ffi::gtk_test_list_all_types(n_types.as_mut_ptr());
         Slice::from_glib_container_num(types as *mut _, n_types.assume_init() as usize)
+    }
+}
+
+#[doc(alias = "gtk_style_context_add_provider_for_display")]
+#[doc(alias = "add_provider_for_display")]
+pub fn style_context_add_provider_for_display(
+    display: &impl IsA<gdk::Display>,
+    provider: &impl IsA<StyleProvider>,
+    priority: u32,
+) {
+    skip_assert_initialized!();
+    unsafe {
+        ffi::gtk_style_context_add_provider_for_display(
+            display.as_ref().to_glib_none().0,
+            provider.as_ref().to_glib_none().0,
+            priority,
+        );
+    }
+}
+
+#[doc(alias = "gtk_style_context_remove_provider_for_display")]
+#[doc(alias = "remove_provider_for_display")]
+pub fn style_context_remove_provider_for_display(
+    display: &impl IsA<gdk::Display>,
+    provider: &impl IsA<StyleProvider>,
+) {
+    skip_assert_initialized!();
+    unsafe {
+        ffi::gtk_style_context_remove_provider_for_display(
+            display.as_ref().to_glib_none().0,
+            provider.as_ref().to_glib_none().0,
+        );
     }
 }

--- a/gtk4/src/lib.rs
+++ b/gtk4/src/lib.rs
@@ -184,6 +184,7 @@ mod snapshot;
 mod spin_button;
 mod string_list;
 mod string_object;
+mod style_context;
 mod text;
 mod text_buffer;
 mod tree_model;

--- a/gtk4/src/style_context.rs
+++ b/gtk4/src/style_context.rs
@@ -1,0 +1,38 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+pub use crate::{prelude::*, StyleContext, StyleProvider};
+use glib::translate::*;
+
+impl StyleContext {
+    #[deprecated(note = "Use gtk::style_context_add_provider_for_display instead.")]
+    #[doc(alias = "gtk_style_context_add_provider_for_display")]
+    pub fn add_provider_for_display(
+        display: &impl IsA<gdk::Display>,
+        provider: &impl IsA<StyleProvider>,
+        priority: u32,
+    ) {
+        skip_assert_initialized!();
+        unsafe {
+            ffi::gtk_style_context_add_provider_for_display(
+                display.as_ref().to_glib_none().0,
+                provider.as_ref().to_glib_none().0,
+                priority,
+            );
+        }
+    }
+
+    #[deprecated(note = "Use gtk::style_context_remove_provider_for_display instead.")]
+    #[doc(alias = "gtk_style_context_remove_provider_for_display")]
+    pub fn remove_provider_for_display(
+        display: &impl IsA<gdk::Display>,
+        provider: &impl IsA<StyleProvider>,
+    ) {
+        skip_assert_initialized!();
+        unsafe {
+            ffi::gtk_style_context_remove_provider_for_display(
+                display.as_ref().to_glib_none().0,
+                provider.as_ref().to_glib_none().0,
+            );
+        }
+    }
+}


### PR DESCRIPTION
To avoid them being marked as deprecated in v4_10and is also more sementically correct Fixes #1317