### PR TITLE
manually add typed and with_type methods

### DIFF
--- a/gdk4/src/content_provider.rs
+++ b/gdk4/src/content_provider.rs
@@ -1,17 +1,22 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use crate::{prelude::*, ContentProvider};
-use glib::translate::*;
+use glib::{translate::*, value::FromValue};
 
 // rustdoc-stripper-ignore-next
 /// Trait containing manually implemented methods of [`ContentProvider`](crate::ContentProvider).
 pub trait ContentProviderExtManual {
     #[doc(alias = "gdk_content_provider_get_value")]
-    fn value(&self, type_: glib::Type) -> Result<glib::Value, glib::Error>;
+    fn value<T: for<'a> FromValue<'a> + StaticType>(&self) -> Result<T, glib::Error> {
+        self.value_with_type(T::static_type())
+            .map(|v| v.get::<T>().unwrap())
+    }
+    #[doc(alias = "gdk_content_provider_get_value")]
+    fn value_with_type(&self, type_: glib::Type) -> Result<glib::Value, glib::Error>;
 }
 
 impl<O: IsA<ContentProvider>> ContentProviderExtManual for O {
-    fn value(&self, type_: glib::Type) -> Result<glib::Value, glib::Error> {
+    fn value_with_type(&self, type_: glib::Type) -> Result<glib::Value, glib::Error> {
         unsafe {
             let mut error = std::ptr::null_mut();
             let mut value = glib::Value::from_type(type_);

--- a/gdk4/src/subclass/content_provider.rs
+++ b/gdk4/src/subclass/content_provider.rs
@@ -37,8 +37,8 @@ pub trait ContentProviderImpl: ContentProviderImplExt + ObjectImpl {
         self.parent_write_mime_type_future(mime_type, stream, io_priority)
     }
 
-    fn value(&self, type_: glib::Type) -> Result<Value, glib::Error> {
-        self.parent_value(type_)
+    fn value_with_type(&self, type_: glib::Type) -> Result<glib::Value, glib::Error> {
+        self.parent_value_with_type(type_)
     }
 }
 
@@ -72,7 +72,7 @@ pub trait ContentProviderImplExt: ObjectSubclass {
         io_priority: glib::Priority,
     ) -> Pin<Box<dyn Future<Output = Result<(), glib::Error>> + 'static>>;
 
-    fn parent_value(&self, type_: glib::Type) -> Result<Value, glib::Error>;
+    fn parent_value_with_type(&self, type_: glib::Type) -> Result<Value, glib::Error>;
 }
 
 impl<T: ContentProviderImpl> ContentProviderImplExt for T {
@@ -258,7 +258,7 @@ impl<T: ContentProviderImpl> ContentProviderImplExt for T {
         ))
     }
 
-    fn parent_value(&self, type_: glib::Type) -> Result<Value, glib::Error> {
+    fn parent_value_with_type(&self, type_: glib::Type) -> Result<Value, glib::Error> {
         unsafe {
             let data = T::type_data();
             let parent_class = data.as_ref().parent_class() as *mut ffi::GdkContentProviderClass;
@@ -421,7 +421,7 @@ unsafe extern "C" fn content_provider_get_value<T: ContentProviderImpl>(
     let imp = instance.imp();
     let value: Value = from_glib_none(value_ptr);
 
-    let ret = imp.value(value.type_());
+    let ret = imp.value_with_type(value.type_());
     match ret {
         Ok(v) => {
             glib::gobject_ffi::g_value_copy(v.to_glib_none().0, value_ptr);

--- a/gtk4/Gir.toml
+++ b/gtk4/Gir.toml
@@ -2634,6 +2634,9 @@ name = "Gtk.Widget"
 status = "generate"
 manual_traits = ["WidgetExtManual"]
     [[object.function]]
+    name = "ancestor"
+    manual = true
+    [[object.function]]
     name = "add_tick_callback"
     manual = true
     doc_ignore_parameters = ["notify"]

--- a/gtk4/src/widget.rs
+++ b/gtk4/src/widget.rs
@@ -12,9 +12,30 @@ pub trait WidgetExtManual: 'static {
         &self,
         callback: P,
     ) -> TickCallbackId;
+
+    #[doc(alias = "gtk_widget_get_ancestor")]
+    #[doc(alias = "get_ancestor")]
+    #[must_use]
+    fn ancestor<T: IsA<Widget>>(&self) -> Option<T> {
+        self.ancestor_with_type(T::static_type())
+            .and_then(|w| w.downcast().ok())
+    }
+
+    #[doc(alias = "gtk_widget_get_ancestor")]
+    #[doc(alias = "get_ancestor")]
+    #[must_use]
+    fn ancestor_with_type(&self, widget_type: glib::types::Type) -> Option<Widget>;
 }
 
 impl<O: IsA<Widget>> WidgetExtManual for O {
+    fn ancestor_with_type(&self, widget_type: glib::types::Type) -> Option<Widget> {
+        unsafe {
+            from_glib_none(ffi::gtk_widget_get_ancestor(
+                self.as_ref().to_glib_none().0,
+                widget_type.into_glib(),
+            ))
+        }
+    }
     fn add_tick_callback<P: Fn(&Self, &gdk::FrameClock) -> Continue + 'static>(
         &self,
         callback: P,


### PR DESCRIPTION
Closes #1384 

I've also found `DropTarget::new` which could receive the same treatment, but that's a more complex case, because it can also accept the type `G_TYPE_INVALID` when the user wants to specify multiple GTypes, so I've just skipped that.

