### PR TITLE
macros: Drop anyhow dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,12 +33,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
-
-[[package]]
 name = "async-channel"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,7 +801,6 @@ dependencies = [
 name = "gtk4-macros"
 version = "0.9.0"
 dependencies = [
- "anyhow",
  "futures-channel",
  "futures-util",
  "gtk4",

--- a/gtk4-macros/Cargo.toml
+++ b/gtk4-macros/Cargo.toml
@@ -21,7 +21,6 @@ xml_validation = ["quick-xml"]
 blueprint = []
 
 [dependencies]
-anyhow = "1.0"
 quick-xml = {version = "0.31", optional = true}
 proc-macro-crate = "3.0"
 proc-macro2 = "1.0"

--- a/gtk4-macros/src/blueprint.rs
+++ b/gtk4-macros/src/blueprint.rs
@@ -1,11 +1,9 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use std::{
-    io::{Read, Write},
+    io::{Error, ErrorKind, Read, Result, Write},
     process::{Command, Stdio},
 };
-
-use anyhow::{bail, Result};
 
 pub(crate) fn compile_blueprint(blueprint: &[u8]) -> Result<String> {
     let mut compiler = Command::new("blueprint-compiler")
@@ -24,7 +22,7 @@ pub(crate) fn compile_blueprint(blueprint: &[u8]) -> Result<String> {
     compiler.stdout.unwrap().read_to_string(&mut buf)?;
 
     if !buf.starts_with('<') {
-        bail!(buf);
+        return Err(Error::new(ErrorKind::Other, buf));
     }
 
     Ok(buf)


### PR DESCRIPTION
Since #1688 was merged, it is used in a single place and it is easy to remove, so it doesn't seem worth it to keep depending on it.