### PR TITLE
Add additional type bounds to Impl traits

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - "1.70"
+          - "1.80"
         conf:
           - {
               name: "gtk4",
@@ -118,8 +118,8 @@ jobs:
   cargo-deny:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
 
   regen_check:
     name: regen checker

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 [[package]]
 name = "cairo-rs"
 version = "0.21.0"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=master#a1a0fdc1e02409a40fe706e18fea19abad6320fa"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=master#f69594c2f59643d60d1cf82081804b2a536f9f31"
 dependencies = [
  "bitflags 2.6.0",
  "cairo-sys-rs",
@@ -139,7 +139,7 @@ dependencies = [
 [[package]]
 name = "cairo-sys-rs"
 version = "0.21.0"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=master#a1a0fdc1e02409a40fe706e18fea19abad6320fa"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=master#f69594c2f59643d60d1cf82081804b2a536f9f31"
 dependencies = [
  "glib-sys",
  "libc",
@@ -391,7 +391,7 @@ dependencies = [
 [[package]]
 name = "gdk-pixbuf"
 version = "0.21.0"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=master#a1a0fdc1e02409a40fe706e18fea19abad6320fa"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=master#f69594c2f59643d60d1cf82081804b2a536f9f31"
 dependencies = [
  "gdk-pixbuf-sys",
  "gio",
@@ -402,7 +402,7 @@ dependencies = [
 [[package]]
 name = "gdk-pixbuf-sys"
 version = "0.21.0"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=master#a1a0fdc1e02409a40fe706e18fea19abad6320fa"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=master#f69594c2f59643d60d1cf82081804b2a536f9f31"
 dependencies = [
  "gio-sys",
  "glib-sys",
@@ -551,7 +551,7 @@ checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 [[package]]
 name = "gio"
 version = "0.21.0"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=master#a1a0fdc1e02409a40fe706e18fea19abad6320fa"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=master#f69594c2f59643d60d1cf82081804b2a536f9f31"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -567,7 +567,7 @@ dependencies = [
 [[package]]
 name = "gio-sys"
 version = "0.21.0"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=master#a1a0fdc1e02409a40fe706e18fea19abad6320fa"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=master#f69594c2f59643d60d1cf82081804b2a536f9f31"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -616,7 +616,7 @@ dependencies = [
 [[package]]
 name = "glib"
 version = "0.21.0"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=master#a1a0fdc1e02409a40fe706e18fea19abad6320fa"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=master#f69594c2f59643d60d1cf82081804b2a536f9f31"
 dependencies = [
  "bitflags 2.6.0",
  "futures-channel",
@@ -636,7 +636,7 @@ dependencies = [
 [[package]]
 name = "glib-macros"
 version = "0.21.0"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=master#a1a0fdc1e02409a40fe706e18fea19abad6320fa"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=master#f69594c2f59643d60d1cf82081804b2a536f9f31"
 dependencies = [
  "heck",
  "proc-macro-crate",
@@ -648,7 +648,7 @@ dependencies = [
 [[package]]
 name = "glib-sys"
 version = "0.21.0"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=master#a1a0fdc1e02409a40fe706e18fea19abad6320fa"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=master#f69594c2f59643d60d1cf82081804b2a536f9f31"
 dependencies = [
  "libc",
  "system-deps",
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "gobject-sys"
 version = "0.21.0"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=master#a1a0fdc1e02409a40fe706e18fea19abad6320fa"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=master#f69594c2f59643d60d1cf82081804b2a536f9f31"
 dependencies = [
  "glib-sys",
  "libc",
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "graphene-rs"
 version = "0.21.0"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=master#a1a0fdc1e02409a40fe706e18fea19abad6320fa"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=master#f69594c2f59643d60d1cf82081804b2a536f9f31"
 dependencies = [
  "glib",
  "graphene-sys",
@@ -708,7 +708,7 @@ dependencies = [
 [[package]]
 name = "graphene-sys"
 version = "0.21.0"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=master#a1a0fdc1e02409a40fe706e18fea19abad6320fa"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=master#f69594c2f59643d60d1cf82081804b2a536f9f31"
 dependencies = [
  "glib-sys",
  "libc",
@@ -1171,7 +1171,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 [[package]]
 name = "pango"
 version = "0.21.0"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=master#a1a0fdc1e02409a40fe706e18fea19abad6320fa"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=master#f69594c2f59643d60d1cf82081804b2a536f9f31"
 dependencies = [
  "gio",
  "glib",
@@ -1182,7 +1182,7 @@ dependencies = [
 [[package]]
 name = "pango-sys"
 version = "0.21.0"
-source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=master#a1a0fdc1e02409a40fe706e18fea19abad6320fa"
+source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=master#f69594c2f59643d60d1cf82081804b2a536f9f31"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -1716,9 +1716,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ edition = "2021"
 homepage = "https://gtk-rs.org/gtk4-rs"
 license = "MIT"
 repository = "https://github.com/gtk-rs/gtk4-rs"
-rust-version = "1.70"
+rust-version = "1.80"
 version = "0.10.0"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For more information about each crate, please refer to their `README.md` file in
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.70`.
+Currently, the minimum supported Rust version is `1.80`.
 
 ## Documentation
 

--- a/examples/virtual_methods/base_button/mod.rs
+++ b/examples/virtual_methods/base_button/mod.rs
@@ -60,7 +60,7 @@ impl<O: IsA<BaseButton>> BaseButtonExt for O {}
 /// implement.
 ///
 /// See `derived_button/imp.rs` for how to override virtual methods.
-pub trait BaseButtonImpl: ButtonImpl {
+pub trait BaseButtonImpl: ButtonImpl + ObjectSubclass<Type: IsA<BaseButton>> {
     /// Default implementation of a virtual method.
     ///
     /// This always calls into the implementation of the parent class so that if

--- a/gdk4-wayland/README.md
+++ b/gdk4-wayland/README.md
@@ -10,7 +10,7 @@ GDK Wayland contains functions specific to the Wayland backend.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.70`.
+Currently, the minimum supported Rust version is `1.80`.
 
 ## Documentation
 

--- a/gdk4-win32/README.md
+++ b/gdk4-win32/README.md
@@ -10,7 +10,7 @@ GDK Win32 contains functions specific to the Win32 backend.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.70`.
+Currently, the minimum supported Rust version is `1.80`.
 
 ## Documentation
 

--- a/gdk4-x11/README.md
+++ b/gdk4-x11/README.md
@@ -10,7 +10,7 @@ GDK X11 contains functions specific to the X11 backend.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.70`.
+Currently, the minimum supported Rust version is `1.80`.
 
 ## Documentation
 

--- a/gdk4/README.md
+++ b/gdk4/README.md
@@ -7,7 +7,7 @@ of [gtk4-rs](https://github.com/gtk-rs/gtk4-rs/).
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.70`.
+Currently, the minimum supported Rust version is `1.80`.
 
 ## Documentation
 

--- a/gdk4/src/subclass/content_provider.rs
+++ b/gdk4/src/subclass/content_provider.rs
@@ -9,7 +9,7 @@ use glib::{translate::*, Value};
 
 use crate::{ffi, prelude::*, subclass::prelude::*, Clipboard, ContentFormats, ContentProvider};
 
-pub trait ContentProviderImpl: ContentProviderImplExt + ObjectImpl {
+pub trait ContentProviderImpl: ObjectImpl + ObjectSubclass<Type: IsA<ContentProvider>> {
     fn content_changed(&self) {
         self.parent_content_changed()
     }
@@ -44,12 +44,7 @@ pub trait ContentProviderImpl: ContentProviderImplExt + ObjectImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::ContentProviderImplExt> Sealed for T {}
-}
-
-pub trait ContentProviderImplExt: sealed::Sealed + ObjectSubclass {
+pub trait ContentProviderImplExt: ContentProviderImpl {
     fn parent_content_changed(&self) {
         unsafe {
             let data = Self::type_data();

--- a/gdk4/src/subclass/paintable.rs
+++ b/gdk4/src/subclass/paintable.rs
@@ -8,7 +8,7 @@ use glib::translate::*;
 
 use crate::{ffi, prelude::*, subclass::prelude::*, Paintable, PaintableFlags, Snapshot};
 
-pub trait PaintableImpl: PaintableImplExt + ObjectImpl {
+pub trait PaintableImpl: ObjectImpl + ObjectSubclass<Type: IsA<Paintable>> {
     #[doc(alias = "get_current_image")]
     fn current_image(&self) -> Paintable {
         self.parent_current_image()
@@ -37,12 +37,7 @@ pub trait PaintableImpl: PaintableImplExt + ObjectImpl {
     fn snapshot(&self, snapshot: &Snapshot, width: f64, height: f64);
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::PaintableImplExt> Sealed for T {}
-}
-
-pub trait PaintableImplExt: sealed::Sealed + ObjectSubclass {
+pub trait PaintableImplExt: PaintableImpl {
     fn parent_current_image(&self) -> Paintable {
         unsafe {
             let type_data = Self::type_data();

--- a/gsk4/README.md
+++ b/gsk4/README.md
@@ -10,7 +10,7 @@ Vulkan implementation.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.70`.
+Currently, the minimum supported Rust version is `1.80`.
 
 ## Documentation
 

--- a/gtk4-macros/README.md
+++ b/gtk4-macros/README.md
@@ -6,7 +6,7 @@ Macro helpers for GTK 4 bindings, part of [gtk4-rs](https://github.com/gtk-rs/gt
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.70`.
+Currently, the minimum supported Rust version is `1.80`.
 
 ## Documentation
 

--- a/gtk4/README.md
+++ b/gtk4/README.md
@@ -23,7 +23,7 @@ See also:
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.70`.
+Currently, the minimum supported Rust version is `1.80`.
 
 ## "Hello, World!" example program
 

--- a/gtk4/src/subclass/accessible.rs
+++ b/gtk4/src/subclass/accessible.rs
@@ -12,7 +12,7 @@ use crate::{
     ffi, prelude::*, subclass::prelude::*, ATContext, Accessible, AccessiblePlatformState,
 };
 
-pub trait AccessibleImpl: ObjectImpl {
+pub trait AccessibleImpl: ObjectImpl + ObjectSubclass<Type: IsA<Accessible>> {
     #[doc(alias = "get_platform_state")]
     fn platform_state(&self, state: AccessiblePlatformState) -> bool {
         self.parent_platform_state(state)
@@ -44,12 +44,7 @@ pub trait AccessibleImpl: ObjectImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::AccessibleImplExt> Sealed for T {}
-}
-
-pub trait AccessibleImplExt: sealed::Sealed + ObjectSubclass {
+pub trait AccessibleImplExt: AccessibleImpl {
     fn parent_platform_state(&self, state: AccessiblePlatformState) -> bool {
         unsafe {
             let type_data = Self::type_data();

--- a/gtk4/src/subclass/accessible_range.rs
+++ b/gtk4/src/subclass/accessible_range.rs
@@ -8,18 +8,13 @@ use glib::translate::*;
 
 use crate::{ffi, prelude::*, subclass::prelude::*, AccessibleRange};
 
-pub trait AccessibleRangeImpl: WidgetImpl {
+pub trait AccessibleRangeImpl: AccessibleImpl + ObjectSubclass<Type: IsA<AccessibleRange>> {
     fn set_current_value(&self, value: f64) -> bool {
         self.parent_set_current_value(value)
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::AccessibleRangeImplExt> Sealed for T {}
-}
-
-pub trait AccessibleRangeImplExt: sealed::Sealed + ObjectSubclass {
+pub trait AccessibleRangeImplExt: AccessibleRangeImpl {
     // Returns true if the operation was performed, false otherwise
     fn parent_set_current_value(&self, value: f64) -> bool {
         unsafe {

--- a/gtk4/src/subclass/actionable.rs
+++ b/gtk4/src/subclass/actionable.rs
@@ -8,7 +8,7 @@ use glib::{translate::*, GString, Variant};
 
 use crate::{ffi, prelude::*, subclass::prelude::*, Actionable};
 
-pub trait ActionableImpl: WidgetImpl {
+pub trait ActionableImpl: WidgetImpl + ObjectSubclass<Type: IsA<Actionable>> {
     #[doc(alias = "get_action_name")]
     fn action_name(&self) -> Option<GString>;
     #[doc(alias = "get_action_target_value")]
@@ -17,12 +17,7 @@ pub trait ActionableImpl: WidgetImpl {
     fn set_action_target_value(&self, value: Option<&Variant>);
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::ActionableImplExt> Sealed for T {}
-}
-
-pub trait ActionableImplExt: sealed::Sealed + ObjectSubclass {
+pub trait ActionableImplExt: ActionableImpl {
     fn parent_action_name(&self) -> Option<GString> {
         unsafe {
             let type_data = Self::type_data();

--- a/gtk4/src/subclass/adjustment.rs
+++ b/gtk4/src/subclass/adjustment.rs
@@ -7,7 +7,7 @@ use glib::translate::*;
 
 use crate::{ffi, prelude::*, subclass::prelude::*, Adjustment};
 
-pub trait AdjustmentImpl: AdjustmentImplExt + ObjectImpl {
+pub trait AdjustmentImpl: ObjectImpl + ObjectSubclass<Type: IsA<Adjustment>> {
     fn changed(&self) {
         self.parent_changed()
     }
@@ -17,12 +17,7 @@ pub trait AdjustmentImpl: AdjustmentImplExt + ObjectImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::AdjustmentImplExt> Sealed for T {}
-}
-
-pub trait AdjustmentImplExt: sealed::Sealed + ObjectSubclass {
+pub trait AdjustmentImplExt: AdjustmentImpl {
     fn parent_changed(&self) {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/application.rs
+++ b/gtk4/src/subclass/application.rs
@@ -7,7 +7,7 @@ use glib::translate::*;
 
 use crate::{ffi, prelude::*, subclass::prelude::*, Application, Window};
 
-pub trait GtkApplicationImpl: GtkApplicationImplExt + ApplicationImpl {
+pub trait GtkApplicationImpl: ApplicationImpl + ObjectSubclass<Type: IsA<Application>> {
     fn window_added(&self, window: &Window) {
         self.parent_window_added(window)
     }
@@ -17,12 +17,7 @@ pub trait GtkApplicationImpl: GtkApplicationImplExt + ApplicationImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::GtkApplicationImplExt> Sealed for T {}
-}
-
-pub trait GtkApplicationImplExt: sealed::Sealed + ObjectSubclass {
+pub trait GtkApplicationImplExt: GtkApplicationImpl {
     fn parent_window_added(&self, window: &Window) {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/application_window.rs
+++ b/gtk4/src/subclass/application_window.rs
@@ -4,8 +4,11 @@
 //! Traits intended for subclassing
 //! [`ApplicationWindow`](crate::ApplicationWindow).
 
-use crate::{subclass::prelude::*, ApplicationWindow};
+use crate::{prelude::*, subclass::prelude::*, ApplicationWindow};
 
-pub trait ApplicationWindowImpl: WindowImpl + 'static {}
+pub trait ApplicationWindowImpl:
+    WindowImpl + ObjectSubclass<Type: IsA<ApplicationWindow>> + 'static
+{
+}
 
 unsafe impl<T: ApplicationWindowImpl> IsSubclassable<T> for ApplicationWindow {}

--- a/gtk4/src/subclass/box_.rs
+++ b/gtk4/src/subclass/box_.rs
@@ -3,8 +3,8 @@
 // rustdoc-stripper-ignore-next
 //! Traits intended for subclassing [`Box`](crate::Box).
 
-use crate::{subclass::prelude::*, Box};
+use crate::{prelude::*, subclass::prelude::*, Box};
 
-pub trait BoxImpl: WidgetImpl {}
+pub trait BoxImpl: WidgetImpl + ObjectSubclass<Type: IsA<Box>> {}
 
 unsafe impl<T: BoxImpl> IsSubclassable<T> for Box {}

--- a/gtk4/src/subclass/buildable.rs
+++ b/gtk4/src/subclass/buildable.rs
@@ -10,7 +10,7 @@ use glib::{translate::*, GString, Object, Quark, Value};
 use super::PtrHolder;
 use crate::{ffi, prelude::*, subclass::prelude::*, Buildable, Builder};
 
-pub trait BuildableImpl: ObjectImpl {
+pub trait BuildableImpl: ObjectImpl + ObjectSubclass<Type: IsA<Buildable>> {
     fn set_id(&self, id: &str) {
         self.parent_set_id(id)
     }
@@ -59,12 +59,7 @@ pub trait BuildableImpl: ObjectImpl {
     // );
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::BuildableImplExt> Sealed for T {}
-}
-
-pub trait BuildableImplExt: sealed::Sealed + ObjectSubclass {
+pub trait BuildableImplExt: BuildableImpl {
     fn parent_set_id(&self, id: &str) {
         unsafe {
             let type_data = Self::type_data();

--- a/gtk4/src/subclass/builder_scope.rs
+++ b/gtk4/src/subclass/builder_scope.rs
@@ -11,11 +11,11 @@ use crate::{
     BuilderScope,
 };
 
-pub trait BuilderCScopeImpl: BuilderScopeImpl {}
+pub trait BuilderCScopeImpl: BuilderScopeImpl + ObjectSubclass<Type: IsA<BuilderCScope>> {}
 
 unsafe impl<T: BuilderCScopeImpl> IsSubclassable<T> for BuilderCScope {}
 
-pub trait BuilderScopeImpl: ObjectImpl {
+pub trait BuilderScopeImpl: ObjectImpl + ObjectSubclass<Type: IsA<BuilderScope>> {
     #[doc(alias = "get_type_from_name")]
     fn type_from_name(&self, builder: &Builder, type_name: &str) -> glib::Type {
         self.parent_type_from_name(builder, type_name)
@@ -35,12 +35,7 @@ pub trait BuilderScopeImpl: ObjectImpl {
     ) -> Result<glib::Closure, glib::Error>;
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::BuilderScopeImplExt> Sealed for T {}
-}
-
-pub trait BuilderScopeImplExt: sealed::Sealed + ObjectSubclass {
+pub trait BuilderScopeImplExt: BuilderScopeImpl {
     fn parent_type_from_name(&self, builder: &Builder, type_name: &str) -> glib::Type {
         unsafe {
             let type_data = Self::type_data();

--- a/gtk4/src/subclass/button.rs
+++ b/gtk4/src/subclass/button.rs
@@ -7,7 +7,7 @@ use glib::translate::*;
 
 use crate::{ffi, prelude::*, subclass::prelude::*, Button};
 
-pub trait ButtonImpl: ButtonImplExt + WidgetImpl {
+pub trait ButtonImpl: WidgetImpl + ObjectSubclass<Type: IsA<Button>> {
     fn activate(&self) {
         self.parent_activate()
     }
@@ -17,12 +17,7 @@ pub trait ButtonImpl: ButtonImplExt + WidgetImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::ButtonImplExt> Sealed for T {}
-}
-
-pub trait ButtonImplExt: sealed::Sealed + ObjectSubclass {
+pub trait ButtonImplExt: ButtonImpl {
     fn parent_activate(&self) {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/cell_area.rs
+++ b/gtk4/src/subclass/cell_area.rs
@@ -63,7 +63,7 @@ impl CellCallbackAllocate {
 
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait CellAreaImpl: CellAreaImplExt + ObjectImpl {
+pub trait CellAreaImpl: ObjectImpl + ObjectSubclass<Type: IsA<CellArea>> {
     fn cell_properties() -> &'static [ParamSpec] {
         &[]
     }
@@ -219,14 +219,9 @@ pub trait CellAreaImpl: CellAreaImplExt + ObjectImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::CellAreaImplExt> Sealed for T {}
-}
-
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait CellAreaImplExt: sealed::Sealed + ObjectSubclass {
+pub trait CellAreaImplExt: CellAreaImpl {
     // Returns true if the area was successfully activated
     fn parent_activate<P: IsA<CellAreaContext>, W: IsA<Widget>>(
         &self,
@@ -956,4 +951,4 @@ pub unsafe trait CellAreaClassExt: ClassStruct {
     }
 }
 
-unsafe impl<T: ClassStruct> CellAreaClassExt for T where T::Type: CellAreaImpl {}
+unsafe impl<T: ClassStruct> CellAreaClassExt for T {}

--- a/gtk4/src/subclass/cell_area_context.rs
+++ b/gtk4/src/subclass/cell_area_context.rs
@@ -11,7 +11,7 @@ use crate::{ffi, prelude::*, subclass::prelude::*, CellAreaContext};
 
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait CellAreaContextImpl: CellAreaContextImplExt + ObjectImpl {
+pub trait CellAreaContextImpl: ObjectImpl + ObjectSubclass<Type: IsA<CellAreaContext>> {
     fn reset(&self) {
         self.parent_reset()
     }
@@ -29,14 +29,9 @@ pub trait CellAreaContextImpl: CellAreaContextImplExt + ObjectImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::CellAreaContextImplExt> Sealed for T {}
-}
-
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait CellAreaContextImplExt: sealed::Sealed + ObjectSubclass {
+pub trait CellAreaContextImplExt: CellAreaContextImpl {
     fn parent_reset(&self) {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/cell_editable.rs
+++ b/gtk4/src/subclass/cell_editable.rs
@@ -10,7 +10,7 @@ use crate::{ffi, prelude::*, subclass::prelude::*, CellEditable};
 
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait CellEditableImpl: ObjectImpl {
+pub trait CellEditableImpl: ObjectImpl + ObjectSubclass<Type: IsA<CellEditable>> {
     fn editing_done(&self) {
         self.parent_editing_done()
     }
@@ -24,14 +24,9 @@ pub trait CellEditableImpl: ObjectImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::CellEditableImplExt> Sealed for T {}
-}
-
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait CellEditableImplExt: sealed::Sealed + ObjectSubclass {
+pub trait CellEditableImplExt: CellEditableImpl {
     fn parent_editing_done(&self) {
         unsafe {
             let type_data = Self::type_data();

--- a/gtk4/src/subclass/cell_layout.rs
+++ b/gtk4/src/subclass/cell_layout.rs
@@ -53,7 +53,7 @@ impl Drop for CellLayoutDataCallback {
 
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait CellLayoutImpl: ObjectImpl {
+pub trait CellLayoutImpl: ObjectImpl + ObjectSubclass<Type: IsA<CellLayout>> {
     fn add_attribute<R: IsA<CellRenderer>>(&self, cell: &R, attribute: &str, column: i32) {
         self.parent_add_attribute(cell, attribute, column)
     }
@@ -96,14 +96,9 @@ pub trait CellLayoutImpl: ObjectImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::CellLayoutImplExt> Sealed for T {}
-}
-
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait CellLayoutImplExt: sealed::Sealed + ObjectSubclass {
+pub trait CellLayoutImplExt: CellLayoutImpl {
     fn parent_add_attribute<R: IsA<CellRenderer>>(&self, cell: &R, attribute: &str, column: i32) {
         unsafe {
             let type_data = Self::type_data();

--- a/gtk4/src/subclass/cell_renderer.rs
+++ b/gtk4/src/subclass/cell_renderer.rs
@@ -15,7 +15,7 @@ use crate::{
 
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait CellRendererImpl: CellRendererImplExt + ObjectImpl {
+pub trait CellRendererImpl: ObjectImpl + ObjectSubclass<Type: IsA<CellRenderer>> {
     fn activate<P: IsA<Widget>>(
         &self,
         event: Option<&gdk::Event>,
@@ -95,14 +95,9 @@ pub trait CellRendererImpl: CellRendererImplExt + ObjectImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::CellRendererImplExt> Sealed for T {}
-}
-
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait CellRendererImplExt: sealed::Sealed + ObjectSubclass {
+pub trait CellRendererImplExt: CellRendererImpl {
     fn parent_request_mode(&self) -> SizeRequestMode {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/cell_renderer_text.rs
+++ b/gtk4/src/subclass/cell_renderer_text.rs
@@ -10,20 +10,17 @@ use crate::{ffi, prelude::*, subclass::prelude::*, CellRendererText};
 
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait CellRendererTextImpl: CellRendererTextImplExt + CellRendererImpl {
+pub trait CellRendererTextImpl:
+    CellRendererImpl + ObjectSubclass<Type: IsA<CellRendererText>>
+{
     fn edited(&self, path: &str, new_text: &str) {
         self.parent_edited(path, new_text);
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::CellRendererTextImplExt> Sealed for T {}
-}
-
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait CellRendererTextImplExt: sealed::Sealed + ObjectSubclass {
+pub trait CellRendererTextImplExt: CellRendererTextImpl {
     fn parent_edited(&self, path: &str, new_text: &str) {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/check_button.rs
+++ b/gtk4/src/subclass/check_button.rs
@@ -7,7 +7,7 @@ use glib::translate::*;
 
 use crate::{ffi, prelude::*, subclass::prelude::*, CheckButton};
 
-pub trait CheckButtonImpl: CheckButtonImplExt + WidgetImpl {
+pub trait CheckButtonImpl: WidgetImpl + ObjectSubclass<Type: IsA<CheckButton>> {
     fn toggled(&self) {
         self.parent_toggled()
     }
@@ -19,12 +19,7 @@ pub trait CheckButtonImpl: CheckButtonImplExt + WidgetImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::CheckButtonImplExt> Sealed for T {}
-}
-
-pub trait CheckButtonImplExt: sealed::Sealed + ObjectSubclass {
+pub trait CheckButtonImplExt: CheckButtonImpl {
     fn parent_toggled(&self) {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/color_chooser.rs
+++ b/gtk4/src/subclass/color_chooser.rs
@@ -11,7 +11,7 @@ use crate::{ffi, prelude::*, subclass::prelude::*, ColorChooser, Orientation};
 
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait ColorChooserImpl: ObjectImpl {
+pub trait ColorChooserImpl: ObjectImpl + ObjectSubclass<Type: IsA<ColorChooser>> {
     fn add_palette(&self, orientation: Orientation, colors_per_line: i32, colors: &[RGBA]) {
         self.parent_add_palette(orientation, colors_per_line, colors);
     }
@@ -25,14 +25,9 @@ pub trait ColorChooserImpl: ObjectImpl {
     fn set_rgba(&self, rgba: RGBA);
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::ColorChooserImplExt> Sealed for T {}
-}
-
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait ColorChooserImplExt: sealed::Sealed + ObjectSubclass {
+pub trait ColorChooserImplExt: ColorChooserImpl {
     fn parent_add_palette(&self, orientation: Orientation, colors_per_line: i32, colors: &[RGBA]) {
         unsafe {
             let type_data = Self::type_data();

--- a/gtk4/src/subclass/combo_box.rs
+++ b/gtk4/src/subclass/combo_box.rs
@@ -9,7 +9,7 @@ use crate::{ffi, prelude::*, subclass::prelude::*, ComboBox};
 
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait ComboBoxImpl: ComboBoxImplExt + WidgetImpl {
+pub trait ComboBoxImpl: WidgetImpl + ObjectSubclass<Type: IsA<ComboBox>> {
     #[cfg(feature = "v4_6")]
     #[cfg_attr(docsrs, doc(cfg(feature = "v4_6")))]
     fn activate(&self) {
@@ -23,14 +23,9 @@ pub trait ComboBoxImpl: ComboBoxImplExt + WidgetImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::ComboBoxImplExt> Sealed for T {}
-}
-
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait ComboBoxImplExt: sealed::Sealed + ObjectSubclass {
+pub trait ComboBoxImplExt: ComboBoxImpl {
     #[cfg(feature = "v4_6")]
     #[cfg_attr(docsrs, doc(cfg(feature = "v4_6")))]
     fn parent_activate(&self) {

--- a/gtk4/src/subclass/dialog.rs
+++ b/gtk4/src/subclass/dialog.rs
@@ -7,7 +7,7 @@ use glib::translate::*;
 
 use crate::{ffi, prelude::*, subclass::prelude::*, Dialog, ResponseType};
 
-pub trait DialogImpl: DialogImplExt + WindowImpl {
+pub trait DialogImpl: WindowImpl + ObjectSubclass<Type: IsA<Dialog>> {
     fn response(&self, response: ResponseType) {
         self.parent_response(response)
     }
@@ -17,12 +17,7 @@ pub trait DialogImpl: DialogImplExt + WindowImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::DialogImplExt> Sealed for T {}
-}
-
-pub trait DialogImplExt: sealed::Sealed + ObjectSubclass {
+pub trait DialogImplExt: DialogImpl {
     fn parent_response(&self, response: ResponseType) {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/drawing_area.rs
+++ b/gtk4/src/subclass/drawing_area.rs
@@ -7,17 +7,13 @@ use glib::translate::*;
 
 use crate::{ffi, prelude::*, subclass::prelude::*, DrawingArea};
 
-pub trait DrawingAreaImpl: DrawingAreaImplExt + WidgetImpl {
+pub trait DrawingAreaImpl: WidgetImpl + ObjectSubclass<Type: IsA<DrawingArea>> {
     fn resize(&self, width: i32, height: i32) {
         self.parent_resize(width, height)
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::DrawingAreaImplExt> Sealed for T {}
-}
-pub trait DrawingAreaImplExt: sealed::Sealed + ObjectSubclass {
+pub trait DrawingAreaImplExt: DrawingAreaImpl {
     fn parent_resize(&self, width: i32, height: i32) {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/editable.rs
+++ b/gtk4/src/subclass/editable.rs
@@ -10,7 +10,7 @@ use libc::{c_char, c_int};
 
 use crate::{ffi, prelude::*, subclass::prelude::*, Editable};
 
-pub trait EditableImpl: WidgetImpl {
+pub trait EditableImpl: WidgetImpl + ObjectSubclass<Type: IsA<Editable>> {
     fn insert_text(&self, text: &str, length: i32, position: &mut i32) {
         self.parent_insert_text(text, length, position);
     }
@@ -51,12 +51,7 @@ pub trait EditableImpl: WidgetImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::EditableImplExt> Sealed for T {}
-}
-
-pub trait EditableImplExt: sealed::Sealed + ObjectSubclass {
+pub trait EditableImplExt: EditableImpl {
     #[doc(alias = "gtk_editable_delegate_get_property")]
     fn delegate_get_property(
         &self,

--- a/gtk4/src/subclass/entry.rs
+++ b/gtk4/src/subclass/entry.rs
@@ -7,18 +7,13 @@ use glib::translate::*;
 
 use crate::{ffi, prelude::*, subclass::prelude::*, Entry};
 
-pub trait EntryImpl: EntryImplExt + WidgetImpl {
+pub trait EntryImpl: WidgetImpl + ObjectSubclass<Type: IsA<Entry>> {
     fn activate(&self) {
         self.parent_activate()
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::EntryImplExt> Sealed for T {}
-}
-
-pub trait EntryImplExt: sealed::Sealed + ObjectSubclass {
+pub trait EntryImplExt: EntryImpl {
     fn parent_activate(&self) {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/entry_buffer.rs
+++ b/gtk4/src/subclass/entry_buffer.rs
@@ -9,7 +9,7 @@ use glib::{translate::*, GString};
 use super::PtrHolder;
 use crate::{ffi, prelude::*, subclass::prelude::*, EntryBuffer};
 
-pub trait EntryBufferImpl: EntryBufferImplExt + ObjectImpl {
+pub trait EntryBufferImpl: ObjectImpl + ObjectSubclass<Type: IsA<EntryBuffer>> {
     fn delete_text(&self, position: u32, n_chars: Option<u32>) -> u32 {
         self.parent_delete_text(position, n_chars)
     }
@@ -36,12 +36,7 @@ pub trait EntryBufferImpl: EntryBufferImplExt + ObjectImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::EntryBufferImplExt> Sealed for T {}
-}
-
-pub trait EntryBufferImplExt: sealed::Sealed + ObjectSubclass {
+pub trait EntryBufferImplExt: EntryBufferImpl {
     fn parent_delete_text(&self, position: u32, n_chars: Option<u32>) -> u32 {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/filter.rs
+++ b/gtk4/src/subclass/filter.rs
@@ -7,7 +7,7 @@ use glib::{translate::*, Object};
 
 use crate::{ffi, prelude::*, subclass::prelude::*, Filter, FilterMatch};
 
-pub trait FilterImpl: FilterImplExt + ObjectImpl {
+pub trait FilterImpl: ObjectImpl + ObjectSubclass<Type: IsA<Filter>> {
     #[doc(alias = "get_strictness")]
     fn strictness(&self) -> FilterMatch {
         self.parent_strictness()
@@ -17,12 +17,7 @@ pub trait FilterImpl: FilterImplExt + ObjectImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::FilterImplExt> Sealed for T {}
-}
-
-pub trait FilterImplExt: sealed::Sealed + ObjectSubclass {
+pub trait FilterImplExt: FilterImpl {
     fn parent_strictness(&self) -> FilterMatch {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/fixed.rs
+++ b/gtk4/src/subclass/fixed.rs
@@ -3,8 +3,8 @@
 // rustdoc-stripper-ignore-next
 //! Traits intended for subclassing [`Fixed`](crate::Fixed).
 
-use crate::{subclass::prelude::*, Fixed};
+use crate::{prelude::*, subclass::prelude::*, Fixed};
 
-pub trait FixedImpl: WidgetImpl {}
+pub trait FixedImpl: WidgetImpl + ObjectSubclass<Type: IsA<Fixed>> {}
 
 unsafe impl<T: FixedImpl> IsSubclassable<T> for Fixed {}

--- a/gtk4/src/subclass/flow_box_child.rs
+++ b/gtk4/src/subclass/flow_box_child.rs
@@ -7,18 +7,13 @@ use glib::translate::*;
 
 use crate::{ffi, prelude::*, subclass::prelude::*, FlowBoxChild};
 
-pub trait FlowBoxChildImpl: FlowBoxChildImplExt + WidgetImpl {
+pub trait FlowBoxChildImpl: WidgetImpl + ObjectSubclass<Type: IsA<FlowBoxChild>> {
     fn activate(&self) {
         self.parent_activate()
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::FlowBoxChildImplExt> Sealed for T {}
-}
-
-pub trait FlowBoxChildImplExt: sealed::Sealed + ObjectSubclass {
+pub trait FlowBoxChildImplExt: FlowBoxChildImpl {
     fn parent_activate(&self) {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/font_chooser.rs
+++ b/gtk4/src/subclass/font_chooser.rs
@@ -49,7 +49,7 @@ impl Drop for FilterCallback {
 
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait FontChooserImpl: ObjectImpl {
+pub trait FontChooserImpl: ObjectImpl + ObjectSubclass<Type: IsA<FontChooser>> {
     fn font_family(&self) -> Option<FontFamily> {
         self.parent_font_family()
     }
@@ -79,14 +79,9 @@ pub trait FontChooserImpl: ObjectImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::FontChooserImplExt> Sealed for T {}
-}
-
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait FontChooserImplExt: sealed::Sealed + ObjectSubclass {
+pub trait FontChooserImplExt: FontChooserImpl {
     fn parent_font_family(&self) -> Option<FontFamily> {
         unsafe {
             let type_data = Self::type_data();

--- a/gtk4/src/subclass/frame.rs
+++ b/gtk4/src/subclass/frame.rs
@@ -9,7 +9,7 @@ use crate::{ffi, prelude::*, subclass::prelude::*, Allocation, Frame};
 
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait FrameImpl: FrameImplExt + WidgetImpl {
+pub trait FrameImpl: WidgetImpl + ObjectSubclass<Type: IsA<Frame>> {
     fn compute_child_allocation(&self) -> Allocation {
         self.parent_compute_child_allocation()
     }
@@ -17,7 +17,7 @@ pub trait FrameImpl: FrameImplExt + WidgetImpl {
 
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait FrameImplExt: ObjectSubclass {
+pub trait FrameImplExt: FrameImpl {
     fn parent_compute_child_allocation(&self) -> Allocation {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/gl_area.rs
+++ b/gtk4/src/subclass/gl_area.rs
@@ -9,7 +9,7 @@ use glib::translate::*;
 use crate::{ffi, prelude::*, subclass::prelude::*, GLArea};
 
 #[allow(clippy::upper_case_acronyms)]
-pub trait GLAreaImpl: GLAreaImplExt + WidgetImpl {
+pub trait GLAreaImpl: WidgetImpl + ObjectSubclass<Type: IsA<GLArea>> {
     fn create_context(&self) -> Option<GLContext> {
         self.parent_create_context()
     }
@@ -23,13 +23,8 @@ pub trait GLAreaImpl: GLAreaImplExt + WidgetImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::GLAreaImplExt> Sealed for T {}
-}
-
 #[allow(clippy::upper_case_acronyms)]
-pub trait GLAreaImplExt: sealed::Sealed + ObjectSubclass {
+pub trait GLAreaImplExt: GLAreaImpl {
     fn parent_create_context(&self) -> Option<GLContext> {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/grid.rs
+++ b/gtk4/src/subclass/grid.rs
@@ -3,8 +3,8 @@
 // rustdoc-stripper-ignore-next
 //! Traits intended for subclassing [`Grid`](crate::Grid).
 
-use crate::{subclass::prelude::*, Grid};
+use crate::{prelude::*, subclass::prelude::*, Grid};
 
-pub trait GridImpl: WidgetImpl {}
+pub trait GridImpl: WidgetImpl + ObjectSubclass<Type: IsA<Grid>> {}
 
 unsafe impl<T: GridImpl> IsSubclassable<T> for Grid {}

--- a/gtk4/src/subclass/im_context.rs
+++ b/gtk4/src/subclass/im_context.rs
@@ -9,7 +9,7 @@ use pango::AttrList;
 use crate::{ffi, prelude::*, subclass::prelude::*, IMContext, Widget};
 
 #[allow(clippy::upper_case_acronyms)]
-pub trait IMContextImpl: IMContextImplExt + ObjectImpl {
+pub trait IMContextImpl: ObjectImpl + ObjectSubclass<Type: IsA<IMContext>> {
     fn commit(&self, string: &str) {
         self.parent_commit(string)
     }
@@ -74,13 +74,8 @@ pub trait IMContextImpl: IMContextImplExt + ObjectImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::IMContextImplExt> Sealed for T {}
-}
-
 #[allow(clippy::upper_case_acronyms)]
-pub trait IMContextImplExt: sealed::Sealed + ObjectSubclass {
+pub trait IMContextImplExt: IMContextImpl {
     fn parent_commit(&self, string: &str) {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/layout_child.rs
+++ b/gtk4/src/subclass/layout_child.rs
@@ -3,9 +3,9 @@
 // rustdoc-stripper-ignore-next
 //! Traits intended for subclassing [`LayoutChild`](crate::LayoutChild).
 
-use crate::{subclass::prelude::*, LayoutChild};
+use crate::{prelude::*, subclass::prelude::*, LayoutChild};
 
-pub trait LayoutChildImpl: ObjectImpl {}
+pub trait LayoutChildImpl: ObjectImpl + ObjectSubclass<Type: IsA<LayoutChild>> {}
 
 unsafe impl<T: LayoutChildImpl> IsSubclassable<T> for LayoutChild {
     fn class_init(class: &mut glib::Class<Self>) {

--- a/gtk4/src/subclass/layout_manager.rs
+++ b/gtk4/src/subclass/layout_manager.rs
@@ -11,7 +11,7 @@ use crate::{
     SizeRequestMode, Widget,
 };
 
-pub trait LayoutManagerImpl: LayoutManagerImplExt + ObjectImpl {
+pub trait LayoutManagerImpl: ObjectImpl + ObjectSubclass<Type: IsA<LayoutManager>> {
     fn allocate(&self, widget: &Widget, width: i32, height: i32, baseline: i32) {
         self.parent_allocate(widget, width, height, baseline)
     }
@@ -48,12 +48,7 @@ pub trait LayoutManagerImpl: LayoutManagerImplExt + ObjectImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::LayoutManagerImplExt> Sealed for T {}
-}
-
-pub trait LayoutManagerImplExt: sealed::Sealed + ObjectSubclass {
+pub trait LayoutManagerImplExt: LayoutManagerImpl {
     fn parent_allocate(&self, widget: &Widget, width: i32, height: i32, baseline: i32) {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/list_box_row.rs
+++ b/gtk4/src/subclass/list_box_row.rs
@@ -7,18 +7,13 @@ use glib::translate::*;
 
 use crate::{ffi, prelude::*, subclass::prelude::*, ListBoxRow};
 
-pub trait ListBoxRowImpl: ListBoxRowImplExt + WidgetImpl {
+pub trait ListBoxRowImpl: WidgetImpl + ObjectSubclass<Type: IsA<ListBoxRow>> {
     fn activate(&self) {
         self.parent_activate()
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::ListBoxRowImplExt> Sealed for T {}
-}
-
-pub trait ListBoxRowImplExt: sealed::Sealed + ObjectSubclass {
+pub trait ListBoxRowImplExt: ListBoxRowImpl {
     fn parent_activate(&self) {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/media_file.rs
+++ b/gtk4/src/subclass/media_file.rs
@@ -7,7 +7,7 @@ use glib::translate::*;
 
 use crate::{ffi, prelude::*, subclass::prelude::*, MediaFile};
 
-pub trait MediaFileImpl: MediaFileImplExt + MediaStreamImpl {
+pub trait MediaFileImpl: MediaStreamImpl + ObjectSubclass<Type: IsA<MediaFile>> {
     fn close(&self) {
         self.parent_close()
     }
@@ -16,12 +16,7 @@ pub trait MediaFileImpl: MediaFileImplExt + MediaStreamImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::MediaFileImplExt> Sealed for T {}
-}
-
-pub trait MediaFileImplExt: sealed::Sealed + ObjectSubclass {
+pub trait MediaFileImplExt: MediaFileImpl {
     fn parent_close(&self) {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/media_stream.rs
+++ b/gtk4/src/subclass/media_stream.rs
@@ -7,7 +7,7 @@ use glib::translate::*;
 
 use crate::{ffi, prelude::*, subclass::prelude::*, MediaStream};
 
-pub trait MediaStreamImpl: MediaStreamImplExt + ObjectImpl {
+pub trait MediaStreamImpl: ObjectImpl + ObjectSubclass<Type: IsA<MediaStream>> {
     fn pause(&self) {
         self.parent_pause()
     }
@@ -33,12 +33,7 @@ pub trait MediaStreamImpl: MediaStreamImplExt + ObjectImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::MediaStreamImplExt> Sealed for T {}
-}
-
-pub trait MediaStreamImplExt: sealed::Sealed + ObjectSubclass {
+pub trait MediaStreamImplExt: MediaStreamImpl {
     fn parent_pause(&self) {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/native_dialog.rs
+++ b/gtk4/src/subclass/native_dialog.rs
@@ -9,7 +9,7 @@ use crate::{ffi, prelude::*, subclass::prelude::*, NativeDialog, ResponseType};
 
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait NativeDialogImpl: NativeDialogImplExt + ObjectImpl {
+pub trait NativeDialogImpl: ObjectImpl + ObjectSubclass<Type: IsA<NativeDialog>> {
     fn response(&self, response: ResponseType) {
         self.parent_response(response)
     }
@@ -23,14 +23,9 @@ pub trait NativeDialogImpl: NativeDialogImplExt + ObjectImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::NativeDialogImplExt> Sealed for T {}
-}
-
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait NativeDialogImplExt: sealed::Sealed + ObjectSubclass {
+pub trait NativeDialogImplExt: NativeDialogImpl {
     fn parent_response(&self, response: ResponseType) {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/orientable.rs
+++ b/gtk4/src/subclass/orientable.rs
@@ -4,8 +4,8 @@
 //! Traits intended for implementing the [`Orientable`](crate::Orientable)
 //! interface.
 
-use crate::{subclass::prelude::*, Orientable};
+use crate::{prelude::*, subclass::prelude::*, Orientable};
 
-pub trait OrientableImpl: WidgetImpl {}
+pub trait OrientableImpl: ObjectImpl + ObjectSubclass<Type: IsA<Orientable>> {}
 
 unsafe impl<T: OrientableImpl> IsImplementable<T> for Orientable {}

--- a/gtk4/src/subclass/popover.rs
+++ b/gtk4/src/subclass/popover.rs
@@ -7,7 +7,7 @@ use glib::translate::*;
 
 use crate::{ffi, prelude::*, subclass::prelude::*, Popover};
 
-pub trait PopoverImpl: PopoverImplExt + WidgetImpl {
+pub trait PopoverImpl: WidgetImpl + ObjectSubclass<Type: IsA<Popover>> {
     fn activate_default(&self) {
         self.parent_activate_default()
     }
@@ -17,12 +17,7 @@ pub trait PopoverImpl: PopoverImplExt + WidgetImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::PopoverImplExt> Sealed for T {}
-}
-
-pub trait PopoverImplExt: sealed::Sealed + ObjectSubclass {
+pub trait PopoverImplExt: PopoverImpl {
     fn parent_activate_default(&self) {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/print_operation.rs
+++ b/gtk4/src/subclass/print_operation.rs
@@ -10,7 +10,9 @@ use crate::{
     PrintOperationPreview, PrintOperationResult, PrintSettings, Widget, Window,
 };
 
-pub trait PrintOperationImpl: PrintOperationImplExt + PrintOperationPreviewImpl {
+pub trait PrintOperationImpl:
+    PrintOperationPreviewImpl + ObjectSubclass<Type: IsA<PrintOperation>>
+{
     fn begin_print(&self, context: &PrintContext) {
         self.parent_begin_print(context)
     }
@@ -61,12 +63,7 @@ pub trait PrintOperationImpl: PrintOperationImplExt + PrintOperationPreviewImpl 
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::PrintOperationImplExt> Sealed for T {}
-}
-
-pub trait PrintOperationImplExt: sealed::Sealed + ObjectSubclass {
+pub trait PrintOperationImplExt: PrintOperationImpl {
     fn parent_begin_print(&self, context: &PrintContext) {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/print_operation_preview.rs
+++ b/gtk4/src/subclass/print_operation_preview.rs
@@ -10,7 +10,9 @@ use crate::{
     ffi, prelude::*, subclass::prelude::*, PageSetup, PrintContext, PrintOperationPreview,
 };
 
-pub trait PrintOperationPreviewImpl: ObjectImpl {
+pub trait PrintOperationPreviewImpl:
+    ObjectImpl + ObjectSubclass<Type: IsA<PrintOperationPreview>>
+{
     fn ready(&self, context: &PrintContext) {
         self.parent_ready(context)
     }
@@ -24,12 +26,7 @@ pub trait PrintOperationPreviewImpl: ObjectImpl {
     fn end_preview(&self);
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::PrintOperationPreviewImplExt> Sealed for T {}
-}
-
-pub trait PrintOperationPreviewImplExt: sealed::Sealed + ObjectSubclass {
+pub trait PrintOperationPreviewImplExt: PrintOperationPreviewImpl {
     fn parent_ready(&self, context: &PrintContext) {
         unsafe {
             let type_data = Self::type_data();

--- a/gtk4/src/subclass/range.rs
+++ b/gtk4/src/subclass/range.rs
@@ -7,7 +7,7 @@ use glib::translate::*;
 
 use crate::{ffi, prelude::*, subclass::prelude::*, Border, Range, ScrollType};
 
-pub trait RangeImpl: RangeImplExt + WidgetImpl {
+pub trait RangeImpl: WidgetImpl + ObjectSubclass<Type: IsA<Range>> {
     fn adjust_bounds(&self, new_value: f64) {
         self.parent_adjust_bounds(new_value)
     }
@@ -30,12 +30,7 @@ pub trait RangeImpl: RangeImplExt + WidgetImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::RangeImplExt> Sealed for T {}
-}
-
-pub trait RangeImplExt: sealed::Sealed + ObjectSubclass {
+pub trait RangeImplExt: RangeImpl {
     fn parent_adjust_bounds(&self, new_value: f64) {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/recent_manager.rs
+++ b/gtk4/src/subclass/recent_manager.rs
@@ -7,17 +7,13 @@ use glib::translate::*;
 
 use crate::{ffi, prelude::*, subclass::prelude::*, RecentManager};
 
-pub trait RecentManagerImpl: RecentManagerImplExt + ObjectImpl {
+pub trait RecentManagerImpl: ObjectImpl + ObjectSubclass<Type: IsA<RecentManager>> {
     fn changed(&self) {
         self.parent_changed()
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::RecentManagerImplExt> Sealed for T {}
-}
-pub trait RecentManagerImplExt: sealed::Sealed + ObjectSubclass {
+pub trait RecentManagerImplExt: RecentManagerImpl {
     fn parent_changed(&self) {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/scale.rs
+++ b/gtk4/src/subclass/scale.rs
@@ -7,19 +7,14 @@ use glib::translate::*;
 
 use crate::{ffi, prelude::*, subclass::prelude::*, Scale};
 
-pub trait ScaleImpl: ScaleImplExt + RangeImpl {
+pub trait ScaleImpl: RangeImpl + ObjectSubclass<Type: IsA<Scale>> {
     #[doc(alias = "get_layout_offsets")]
     fn layout_offsets(&self) -> (i32, i32) {
         self.parent_layout_offsets()
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::ScaleImplExt> Sealed for T {}
-}
-
-pub trait ScaleImplExt: sealed::Sealed + ObjectSubclass {
+pub trait ScaleImplExt: ScaleImpl {
     fn parent_layout_offsets(&self) -> (i32, i32) {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/scale_button.rs
+++ b/gtk4/src/subclass/scale_button.rs
@@ -7,18 +7,13 @@ use glib::translate::*;
 
 use crate::{ffi, prelude::*, subclass::prelude::*, ScaleButton};
 
-pub trait ScaleButtonImpl: ScaleButtonImplExt + WidgetImpl {
+pub trait ScaleButtonImpl: WidgetImpl + ObjectSubclass<Type: IsA<ScaleButton>> {
     fn value_changed(&self, new_value: f64) {
         self.parent_value_changed(new_value)
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::ScaleButtonImplExt> Sealed for T {}
-}
-
-pub trait ScaleButtonImplExt: sealed::Sealed + ObjectSubclass {
+pub trait ScaleButtonImplExt: ScaleButtonImpl {
     fn parent_value_changed(&self, new_value: f64) {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/scrollable.rs
+++ b/gtk4/src/subclass/scrollable.rs
@@ -8,19 +8,14 @@ use glib::translate::*;
 
 use crate::{ffi, prelude::*, subclass::prelude::*, Border, Scrollable};
 
-pub trait ScrollableImpl: WidgetImpl {
+pub trait ScrollableImpl: WidgetImpl + ObjectSubclass<Type: IsA<Scrollable>> {
     #[doc(alias = "get_border")]
     fn border(&self) -> Option<Border> {
         self.parent_border()
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::ScrollableImplExt> Sealed for T {}
-}
-
-pub trait ScrollableImplExt: sealed::Sealed + ObjectSubclass {
+pub trait ScrollableImplExt: ScrollableImpl {
     fn parent_border(&self) -> Option<Border> {
         unsafe {
             let type_data = Self::type_data();

--- a/gtk4/src/subclass/section_model.rs
+++ b/gtk4/src/subclass/section_model.rs
@@ -8,19 +8,14 @@ use glib::translate::*;
 
 use crate::{ffi, prelude::*, subclass::prelude::*, SectionModel};
 
-pub trait SectionModelImpl: ListModelImpl {
+pub trait SectionModelImpl: ListModelImpl + ObjectSubclass<Type: IsA<SectionModel>> {
     #[doc(alias = "get_section")]
     fn section(&self, position: u32) -> (u32, u32) {
         self.parent_section(position)
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::SectionModelImplExt> Sealed for T {}
-}
-
-pub trait SectionModelImplExt: sealed::Sealed + ObjectSubclass {
+pub trait SectionModelImplExt: SectionModelImpl {
     fn parent_section(&self, position: u32) -> (u32, u32) {
         unsafe {
             let type_data = Self::type_data();

--- a/gtk4/src/subclass/selection_model.rs
+++ b/gtk4/src/subclass/selection_model.rs
@@ -8,7 +8,7 @@ use glib::translate::*;
 
 use crate::{ffi, prelude::*, subclass::prelude::*, Bitset, SelectionModel};
 
-pub trait SelectionModelImpl: ListModelImpl {
+pub trait SelectionModelImpl: ListModelImpl + ObjectSubclass<Type: IsA<SelectionModel>> {
     #[doc(alias = "get_selection_in_range")]
     fn selection_in_range(&self, position: u32, n_items: u32) -> Bitset {
         self.parent_selection_in_range(position, n_items)
@@ -47,12 +47,7 @@ pub trait SelectionModelImpl: ListModelImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::SelectionModelImplExt> Sealed for T {}
-}
-
-pub trait SelectionModelImplExt: sealed::Sealed + ObjectSubclass {
+pub trait SelectionModelImplExt: SelectionModelImpl {
     fn parent_selection_in_range(&self, position: u32, n_items: u32) -> Bitset {
         unsafe {
             let type_data = Self::type_data();

--- a/gtk4/src/subclass/shortcut_manager.rs
+++ b/gtk4/src/subclass/shortcut_manager.rs
@@ -8,7 +8,7 @@ use glib::translate::*;
 
 use crate::{ffi, prelude::*, subclass::prelude::*, ShortcutController, ShortcutManager};
 
-pub trait ShortcutManagerImpl: ObjectImpl {
+pub trait ShortcutManagerImpl: ObjectImpl + ObjectSubclass<Type: IsA<ShortcutManager>> {
     fn add_controller(&self, controller: &ShortcutController) {
         self.parent_add_controller(controller);
     }
@@ -18,12 +18,7 @@ pub trait ShortcutManagerImpl: ObjectImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::ShortcutManagerImplExt> Sealed for T {}
-}
-
-pub trait ShortcutManagerImplExt: sealed::Sealed + ObjectSubclass {
+pub trait ShortcutManagerImplExt: ShortcutManagerImpl {
     fn parent_add_controller(&self, controller: &ShortcutController) {
         unsafe {
             let type_data = Self::type_data();

--- a/gtk4/src/subclass/sorter.rs
+++ b/gtk4/src/subclass/sorter.rs
@@ -7,7 +7,7 @@ use glib::{translate::*, Object};
 
 use crate::{ffi, prelude::*, subclass::prelude::*, Ordering, Sorter, SorterOrder};
 
-pub trait SorterImpl: SorterImplExt + ObjectImpl {
+pub trait SorterImpl: ObjectImpl + ObjectSubclass<Type: IsA<Sorter>> {
     fn compare(&self, item1: &Object, item2: &Object) -> Ordering {
         self.parent_compare(item1, item2)
     }
@@ -17,12 +17,7 @@ pub trait SorterImpl: SorterImplExt + ObjectImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::SorterImplExt> Sealed for T {}
-}
-
-pub trait SorterImplExt: sealed::Sealed + ObjectSubclass {
+pub trait SorterImplExt: SorterImpl {
     fn parent_compare(&self, item1: &Object, item2: &Object) -> Ordering {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/style_context.rs
+++ b/gtk4/src/subclass/style_context.rs
@@ -9,20 +9,15 @@ use crate::{ffi, prelude::*, subclass::prelude::*, StyleContext};
 
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait StyleContextImpl: StyleContextImplExt + ObjectImpl {
+pub trait StyleContextImpl: ObjectImpl + ObjectSubclass<Type: IsA<StyleContext>> {
     fn changed(&self) {
         self.parent_changed()
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::StyleContextImplExt> Sealed for T {}
-}
-
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait StyleContextImplExt: sealed::Sealed + ObjectSubclass {
+pub trait StyleContextImplExt: StyleContextImpl {
     fn parent_changed(&self) {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/symbolic_paintable.rs
+++ b/gtk4/src/subclass/symbolic_paintable.rs
@@ -8,7 +8,9 @@ use glib::translate::*;
 
 use crate::{ffi, prelude::*, subclass::prelude::*, SymbolicPaintable};
 
-pub trait SymbolicPaintableImpl: PaintableImpl {
+pub trait SymbolicPaintableImpl:
+    PaintableImpl + ObjectSubclass<Type: IsA<SymbolicPaintable>>
+{
     fn snapshot_symbolic(
         &self,
         snapshot: &gdk::Snapshot,
@@ -20,12 +22,7 @@ pub trait SymbolicPaintableImpl: PaintableImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::SymbolicPaintableImplExt> Sealed for T {}
-}
-
-pub trait SymbolicPaintableImplExt: sealed::Sealed + ObjectSubclass {
+pub trait SymbolicPaintableImplExt: SymbolicPaintableImpl {
     fn parent_snapshot_symbolic(
         &self,
         snapshot: &gdk::Snapshot,

--- a/gtk4/src/subclass/text_buffer.rs
+++ b/gtk4/src/subclass/text_buffer.rs
@@ -9,7 +9,7 @@ use crate::{
     ffi, prelude::*, subclass::prelude::*, TextBuffer, TextChildAnchor, TextIter, TextMark, TextTag,
 };
 
-pub trait TextBufferImpl: TextBufferImplExt + ObjectImpl {
+pub trait TextBufferImpl: ObjectImpl + ObjectSubclass<Type: IsA<TextBuffer>> {
     fn apply_tag(&self, tag: &TextTag, start: &TextIter, end: &TextIter) {
         self.parent_apply_tag(tag, start, end)
     }
@@ -57,12 +57,7 @@ pub trait TextBufferImpl: TextBufferImplExt + ObjectImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::TextBufferImplExt> Sealed for T {}
-}
-
-pub trait TextBufferImplExt: sealed::Sealed + ObjectSubclass {
+pub trait TextBufferImplExt: TextBufferImpl {
     fn parent_apply_tag(&self, tag: &TextTag, start: &TextIter, end: &TextIter) {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/text_view.rs
+++ b/gtk4/src/subclass/text_view.rs
@@ -10,7 +10,7 @@ use crate::{
     TextIter, TextView, TextViewLayer,
 };
 
-pub trait TextViewImpl: TextViewImplExt + WidgetImpl {
+pub trait TextViewImpl: WidgetImpl + ObjectSubclass<Type: IsA<TextView>> {
     fn backspace(&self) {
         self.parent_backspace()
     }
@@ -66,12 +66,7 @@ pub trait TextViewImpl: TextViewImplExt + WidgetImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::TextViewImplExt> Sealed for T {}
-}
-
-pub trait TextViewImplExt: sealed::Sealed + ObjectSubclass {
+pub trait TextViewImplExt: TextViewImpl {
     fn parent_backspace(&self) {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/toggle_button.rs
+++ b/gtk4/src/subclass/toggle_button.rs
@@ -7,18 +7,13 @@ use glib::translate::*;
 
 use crate::{ffi, prelude::*, subclass::prelude::*, ToggleButton};
 
-pub trait ToggleButtonImpl: ToggleButtonImplExt + ButtonImpl {
+pub trait ToggleButtonImpl: ButtonImpl + ObjectSubclass<Type: IsA<ToggleButton>> {
     fn toggled(&self) {
         self.parent_toggled()
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::ToggleButtonImplExt> Sealed for T {}
-}
-
-pub trait ToggleButtonImplExt: sealed::Sealed + ObjectSubclass {
+pub trait ToggleButtonImplExt: ToggleButtonImpl {
     fn parent_toggled(&self) {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/tree_drag_dest.rs
+++ b/gtk4/src/subclass/tree_drag_dest.rs
@@ -10,19 +10,14 @@ use crate::{ffi, prelude::*, subclass::prelude::*, TreeDragDest, TreePath};
 
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait TreeDragDestImpl: ObjectImpl {
+pub trait TreeDragDestImpl: ObjectImpl + ObjectSubclass<Type: IsA<TreeDragDest>> {
     fn drag_data_received(&self, dest: &TreePath, value: Value) -> bool;
     fn row_drop_possible(&self, dest: &TreePath, value: Value) -> bool;
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::TreeDragDestImplExt> Sealed for T {}
-}
-
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait TreeDragDestImplExt: sealed::Sealed + ObjectSubclass {
+pub trait TreeDragDestImplExt: TreeDragDestImpl {
     fn parent_drag_data_received(&self, dest: &TreePath, value: Value) -> bool {
         unsafe {
             let type_data = Self::type_data();

--- a/gtk4/src/subclass/tree_drag_source.rs
+++ b/gtk4/src/subclass/tree_drag_source.rs
@@ -10,7 +10,7 @@ use crate::{ffi, prelude::*, subclass::prelude::*, TreeDragSource, TreePath};
 
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait TreeDragSourceImpl: ObjectImpl {
+pub trait TreeDragSourceImpl: ObjectImpl + ObjectSubclass<Type: IsA<TreeDragSource>> {
     fn row_draggable(&self, path: &TreePath) -> bool {
         self.parent_row_draggable(path)
     }
@@ -18,14 +18,9 @@ pub trait TreeDragSourceImpl: ObjectImpl {
     fn drag_data_delete(&self, path: &TreePath) -> bool;
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::TreeDragSourceImplExt> Sealed for T {}
-}
-
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait TreeDragSourceImplExt: sealed::Sealed + ObjectSubclass {
+pub trait TreeDragSourceImplExt: TreeDragSourceImpl {
     // Returns true if the row can be dragged
     fn parent_row_draggable(&self, path: &TreePath) -> bool {
         unsafe {

--- a/gtk4/src/subclass/tree_model_filter.rs
+++ b/gtk4/src/subclass/tree_model_filter.rs
@@ -9,7 +9,7 @@ use crate::{ffi, prelude::*, subclass::prelude::*, TreeIter, TreeModel, TreeMode
 
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait TreeModelFilterImpl: TreeModelFilterImplExt + ObjectImpl {
+pub trait TreeModelFilterImpl: ObjectImpl + ObjectSubclass<Type: IsA<TreeModelFilter>> {
     fn visible<M: IsA<TreeModel>>(&self, child_model: &M, iter: &TreeIter) -> bool {
         self.parent_visible(child_model, iter)
     }
@@ -25,14 +25,9 @@ pub trait TreeModelFilterImpl: TreeModelFilterImplExt + ObjectImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::TreeModelFilterImplExt> Sealed for T {}
-}
-
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait TreeModelFilterImplExt: sealed::Sealed + ObjectSubclass {
+pub trait TreeModelFilterImplExt: TreeModelFilterImpl {
     // Whether the row indicated by iter is visible
     fn parent_visible<M: IsA<TreeModel>>(&self, child_model: &M, iter: &TreeIter) -> bool {
         unsafe {

--- a/gtk4/src/subclass/tree_view.rs
+++ b/gtk4/src/subclass/tree_view.rs
@@ -12,7 +12,7 @@ use crate::{
 
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait TreeViewImpl: TreeViewImplExt + WidgetImpl {
+pub trait TreeViewImpl: WidgetImpl + ObjectSubclass<Type: IsA<TreeView>> {
     fn columns_changed(&self) {
         self.parent_columns_changed()
     }
@@ -74,14 +74,9 @@ pub trait TreeViewImpl: TreeViewImplExt + WidgetImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::TreeViewImplExt> Sealed for T {}
-}
-
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait TreeViewImplExt: sealed::Sealed + ObjectSubclass {
+pub trait TreeViewImplExt: TreeViewImpl {
     fn parent_columns_changed(&self) {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/window.rs
+++ b/gtk4/src/subclass/window.rs
@@ -7,7 +7,7 @@ use glib::translate::*;
 
 use crate::{ffi, prelude::*, subclass::prelude::*, Window};
 
-pub trait WindowImpl: WindowImplExt + WidgetImpl {
+pub trait WindowImpl: WidgetImpl + ObjectSubclass<Type: IsA<Window>> {
     fn activate_focus(&self) {
         self.parent_activate_focus()
     }
@@ -29,12 +29,7 @@ pub trait WindowImpl: WindowImplExt + WidgetImpl {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-    impl<T: super::WindowImplExt> Sealed for T {}
-}
-
-pub trait WindowImplExt: sealed::Sealed + ObjectSubclass {
+pub trait WindowImplExt: WindowImpl {
     fn parent_activate_focus(&self) {
         unsafe {
             let data = Self::type_data();

--- a/gtk4/src/subclass/window_group.rs
+++ b/gtk4/src/subclass/window_group.rs
@@ -3,8 +3,8 @@
 // rustdoc-stripper-ignore-next
 //! Traits intended for subclassing [`WindowGroup`](crate::WindowGroup).
 
-use crate::{subclass::prelude::*, WindowGroup};
+use crate::{prelude::*, subclass::prelude::*, WindowGroup};
 
-pub trait WindowGroupImpl: ObjectImpl {}
+pub trait WindowGroupImpl: ObjectImpl + ObjectSubclass<Type: IsA<WindowGroup>> {}
 
 unsafe impl<T: WindowGroupImpl> IsSubclassable<T> for WindowGroup {}


### PR DESCRIPTION
Mirrors https://github.com/gtk-rs/gtk-rs-core/pull/1519
See https://github.com/gtk-rs/gtk-rs-core/issues/1515

Open questions:
- [x] `GInitiallyUnowned`: Technically a parent class, but we mostly ignore it in other places already
- [ ] Interfaces, especially the ones implemented by `GtkWidget` are currently not covered by the implementing classes. Should they? One normally doesn't need to reimplement them, but we need to check whether we are required to specify them for safety reasons anyway