### PR TITLE
Remove unnecessary upcast from examples/squeezer_bin/main.rs

### DIFF
--- a/examples/squeezer_bin/main.rs
+++ b/examples/squeezer_bin/main.rs
@@ -14,9 +14,7 @@ fn main() -> glib::ExitCode {
         let mode_switch = gtk::Switch::new();
         let switch_label = gtk::Label::new(Some("keep aspect ratio"));
         let squeezer = SqueezerBin::default();
-        squeezer.set_child(Some(
-            gtk::Label::new(Some("Hello World!")).upcast::<gtk::Widget>(),
-        ));
+        squeezer.set_child(Some(gtk::Label::new(Some("Hello World!"))));
 
         headerbar.pack_start(&mode_switch);
         headerbar.pack_start(&switch_label);


### PR DESCRIPTION
I noticed this example runs as expected even without `.upcast::<gtk::Widget>()`

I have a limited understanding of the language and libraries. I welcome pedantic feedback.

What I understand is that

* `SqueezerBin.set_child()` expects an argument of type `Option<&gtk::Widget>`
   https://github.com/gtk-rs/gtk4-rs/blob/53407150ab1f46494c767614783b06958a418613/examples/squeezer_bin/squeezer_bin/imp.rs#L26
* `gtk::Label` extends `gtk::Widget`, so I believe the type constraint is already satisfied
    https://github.com/gtk-rs/gtk4-rs/blob/53407150ab1f46494c767614783b06958a418613/gtk4/src/auto/label.rs#L36

**Try it yourself**

1. Clone this repository
2. `cd` in the `examples` directory
3. Run the command `cargo run --bin squeezer_bin`
