### PR TITLE
book: Make book listings work on macos by using glib user_data_dir

### DIFF
--- a/book/listings/Cargo.lock
+++ b/book/listings/Cargo.lock
@@ -370,27 +370,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "endi"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,7 +872,6 @@ dependencies = [
  "anyhow",
  "ashpd",
  "async-channel",
- "dirs",
  "glib-build-tools",
  "gtk4",
  "libadwaita",
@@ -1130,16 +1108,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
-name = "libredox"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
-dependencies = [
- "bitflags",
- "libc",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,12 +1197,6 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-stream"
@@ -1454,17 +1416,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
-dependencies = [
- "getrandom",
- "libredox",
- "thiserror",
 ]
 
 [[package]]

--- a/book/listings/Cargo.toml
+++ b/book/listings/Cargo.toml
@@ -9,7 +9,6 @@ adw = { version = "0.7", package = "libadwaita", features = ["v1_5"] }
 anyhow = "1.0"
 ashpd = { version = "0.9", features = ["gtk4"] }
 async-channel = "2.0"
-dirs = "5.0"
 gtk = { version = "0.9", package = "gtk4", features = ["v4_12"] }
 reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls",

--- a/book/listings/xtask/main.rs
+++ b/book/listings/xtask/main.rs
@@ -1,7 +1,6 @@
 use std::env;
 use std::path::PathBuf;
 
-use anyhow::Context;
 use walkdir::WalkDir;
 use xshell::{cmd, Shell};
 
@@ -53,9 +52,7 @@ fn schema_dir() -> anyhow::Result<PathBuf> {
     let schema_dir = if cfg!(windows) {
         PathBuf::from("C:/ProgramData/glib-2.0/schemas/")
     } else {
-        dirs::data_dir()
-            .context("Could not get data dir")?
-            .join("glib-2.0/schemas")
+        gtk::glib::user_data_dir().join("glib-2.0/schemas")
     };
     Ok(schema_dir)
 }


### PR DESCRIPTION
`dirs::data_dir()` returns a different directory that glib expects for the schemas on macos (see https://docs.rs/dirs/latest/dirs/fn.data_dir.html)
Using `glib::user_data_dir()` instead will return the expected directory for glib.