### PR TITLE
Replace simple `impl Debug` with derived `Debug` in tokio example

### DIFF
--- a/examples/tokio_async_request/main.rs
+++ b/examples/tokio_async_request/main.rs
@@ -15,15 +15,9 @@ pub struct ResultBody {
     results: Vec<Pokemon>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct PokemonClient {
     page: u32,
-}
-
-impl Default for PokemonClient {
-    fn default() -> Self {
-        Self { page: 0 }
-    }
 }
 
 impl PokemonClient {

--- a/gtk4/src/rt.rs
+++ b/gtk4/src/rt.rs
@@ -13,7 +13,7 @@ extern "C" {
 }
 
 thread_local! {
-    static IS_MAIN_THREAD: Cell<bool> = Cell::new(false)
+    static IS_MAIN_THREAD: Cell<bool> = const{Cell::new(false)}
 }
 
 static INITIALIZED: AtomicBool = AtomicBool::new(false);


### PR DESCRIPTION
As proposed in the linked issue, this commit removes the trivial `impl Default`

fixes: #1662