### PR TITLE
Update link for Cogitri/Health to World/Health

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ A small list of applications built with gtk4-rs:
 - [Solanum](https://gitlab.gnome.org/World/Solanum): A pomodoro timer
 - [Shortwave](https://gitlab.gnome.org/World/Shortwave): An internet radio player
 - [Authenticator](https://gitlab.gnome.org/World/Authenticator): A two-factor code generator
-- [Health](https://gitlab.gnome.org/Cogitri/Health): A health tracking app
+- [Health](https://gitlab.gnome.org/World/Health): A health tracking app
 - [Video Trimmer](https://gitlab.gnome.org/YaLTeR/video-trimmer): A fast video trimmer
 
 Libraries built with gtk4-rs:


### PR DESCRIPTION
Noticed that this repository had been moved when looking at the examples in the README.