### PR TITLE
Use `iter` on `gio::ListModel`

### DIFF
--- a/book/listings/todo/2/window/imp.rs
+++ b/book/listings/todo/2/window/imp.rs
@@ -4,7 +4,6 @@ use std::fs::File;
 use gio::Settings;
 use glib::signal::Inhibit;
 use glib::subclass::InitializingObject;
-use gtk::glib::Cast;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use gtk::{gio, glib, CompositeTemplate, Entry, ListView};
@@ -74,10 +73,9 @@ impl WindowImpl for Window {
         let backup_data: Vec<TaskData> = self
             .obj()
             .tasks()
-            .snapshot()
-            .iter()
-            .filter_map(Cast::downcast_ref::<TaskObject>)
-            .map(TaskObject::task_data)
+            .iter::<TaskObject>()
+            .filter_map(Result::ok)
+            .map(|task_object| task_object.task_data())
             .collect();
 
         // Save state to file

--- a/book/listings/todo/3/window/imp.rs
+++ b/book/listings/todo/3/window/imp.rs
@@ -4,7 +4,6 @@ use std::fs::File;
 use gio::Settings;
 use glib::signal::Inhibit;
 use glib::subclass::InitializingObject;
-use gtk::glib::Cast;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use gtk::{gio, glib, CompositeTemplate, Entry, ListView};
@@ -69,10 +68,9 @@ impl WindowImpl for Window {
         let backup_data: Vec<TaskData> = self
             .obj()
             .tasks()
-            .snapshot()
-            .iter()
-            .filter_map(Cast::downcast_ref::<TaskObject>)
-            .map(TaskObject::task_data)
+            .iter::<TaskObject>()
+            .filter_map(Result::ok)
+            .map(|task_object| task_object.task_data())
             .collect();
 
         // Save state to file

--- a/book/listings/todo/4/window/imp.rs
+++ b/book/listings/todo/4/window/imp.rs
@@ -4,7 +4,6 @@ use std::fs::File;
 use gio::Settings;
 use glib::signal::Inhibit;
 use glib::subclass::InitializingObject;
-use gtk::glib::Cast;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use gtk::{gio, glib, CompositeTemplate, Entry, ListView};
@@ -69,10 +68,9 @@ impl WindowImpl for Window {
         let backup_data: Vec<TaskData> = self
             .obj()
             .tasks()
-            .snapshot()
-            .iter()
-            .filter_map(Cast::downcast_ref::<TaskObject>)
-            .map(TaskObject::task_data)
+            .iter::<TaskObject>()
+            .filter_map(Result::ok)
+            .map(|task_object| task_object.task_data())
             .collect();
 
         // Save state to file

--- a/book/listings/todo/5/window/imp.rs
+++ b/book/listings/todo/5/window/imp.rs
@@ -4,7 +4,6 @@ use std::fs::File;
 use gio::Settings;
 use glib::signal::Inhibit;
 use glib::subclass::InitializingObject;
-use gtk::glib::Cast;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use gtk::{gio, glib, CompositeTemplate, Entry, ListView};
@@ -69,10 +68,9 @@ impl WindowImpl for Window {
         let backup_data: Vec<TaskData> = self
             .obj()
             .tasks()
-            .snapshot()
-            .iter()
-            .filter_map(Cast::downcast_ref::<TaskObject>)
-            .map(TaskObject::task_data)
+            .iter::<TaskObject>()
+            .filter_map(Result::ok)
+            .map(|task_object| task_object.task_data())
             .collect();
 
         // Save state to file

--- a/book/listings/todo/6/window/imp.rs
+++ b/book/listings/todo/6/window/imp.rs
@@ -71,10 +71,9 @@ impl WindowImpl for Window {
         let backup_data: Vec<TaskData> = self
             .obj()
             .tasks()
-            .snapshot()
-            .iter()
-            .filter_map(Cast::downcast_ref::<TaskObject>)
-            .map(TaskObject::task_data)
+            .iter::<TaskObject>()
+            .filter_map(Result::ok)
+            .map(|task_object| task_object.task_data())
             .collect();
 
         // Save state to file

--- a/book/listings/todo/7/window/imp.rs
+++ b/book/listings/todo/7/window/imp.rs
@@ -72,10 +72,9 @@ impl WindowImpl for Window {
         let backup_data: Vec<TaskData> = self
             .obj()
             .tasks()
-            .snapshot()
-            .iter()
-            .filter_map(Cast::downcast_ref::<TaskObject>)
-            .map(TaskObject::task_data)
+            .iter::<TaskObject>()
+            .filter_map(Result::ok)
+            .map(|task_object| task_object.task_data())
             .collect();
 
         // Save state to file

--- a/book/listings/todo/8/collection_object/mod.rs
+++ b/book/listings/todo/8/collection_object/mod.rs
@@ -25,12 +25,10 @@ impl CollectionObject {
         let title = self.imp().title.borrow().clone();
         let tasks_data = self
             .tasks()
-            .snapshot()
-            .iter()
-            .filter_map(Cast::downcast_ref::<TaskObject>)
-            .map(TaskObject::task_data)
+            .iter::<TaskObject>()
+            .filter_map(Result::ok)
+            .map(|task_object| task_object.task_data())
             .collect();
-
         CollectionData { title, tasks_data }
     }
 

--- a/book/listings/todo/8/window/imp.rs
+++ b/book/listings/todo/8/window/imp.rs
@@ -88,10 +88,9 @@ impl WindowImpl for Window {
         let backup_data: Vec<CollectionData> = self
             .obj()
             .collections()
-            .snapshot()
-            .iter()
-            .filter_map(Cast::downcast_ref::<CollectionObject>)
-            .map(CollectionObject::to_collection_data)
+            .iter::<CollectionObject>()
+            .filter_map(|collection_object| collection_object.ok())
+            .map(|collection_object| collection_object.to_collection_data())
             .collect();
 
         // Save state to file


### PR DESCRIPTION
That way, we don't have to allocate an intermediate `Vec` anymore.
Fixes #1032