### PR TITLE
misc: Add IntelliJ dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ book/book
 *.log
 **/**/docs.md
 **~
+.idea


### PR DESCRIPTION
The VS code directory is already in .gitignore. This would help the IntelliJ/RustRover devs to keep their commits clean.