### PR TITLE
Bind Settings to `active` instead of `state`

### DIFF
--- a/book/listings/settings/2/main.rs
+++ b/book/listings/settings/2/main.rs
@@ -31,7 +31,7 @@ fn build_ui(app: &Application) {
 
     // ANCHOR: settings_bind
     settings
-        .bind("is-switch-enabled", &switch, "state")
+        .bind("is-switch-enabled", &switch, "active")
         .flags(SettingsBindFlags::DEFAULT)
         .build();
     // ANCHOR_END: settings_bind

--- a/book/src/settings.md
+++ b/book/src/settings.md
@@ -76,7 +76,7 @@ Filename: <a class=file-link href="https://github.com/gtk-rs/gtk4-rs/blob/master
 
 The `Switch` now retains its state even after closing the application.
 But we can make this even better.
-The `Switch` has a property "state" and `Settings` allows us to bind properties to a specific setting.
+The `Switch` has a property "active" and `Settings` allows us to bind properties to a specific setting.
 So let's do exactly that.
 
 We can remove the [`boolean`](https://gtk-rs.org/gtk-rs-core/stable/latest/docs/gio/prelude/trait.SettingsExt.html#tymethod.boolean) call before initializing the `Switch` as well as the [`connect_state_set`](../docs/gtk4/struct.Switch.html#method.connect_state_set) call.


### PR DESCRIPTION
When binding to `state` the `Switch` can be in a wrong position where it is colored to be active, but the slider is at the wrong spot. As per advice in the GTK-chat, one should instead bind to the active-property.

![image](https://user-images.githubusercontent.com/48252573/231716796-244db02e-64bc-4b5a-a047-9702a44dcd6b.png)
