### PR TITLE
gtk4: Manually implement `GraphicsOffload` constructor for now

### DIFF
--- a/gtk4/Gir.toml
+++ b/gtk4/Gir.toml
@@ -129,7 +129,6 @@ generate = [
     "Gtk.GestureRotate",
     "Gtk.GestureSwipe",
     "Gtk.GestureZoom",
-    "Gtk.GraphicsOffload",
     "Gtk.GraphicsOffloadEnabled",
     "Gtk.Grid",
     "Gtk.GridLayout",
@@ -1369,6 +1368,15 @@ status = "generate"
     name = "create-context"
         [object.signal.return]
         nullable = true
+
+[[object]]
+name = "Gtk.GraphicsOffload"
+status = "generate"
+    [[object.function]]
+    name = "new"
+    # transfer none
+    # https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/7159
+    manual = true
 
 [[object]]
 name = "Gtk.GridLayoutChild"

--- a/gtk4/src/auto/graphics_offload.rs
+++ b/gtk4/src/auto/graphics_offload.rs
@@ -23,17 +23,6 @@ glib::wrapper! {
 }
 
 impl GraphicsOffload {
-    #[doc(alias = "gtk_graphics_offload_new")]
-    pub fn new(child: Option<&impl IsA<Widget>>) -> GraphicsOffload {
-        assert_initialized_main_thread!();
-        unsafe {
-            Widget::from_glib_full(ffi::gtk_graphics_offload_new(
-                child.map(|p| p.as_ref()).to_glib_none().0,
-            ))
-            .unsafe_cast()
-        }
-    }
-
     // rustdoc-stripper-ignore-next
     /// Creates a new builder-pattern struct instance to construct [`GraphicsOffload`] objects.
     ///
@@ -119,14 +108,6 @@ impl GraphicsOffload {
                 Box_::into_raw(f),
             )
         }
-    }
-}
-
-#[cfg(feature = "v4_14")]
-#[cfg_attr(docsrs, doc(cfg(feature = "v4_14")))]
-impl Default for GraphicsOffload {
-    fn default() -> Self {
-        glib::object::Object::new::<Self>()
     }
 }
 

--- a/gtk4/src/graphics_offload.rs
+++ b/gtk4/src/graphics_offload.rs
@@ -1,0 +1,26 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use glib::translate::*;
+
+use crate::{prelude::*, GraphicsOffload, Widget};
+
+impl GraphicsOffload {
+    #[doc(alias = "gtk_graphics_offload_new")]
+    pub fn new(child: Option<&impl IsA<Widget>>) -> GraphicsOffload {
+        assert_initialized_main_thread!();
+        unsafe {
+            Widget::from_glib_none(ffi::gtk_graphics_offload_new(
+                child.map(|p| p.as_ref()).to_glib_none().0,
+            ))
+            .unsafe_cast()
+        }
+    }
+}
+
+#[cfg(feature = "v4_14")]
+#[cfg_attr(docsrs, doc(cfg(feature = "v4_14")))]
+impl Default for GraphicsOffload {
+    fn default() -> Self {
+        glib::object::Object::new::<Self>()
+    }
+}

--- a/gtk4/src/lib.rs
+++ b/gtk4/src/lib.rs
@@ -145,6 +145,9 @@ mod font_chooser;
 mod font_dialog;
 mod functions;
 mod gesture_stylus;
+#[cfg(feature = "v4_14")]
+#[cfg_attr(docsrs, doc(cfg(feature = "v4_14")))]
+mod graphics_offload;
 mod icon_theme;
 mod im_context_simple;
 mod info_bar;


### PR DESCRIPTION
Needs to be transfer-none instead of transfer-full