### PR TITLE
Fix `SqueezerBin::size_allocate()` in example

### DIFF
--- a/examples/squeezer_bin/squeezer_bin/imp.rs
+++ b/examples/squeezer_bin/squeezer_bin/imp.rs
@@ -52,7 +52,7 @@ impl WidgetImpl for SqueezerBin {
     fn size_allocate(&self, width: i32, height: i32, baseline: i32) {
         let widget = self.obj();
         if let Some(child) = widget.child() {
-            let ((_, horizontal_size), (_, vertical_size)) = child_size(&*widget);
+            let ((_, horizontal_size), (_, vertical_size)) = child_size(&child);
 
             let (mut horizontal_zoom, mut vertical_zoom) = (
                 width as f32 / horizontal_size as f32,


### PR DESCRIPTION
The example `squeezer_bin` is not working on my machine, as described in #1757.

While investigating that bug, I noticed a mistake in `SqueezerBin::size_allocate()`. I noticed the function `child_size()` is returning all zeros, because it is being passed the wrong argument. This PR fixes that mistake.

There is still a bug in the code that causes this example to panic. To avoid panic and to test this change, comment out these lines:

https://github.com/gtk-rs/gtk4-rs/blob/3826b9acf320beedc3a1b0a326501e8ebadc05e6/examples/squeezer_bin/main.rs#L22-L24

`cd` into the directory `examples` and run `cargo run --bin squeezer_bin`.

After this change, the text "Hello World!" should be visible in the window.