### PR TITLE
gtk: Don't propogate unused argument

### DIFF
--- a/gtk4/src/subclass/widget.rs
+++ b/gtk4/src/subclass/widget.rs
@@ -1008,11 +1008,7 @@ pub unsafe trait WidgetClassExt: ClassStruct {
 
     #[doc(alias = "gtk_widget_class_add_binding")]
     fn add_binding<
-        F: Fn(
-                &<<Self as ClassStruct>::Type as ObjectSubclass>::Type,
-                Option<&Variant>,
-            ) -> glib::Propagation
-            + 'static,
+        F: Fn(&<<Self as ClassStruct>::Type as ObjectSubclass>::Type) -> glib::Propagation + 'static,
     >(
         &mut self,
         keyval: gdk::Key,
@@ -1022,8 +1018,8 @@ pub unsafe trait WidgetClassExt: ClassStruct {
         let shortcut = crate::Shortcut::new(
             Some(crate::KeyvalTrigger::new(keyval, mods)),
             Some(crate::CallbackAction::new(
-                move |widget, args| -> glib::Propagation {
-                    unsafe { callback(widget.unsafe_cast_ref(), args) }
+                move |widget, _| -> glib::Propagation {
+                    unsafe { callback(widget.unsafe_cast_ref()) }
                 },
             )),
         );


### PR DESCRIPTION
Unlike the C version we are emulating, we dont set any ‘arguments’, and in any case they have little value in a language with native closures

It's therefore plain confusing to require users to accept this second parameter that will *always* be `None`

Fix: https://github.com/gtk-rs/gtk4-rs/issues/1590
See: https://github.com/gtk-rs/gtk4-rs/issues/1542