### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# gtk4-rs ![CI](https://github.com/gtk-rs/gtk4-rs/workflows/CI/badge.svg)
+# gtk4-rs
+
+![CI](https://github.com/gtk-rs/gtk4-rs/workflows/CI/badge.svg)
 
 A group of crates that aims to provide complete [GTK](https://gtk.org/) 4 bindings. This repository contains all the "core" crates of GTK 4.
 


### PR DESCRIPTION
This places the `CI`-badge below the `gtk4-rs` title. Reason for this is that it's usually placed there, like in most other repositories.

_This change is absolutely necessary._