### PR TITLE
docs: fix composite template internal_child -> internal

### DIFF
--- a/gtk4-macros/src/lib.rs
+++ b/gtk4-macros/src/lib.rs
@@ -70,7 +70,7 @@ pub fn include_blueprint(input: TokenStream) -> TokenStream {
 /// The `template_child` attribute is used to mark all internal widgets
 /// we need to have programmatic access to. It can take two parameters:
 /// - `id` which defaults to the item name if not defined
-/// - `internal_child` whether the child should be accessible as an
+/// - `internal` whether the child should be accessible as an
 ///   “internal-child”, defaults to `false`
 ///
 /// # Example


### PR DESCRIPTION
`template_child` wants `internal`, not `internal_child`