### PR TITLE
macros: Drop macro-proc-error and upgrade syn to 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,7 +392,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn",
 ]
 
 [[package]]
@@ -677,7 +677,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn",
 ]
 
 [[package]]
@@ -815,7 +815,7 @@ dependencies = [
  "proc-macro2",
  "quick-xml",
  "quote",
- "syn 1.0.109",
+ "syn",
  "trybuild2",
 ]
 
@@ -1535,7 +1535,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn",
 ]
 
 [[package]]
@@ -1647,17 +1647,6 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11a6ae1e52eb25aab8f3fb9fca13be982a373b8f1157ca14b897a825ba4a2d35"
@@ -1757,7 +1746,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn",
 ]
 
 [[package]]
@@ -1802,7 +1791,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn",
 ]
 
 [[package]]
@@ -2048,7 +2037,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -2082,7 +2071,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,7 +812,6 @@ dependencies = [
  "futures-util",
  "gtk4",
  "proc-macro-crate",
- "proc-macro-error",
  "proc-macro2",
  "quick-xml",
  "quote",
@@ -1292,30 +1291,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
  "toml_edit 0.21.1",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -34,12 +34,6 @@ allow-git = [
   "https://github.com/gtk-rs/gtk-rs-core",
 ]
 
-# proc-macro-error depends on an old version of syn
-# See https://github.com/gtk-rs/gtk4-rs/issues/1409
-[[bans.skip]]
-name = "syn"
-version = "1.0"
-
 # proc-macro-crate depends on an older version of toml_edit
 # https://github.com/bkchr/proc-macro-crate/pull/50
 [[bans.skip]]

--- a/gtk4-macros/Cargo.toml
+++ b/gtk4-macros/Cargo.toml
@@ -26,7 +26,7 @@ quick-xml = {version = "0.31", optional = true}
 proc-macro-crate = "3.0"
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = {version = "1.0", features = ["full"]}
+syn = {version = "2.0", features = ["full"]}
 
 [dev-dependencies]
 futures-channel = "0.3"

--- a/gtk4-macros/Cargo.toml
+++ b/gtk4-macros/Cargo.toml
@@ -24,7 +24,6 @@ blueprint = []
 anyhow = "1.0"
 quick-xml = {version = "0.31", optional = true}
 proc-macro-crate = "3.0"
-proc-macro-error = "1.0"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = {version = "1.0", features = ["full"]}


### PR DESCRIPTION
This can be reviewed per commit.

I rewrote a bunch of stuff in attribute_parser.rs because I found it easier than to port the existing code. I could have rewrote more to be simpler but that would have involved changing the types that are exported from the module, which would have involved changes in other parts too. It can probably be done in a following PR.

This almost gets rid of the anyhow dependency in the macros crate, because of the need to use `syn::Error::into_compile_error`. It can probably be completely removed in a following PR, since it has only a single use and can be easily replaced.

Supersedes #1422.\
Closes #1409.