### PR TITLE
gdk/sys: Re-ignore N_FORMATS

### DIFF
--- a/gdk4/sys/Gir.toml
+++ b/gdk4/sys/Gir.toml
@@ -22,3 +22,10 @@ status = "generate"
     [[object.function]]
     name = "drag_surface_size_get_type"
     version = "4.12"
+
+[[object]]
+name = "Gdk.MemoryFormat"
+status = "generate"
+    [[object.member]]
+    name = "n_formats"
+    alias = true # not useful

--- a/gdk4/sys/src/lib.rs
+++ b/gdk4/sys/src/lib.rs
@@ -163,7 +163,6 @@ pub const GDK_MEMORY_G16A16: GdkMemoryFormat = 22;
 pub const GDK_MEMORY_G16: GdkMemoryFormat = 23;
 pub const GDK_MEMORY_A8: GdkMemoryFormat = 24;
 pub const GDK_MEMORY_A16: GdkMemoryFormat = 25;
-pub const GDK_MEMORY_N_FORMATS: GdkMemoryFormat = 26;
 
 pub type GdkNotifyType = c_int;
 pub const GDK_NOTIFY_ANCESTOR: GdkNotifyType = 0;


### PR DESCRIPTION
It was reverted in 8e7e745913d42f698cba83ac7c1bf2f96fdff0a6 as it is useful for -sys bindings
but it is probelmatic for us now as new values breaks our sys tests until we add a way to ignore certains consts from the abi test