### PR TITLE
gtk4: allow subclassing WindowGroup

### DIFF
--- a/gtk4/src/subclass/mod.rs
+++ b/gtk4/src/subclass/mod.rs
@@ -84,6 +84,7 @@ pub mod tree_model_filter;
 pub mod tree_view;
 pub mod widget;
 pub mod window;
+pub mod window_group;
 
 // rustdoc-stripper-ignore-next
 /// Traits intended for blanket imports.
@@ -174,4 +175,5 @@ pub mod prelude {
         CompositeTemplateDisposeExt, CompositeTemplateInitializingExt, WidgetImpl, WidgetImplExt,
     };
     pub use super::window::{WindowImpl, WindowImplExt};
+    pub use super::window_group::WindowGroupImpl;
 }

--- a/gtk4/src/subclass/window_group.rs
+++ b/gtk4/src/subclass/window_group.rs
@@ -1,0 +1,10 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+// rustdoc-stripper-ignore-next
+//! Traits intended for subclassing [`WindowGroup`](crate::WindowGroup).
+
+use crate::{subclass::prelude::*, WindowGroup};
+
+pub trait WindowGroupImpl: ObjectImpl {}
+
+unsafe impl<T: WindowGroupImpl> IsSubclassable<T> for WindowGroup {}


### PR DESCRIPTION
This is to complete subclassing `PanelWorkbench` in libpanel: [panel-workbench.h#L39](https://gitlab.gnome.org/GNOME/libpanel/-/blob/e2f8a7281ea7034819c1e647a2c2957e9fd1483f/src/panel-workbench.h#L39)