### PR TITLE
Fix required features not shown in docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -67,6 +67,7 @@ jobs:
             --extern-html-root-url=khronos_egl=https://docs.rs/khronos-egl/latest/
             --extern-html-root-url=xkb=https://docs.rs/xkb/latest/
             --extern-html-root-url=windows=https://microsoft.github.io/windows-docs-rs/doc/
+            --cfg docsrs
       - uses: actions-rs/cargo@v1
         with:
           command: doc

--- a/gdk4-wayland/Cargo.toml
+++ b/gdk4-wayland/Cargo.toml
@@ -20,6 +20,8 @@ egl = ["khronos-egl"]
 xkb_crate = ["xkb"]
 
 [package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/gdk4-wayland/sys/Cargo.toml
+++ b/gdk4-wayland/sys/Cargo.toml
@@ -23,6 +23,9 @@ version = "4.4"
 version = "4.10"
 
 [package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]
 features = []
 
 [lib]

--- a/gdk4-win32/Cargo.toml
+++ b/gdk4-win32/Cargo.toml
@@ -14,6 +14,8 @@ rust-version = "1.64"
 build = "build.rs"
 
 [package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.system-deps.gtk4_win32]

--- a/gdk4-win32/sys/Cargo.toml
+++ b/gdk4-win32/sys/Cargo.toml
@@ -23,6 +23,9 @@ version = "4.4"
 version = "4.8"
 
 [package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]
 features = []
 
 [lib]

--- a/gdk4-x11/Cargo.toml
+++ b/gdk4-x11/Cargo.toml
@@ -18,6 +18,8 @@ egl = ["khronos-egl"]
 xlib = ["x11"]
 
 [package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/gdk4-x11/sys/Cargo.toml
+++ b/gdk4-x11/sys/Cargo.toml
@@ -23,6 +23,9 @@ version = "4.4"
 version = "4.10"
 
 [package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]
 features = []
 
 [lib]

--- a/gdk4/Cargo.toml
+++ b/gdk4/Cargo.toml
@@ -23,6 +23,8 @@ v4_10 = ["ffi/v4_10", "v4_8"]
 v4_12 = ["ffi/v4_12", "v4_10"]
 
 [package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/gdk4/sys/Cargo.toml
+++ b/gdk4/sys/Cargo.toml
@@ -13,6 +13,9 @@ version = "0.7.0"
 rust-version = "1.64"
 
 [package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]
 features = []
 
 [package.metadata.system-deps.gtk4]

--- a/gsk4/Cargo.toml
+++ b/gsk4/Cargo.toml
@@ -22,6 +22,8 @@ v4_6 = ["ffi/v4_6", "gdk/v4_6", "v4_4"]
 v4_10 = ["ffi/v4_10", "gdk/v4_10", "v4_6"]
 
 [package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/gsk4/sys/Cargo.toml
+++ b/gsk4/sys/Cargo.toml
@@ -13,6 +13,9 @@ version = "0.7.0"
 rust-version = "1.64"
 
 [package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]
 features = []
 
 [package.metadata.system-deps.gtk4]

--- a/gtk4/Cargo.toml
+++ b/gtk4/Cargo.toml
@@ -34,6 +34,8 @@ gnome_43 = ["v4_8", "cairo-rs/v1_16", "gdk-pixbuf/v2_42", "gio/v2_74"]
 gnome_42 = ["v4_6", "cairo-rs/v1_16", "gdk-pixbuf/v2_42", "gio/v2_72"]
 
 [package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/gtk4/sys/Cargo.toml
+++ b/gtk4/sys/Cargo.toml
@@ -14,6 +14,9 @@ version = "0.7.0"
 rust-version = "1.64"
 
 [package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]
 features = []
 
 [package.metadata.system-deps.gtk4]


### PR DESCRIPTION
Fix for https://github.com/gtk-rs/gtk-rs-core/issues/1090 on the gtk4-rs side

So it seems like you need both RUSTFLAGS and RUSTDOCFLAGS because `build.rs` doesn't care about the doc flags and cargo only passes RUSTDOCFLAGS to rustdoc...