### PR TITLE
Add `--generate-link-to-definition` option when building on docs.rs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -68,6 +68,7 @@ jobs:
             --extern-html-root-url=xkb=https://docs.rs/xkb/latest/
             --extern-html-root-url=windows=https://microsoft.github.io/windows-docs-rs/doc/
             --cfg docsrs
+            -Zunstable-options --generate-link-to-definition
       - uses: actions-rs/cargo@v1
         with:
           command: doc

--- a/gdk4-wayland/Cargo.toml
+++ b/gdk4-wayland/Cargo.toml
@@ -23,7 +23,7 @@ xkb_crate = ["xkb"]
 [package.metadata.docs.rs]
 all-features = true
 rustc-args = ["--cfg", "docsrs"]
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 
 [dependencies]
 ffi = {path = "./sys", package = "gdk4-wayland-sys", version = "0.7"}

--- a/gdk4-wayland/sys/Cargo.toml
+++ b/gdk4-wayland/sys/Cargo.toml
@@ -28,7 +28,7 @@ version = "4.11"
 [package.metadata.docs.rs]
 all-features = true
 rustc-args = ["--cfg", "docsrs"]
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 features = []
 
 [lib]

--- a/gdk4-win32/Cargo.toml
+++ b/gdk4-win32/Cargo.toml
@@ -16,7 +16,7 @@ build = "build.rs"
 [package.metadata.docs.rs]
 all-features = true
 rustc-args = ["--cfg", "docsrs"]
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 
 [package.metadata.system-deps.gtk4_win32]
 name = "gtk4-win32"

--- a/gdk4-win32/sys/Cargo.toml
+++ b/gdk4-win32/sys/Cargo.toml
@@ -25,7 +25,7 @@ version = "4.8"
 [package.metadata.docs.rs]
 all-features = true
 rustc-args = ["--cfg", "docsrs"]
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 features = []
 
 [lib]

--- a/gdk4-x11/Cargo.toml
+++ b/gdk4-x11/Cargo.toml
@@ -20,7 +20,7 @@ xlib = ["x11"]
 [package.metadata.docs.rs]
 all-features = true
 rustc-args = ["--cfg", "docsrs"]
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 
 [dependencies]
 ffi = {path = "./sys", package = "gdk4-x11-sys", version = "0.7"}

--- a/gdk4-x11/sys/Cargo.toml
+++ b/gdk4-x11/sys/Cargo.toml
@@ -25,7 +25,7 @@ version = "4.10"
 [package.metadata.docs.rs]
 all-features = true
 rustc-args = ["--cfg", "docsrs"]
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 features = []
 
 [lib]

--- a/gdk4/Cargo.toml
+++ b/gdk4/Cargo.toml
@@ -25,7 +25,7 @@ v4_12 = ["ffi/v4_12", "v4_10"]
 [package.metadata.docs.rs]
 all-features = true
 rustc-args = ["--cfg", "docsrs"]
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 
 [dependencies]
 cairo-rs = {git = "https://github.com/gtk-rs/gtk-rs-core", version = "0.18"}

--- a/gdk4/sys/Cargo.toml
+++ b/gdk4/sys/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.64"
 [package.metadata.docs.rs]
 all-features = true
 rustc-args = ["--cfg", "docsrs"]
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 features = []
 
 [package.metadata.system-deps.gtk4]

--- a/gsk4/Cargo.toml
+++ b/gsk4/Cargo.toml
@@ -25,7 +25,7 @@ v4_10 = ["ffi/v4_10", "gdk/v4_10", "v4_6"]
 [package.metadata.docs.rs]
 all-features = true
 rustc-args = ["--cfg", "docsrs"]
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 
 [dependencies]
 cairo-rs = {git = "https://github.com/gtk-rs/gtk-rs-core", version = "0.18"}

--- a/gsk4/sys/Cargo.toml
+++ b/gsk4/sys/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.64"
 [package.metadata.docs.rs]
 all-features = true
 rustc-args = ["--cfg", "docsrs"]
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 features = []
 
 [package.metadata.system-deps.gtk4]

--- a/gtk4-macros/Cargo.toml
+++ b/gtk4-macros/Cargo.toml
@@ -33,3 +33,6 @@ futures-channel = "0.3"
 futures-util = "0.3"
 gtk = { path = "../gtk4", package = "gtk4", version = "0.7" }
 trybuild2 = "1.0"
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]

--- a/gtk4/Cargo.toml
+++ b/gtk4/Cargo.toml
@@ -36,7 +36,7 @@ gnome_42 = ["v4_6", "cairo-rs/v1_16", "gdk-pixbuf/v2_42", "gio/v2_72"]
 [package.metadata.docs.rs]
 all-features = true
 rustc-args = ["--cfg", "docsrs"]
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 
 [dependencies]
 cairo-rs = {git = "https://github.com/gtk-rs/gtk-rs-core", version = "0.18"}

--- a/gtk4/sys/Cargo.toml
+++ b/gtk4/sys/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.64"
 [package.metadata.docs.rs]
 all-features = true
 rustc-args = ["--cfg", "docsrs"]
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 features = []
 
 [package.metadata.system-deps.gtk4]


### PR DESCRIPTION
This option generates links in source code pages, allowing to jump to definition and to jump back to doc. It makes browsing the source code pages much nicer. You can see it in action [here](https://doc.rust-lang.org/stable/nightly-rustc/src/rustc_middle/lib.rs.html#90).