### PR TITLE
Impl Write on text buffers

### DIFF
--- a/gtk4/src/entry_buffer.rs
+++ b/gtk4/src/entry_buffer.rs
@@ -127,3 +127,11 @@ impl Default for EntryBuffer {
         glib::Object::new()
     }
 }
+
+impl std::fmt::Write for EntryBuffer {
+    fn write_str(&mut self, s: &str) -> std::fmt::Result {
+        let pos = self.length();
+        self.insert_text(pos, s);
+        Ok(())
+    }
+}

--- a/gtk4/src/text_buffer.rs
+++ b/gtk4/src/text_buffer.rs
@@ -103,3 +103,11 @@ pub trait TextBufferExtManual: sealed::Sealed + IsA<TextBuffer> + 'static {
 }
 
 impl<O: IsA<TextBuffer>> TextBufferExtManual for O {}
+
+impl std::fmt::Write for TextBuffer {
+    fn write_str(&mut self, s: &str) -> std::fmt::Result {
+        let mut iter = self.end_iter();
+        self.insert(&mut iter, s);
+        Ok(())
+    }
+}


### PR DESCRIPTION
Text is always written at the end. I could insert the text at cursor position, but I think inserting always at the end provides more consistent behavior.