### PR TITLE
book: Add setuptools installation

### DIFF
--- a/book/src/installation_windows.md
+++ b/book/src/installation_windows.md
@@ -131,6 +131,9 @@ git clone https://gitlab.gnome.org/GNOME/librsvg.git --depth 1
 :: Make sure that cmd finds pkg-config-lite when searching for pkg-config
 where pkg-config
 
+:: Make sure that setuptools is available. 
+pip install setuptools
+
 cd gtk
 meson setup builddir --prefix=C:/gnome -Dbuild-tests=false -Dmedia-gstreamer=disabled
 meson install -C builddir


### PR DESCRIPTION
Starting with Python 3.10 and 3.11, distutils is formally marked as deprecated, but some dependencies that GTK4 relies upon still require it for compilation. Prompt users to install setuptools to mitigate this. 

```
FAILED: subprojects/glib/gio/gdbus-daemon-generated.h subprojects/glib/gio/gdbus-daemon-generated.c
"C:\Users\wroy\AppData\Local\Programs\Python\Python312\python.exe" "subprojects/glib/gio/gdbus-2.0/codegen/gdbus-codegen" "--interface-prefix" "org." "--output-directory" "subprojects/glib/gio" "--generate-c-code" "gdbus-daemon-generated" "--c-namespace" "_G" "../subprojects/glib/gio/dbus-daemon.xml"
Traceback (most recent call last):
  File "C:\gtk\builddir\subprojects\glib\gio\gdbus-2.0\codegen\gdbus-codegen", line 53, in <module>
    from codegen import codegen_main
  File "C:\gtk\builddir\subprojects\glib\gio\gdbus-2.0\codegen\codegen_main.py", line 29, in <module>
    from . import dbustypes
  File "C:\gtk\builddir\subprojects\glib\gio\gdbus-2.0\codegen\dbustypes.py", line 22, in <module>
    from . import utils
  File "C:\gtk\builddir\subprojects\glib\gio\gdbus-2.0\codegen\utils.py", line 22, in <module>
    import distutils.version
ModuleNotFoundError: No module named 'distutils'
[455/4106] Generating subprojects/glib/gio/tests/gdbus-obj...anager-example/objectmanager-rst-gen with a custom command
FAILED: subprojects/glib/gio/tests/gdbus-object-manager-example/objectmanager-rst-gen-org.gtk.GDBus.Example.ObjectManager.Animal.rst subprojects/glib/gio/tests/gdbus-object-manager-example/objectmanager-rst-gen-org.gtk.GDBus.Example.ObjectManager.Cat.rst
"C:\Users\wroy\AppData\Local\Programs\Python\Python312\python.exe" "subprojects/glib/gio/gdbus-2.0/codegen/gdbus-codegen" "--interface-prefix" "org.gtk.GDBus.Example.ObjectManager." "--generate-rst" "objectmanager-rst-gen" "--output-directory" "subprojects/glib/gio/tests/gdbus-object-manager-example" "../subprojects/glib/gio/tests/gdbus-object-manager-example/gdbus-example-objectmanager.xml"
Traceback (most recent call last):
  File "C:\gtk\builddir\subprojects\glib\gio\gdbus-2.0\codegen\gdbus-codegen", line 53, in <module>
    from codegen import codegen_main
  File "C:\gtk\builddir\subprojects\glib\gio\gdbus-2.0\codegen\codegen_main.py", line 29, in <module>
    from . import dbustypes
  File "C:\gtk\builddir\subprojects\glib\gio\gdbus-2.0\codegen\dbustypes.py", line 22, in <module>
    from . import utils
  File "C:\gtk\builddir\subprojects\glib\gio\gdbus-2.0\codegen\utils.py", line 22, in <module>
    import distutils.version
ModuleNotFoundError: No module named 'distutils'
[456/4106] Generating subprojects/glib/gio/tests/gdbus-object-manager-example/objectmanager-gen with a custom command
FAILED: subprojects/glib/gio/tests/gdbus-object-manager-example/objectmanager-gen.h subprojects/glib/gio/tests/gdbus-object-manager-example/objectmanager-gen.c subprojects/glib/gio/tests/gdbus-object-manager-example/objectmanager-gen-org.gtk.GDBus.Example.ObjectManager.Animal.xml subprojects/glib/gio/tests/gdbus-object-manager-example/objectmanager-gen-org.gtk.GDBus.Example.ObjectManager.Cat.xml
"C:\Users\wroy\AppData\Local\Programs\Python\Python312\python.exe" "subprojects/glib/gio/gdbus-2.0/codegen/gdbus-codegen" "--interface-prefix" "org.gtk.GDBus.Example.ObjectManager." "--c-namespace" "Example" "--c-generate-object-manager" "--output-directory" "subprojects/glib/gio/tests/gdbus-object-manager-example" "--generate-c-code" "objectmanager-gen" "--generate-docbook" "objectmanager-gen" "--symbol-decorator" "GDBUS_OBJECT_MANAGER_EXAMPLE_AVAILABLE_IN_ALL" "--symbol-decorator-header" "gdbus-example-objectmanager-visibility.h" "../subprojects/glib/gio/tests/gdbus-object-manager-example/gdbus-example-objectmanager.xml"
Traceback (most recent call last):
  File "C:\gtk\builddir\subprojects\glib\gio\gdbus-2.0\codegen\gdbus-codegen", line 53, in <module>
    from codegen import codegen_main
  File "C:\gtk\builddir\subprojects\glib\gio\gdbus-2.0\codegen\codegen_main.py", line 29, in <module>
    from . import dbustypes
  File "C:\gtk\builddir\subprojects\glib\gio\gdbus-2.0\codegen\dbustypes.py", line 22, in <module>
    from . import utils
  File "C:\gtk\builddir\subprojects\glib\gio\gdbus-2.0\codegen\utils.py", line 22, in <module>
    import distutils.version
ModuleNotFoundError: No module named 'distutils'
```

https://peps.python.org/pep-0632/