### PR TITLE
Update librsvg in installation_windows.md

### DIFF
--- a/book/src/installation_windows.md
+++ b/book/src/installation_windows.md
@@ -143,9 +143,7 @@ cmake --install build
 cd /
 
 cd librsvg/win32
-where python
-nmake /f generate-msvc.mak generate-nmake-files PYTHON=<output from last command>
-xcopy /s C:\gnome\include\cairo C:\gnome\include
+nmake /f generate-msvc.mak generate-nmake-files
 nmake /f Makefile.vc CFG=release install PREFIX=C:\gnome
 cd /
 ```


### PR DESCRIPTION
Due to recent merges in librsvg, it's no longer necessary to explicitly pass Python and there is no need to perform the xcopy operation for cairo headers.

https://gitlab.gnome.org/GNOME/librsvg/-/merge_requests/824