### PR TITLE
Fix segfault in FileChooserExtManual::add_choice()

### DIFF
--- a/gtk4/src/file_chooser.rs
+++ b/gtk4/src/file_chooser.rs
@@ -16,40 +16,45 @@ mod sealed {
 pub trait FileChooserExtManual: sealed::Sealed + IsA<FileChooser> + 'static {
     #[doc(alias = "gtk_file_chooser_add_choice")]
     fn add_choice(&self, id: impl IntoGStr, label: impl IntoGStr, options: &[(&str, &str)]) {
-        unsafe {
-            let (options_ids, options_labels) = if options.is_empty() {
-                (std::ptr::null(), std::ptr::null())
-            } else {
-                let stashes_ids = options
-                    .iter()
-                    .map(|o| o.0.to_glib_none())
-                    .collect::<Vec<_>>();
-                let stashes_labels = options
-                    .iter()
-                    .map(|o| o.1.to_glib_none())
-                    .collect::<Vec<_>>();
-                (
-                    stashes_ids
-                        .iter()
-                        .map(|o| o.0)
-                        .collect::<Vec<*const libc::c_char>>()
-                        .as_ptr(),
-                    stashes_labels
-                        .iter()
-                        .map(|o| o.0)
-                        .collect::<Vec<*const libc::c_char>>()
-                        .as_ptr(),
-                )
-            };
-
+        if options.is_empty() {
             id.run_with_gstr(|id| {
-                label.run_with_gstr(|label| {
+                label.run_with_gstr(|label| unsafe {
                     ffi::gtk_file_chooser_add_choice(
                         self.as_ref().to_glib_none().0,
                         id.as_ptr(),
                         label.as_ptr(),
-                        mut_override(options_ids),
-                        mut_override(options_labels),
+                        mut_override(std::ptr::null()),
+                        mut_override(std::ptr::null()),
+                    );
+                });
+            });
+        } else {
+            let stashes_ids = options
+                .iter()
+                .map(|o| o.0.to_glib_none())
+                .collect::<Vec<_>>();
+            let stashes_labels = options
+                .iter()
+                .map(|o| o.1.to_glib_none())
+                .collect::<Vec<_>>();
+            let options_ids = stashes_ids
+                .iter()
+                .map(|o| o.0)
+                .chain(std::iter::once(std::ptr::null()))
+                .collect::<Vec<*const libc::c_char>>();
+            let options_labels = stashes_labels
+                .iter()
+                .map(|o| o.0)
+                .chain(std::iter::once(std::ptr::null()))
+                .collect::<Vec<*const libc::c_char>>();
+            id.run_with_gstr(|id| {
+                label.run_with_gstr(|label| unsafe {
+                    ffi::gtk_file_chooser_add_choice(
+                        self.as_ref().to_glib_none().0,
+                        id.as_ptr(),
+                        label.as_ptr(),
+                        mut_override(options_ids.as_ptr()),
+                        mut_override(options_labels.as_ptr()),
                     );
                 });
             });


### PR DESCRIPTION
### Bug

The [`FileChooserExtManual::add_choice`](https://gtk-rs.org/gtk4-rs/stable/latest/docs/gtk4/prelude/trait.FileChooserExtManual.html#method.add_choice) method includes some custom code, which is used to convert from
```rust
options: &[(&str, &str)]
```
to the final two arguments of [`gtk_file_chooser_add_choice`](https://docs.gtk.org/gtk4/method.FileChooser.add_choice.html):
```c
const char **options, const char **option_labels
```
This conversion is broken, and will segfault when passed anything other than an empty slice. See [this repository](https://github.com/martinling/file-chooser-testcase) for a minimal test program implemented in both C and Rust. The C version runs correctly, showing a dialog with both a boolean choice and a multiple value choice:

![image](https://github.com/user-attachments/assets/bff9bede-6291-4092-a648-323bb19281d6)

The Rust version segfaults in the `add_choice` call when trying to add the multiple value choice. Tested on Debian x86_64 with `libgtk-4-1` version `4.14.4+ds-8` and Rust 1.80.

### History

This method was first implemented in PR #612, but that version had three bugs that I can see:
1. It did not handle the empty slice case (which must be passed as `NULL, NULL` to get a boolean option).
2. It was missing the required null terminations for each array in the non-empty slice case.
3. It allowed its final pair of `Vec` temporaries to be dropped, since only the return values of `Vec::as_ptr` were kept in scope.

Later, PR #1234 noted that this method was segfaulting, and fixed bug 1, the empty input case. It did not address the other two bugs. It also caused more of the required temporaries to be dropped, by placing them in an `else` block that ends before the C call.

### Fix

This PR fixes the method to work correctly for all cases, handling the empty and non-empty cases separately, keeping all required temporaries in scope for the non-empty case, and adding the necessary null terminations to the generated string arrays. Additionally, since everything except calling the C function is actually safe Rust, I have reduced the use of `unsafe` to the call sites only.

The fix can be tested using the test case repository linked above.