### PR TITLE
Add interface bounds to Impls

### DIFF
--- a/examples/column_view_datagrid/grid_cell/mod.rs
+++ b/examples/column_view_datagrid/grid_cell/mod.rs
@@ -7,7 +7,8 @@ pub struct Entry {
 
 glib::wrapper! {
     pub struct GridCell(ObjectSubclass<imp::GridCell>)
-        @extends gtk::Widget;
+        @extends gtk::Widget,
+        @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
 impl Default for GridCell {

--- a/examples/composite_dialog/my_app_window/mod.rs
+++ b/examples/composite_dialog/my_app_window/mod.rs
@@ -2,11 +2,14 @@
 #[allow(deprecated)]
 mod imp;
 
-use gtk::{glib, prelude::*, subclass::prelude::*};
+use gtk::{gio, glib, prelude::*, subclass::prelude::*};
 
 glib::wrapper! {
     pub struct MyAppWindow(ObjectSubclass<imp::MyAppWindow>)
-        @extends gtk::Widget, gtk::Window, gtk::ApplicationWindow;
+        @extends gtk::Widget, gtk::Window, gtk::ApplicationWindow,
+        @implements gtk::Accessible, gio::ActionGroup, gio::ActionMap,
+        gtk::Buildable, gtk::ConstraintTarget, gtk::Native, gtk::Root,
+        gtk::ShortcutManager;
 }
 
 #[gtk::template_callbacks]

--- a/examples/composite_template/ex_application_window/mod.rs
+++ b/examples/composite_template/ex_application_window/mod.rs
@@ -5,7 +5,8 @@ use gtk::{gio, glib, prelude::*, subclass::prelude::*};
 glib::wrapper! {
     pub struct ExApplicationWindow(ObjectSubclass<imp::ExApplicationWindow>)
         @extends gtk::Widget, gtk::Window, gtk::ApplicationWindow,
-        @implements gio::ActionMap, gio::ActionGroup;
+        @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget,
+        gtk::Native, gtk::Root, gtk::ShortcutManager, gio::ActionMap, gio::ActionGroup;
 }
 
 impl ExApplicationWindow {

--- a/examples/composite_template/ex_menu_button/mod.rs
+++ b/examples/composite_template/ex_menu_button/mod.rs
@@ -4,5 +4,6 @@ use gtk::glib;
 
 glib::wrapper! {
     pub struct ExMenuButton(ObjectSubclass<imp::ExMenuButton>)
-        @extends gtk::Widget;
+        @extends gtk::Widget,
+        @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }

--- a/examples/confetti_snapshot_animation/confetti_widget/mod.rs
+++ b/examples/confetti_snapshot_animation/confetti_widget/mod.rs
@@ -9,7 +9,9 @@ use gtk::{
 use crate::{AnimatedExplosion, ExplosionParameters};
 
 glib::wrapper! {
-    pub struct ConfettiWidget(ObjectSubclass<imp::ConfettiWidget>) @implements gtk::Widget;
+    pub struct ConfettiWidget(ObjectSubclass<imp::ConfettiWidget>)
+    @extends gtk::Widget,
+    @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
 impl Default for ConfettiWidget {

--- a/examples/custom_buildable/custom_buildable/mod.rs
+++ b/examples/custom_buildable/custom_buildable/mod.rs
@@ -5,7 +5,7 @@ use gtk::{glib, prelude::*, subclass::prelude::*};
 glib::wrapper! {
     pub struct CustomBuildable(ObjectSubclass<imp::CustomBuildable>)
         @extends gtk::Widget,
-        @implements gtk::Buildable;
+        @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
 impl CustomBuildable {

--- a/examples/custom_editable/custom_editable/mod.rs
+++ b/examples/custom_editable/custom_editable/mod.rs
@@ -7,7 +7,7 @@ use crate::custom_tag::CustomTag;
 glib::wrapper! {
     pub struct CustomEditable(ObjectSubclass<imp::CustomEditable>)
         @extends gtk::Widget,
-        @implements gtk::Editable;
+        @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget, gtk::Editable;
 }
 
 impl Default for CustomEditable {

--- a/examples/custom_editable/custom_tag/mod.rs
+++ b/examples/custom_editable/custom_tag/mod.rs
@@ -4,7 +4,8 @@ use gtk::glib;
 
 glib::wrapper! {
     pub struct CustomTag(ObjectSubclass<imp::CustomTag>)
-        @extends gtk::Widget;
+        @extends gtk::Widget,
+        @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
 impl CustomTag {

--- a/examples/custom_layout_manager/custom_layout_child/mod.rs
+++ b/examples/custom_layout_manager/custom_layout_child/mod.rs
@@ -4,7 +4,8 @@ use gtk::{gdk, glib};
 
 glib::wrapper! {
     pub struct CustomLayoutChild(ObjectSubclass<imp::CustomLayoutChild>)
-        @extends gtk::Widget;
+        @extends gtk::Widget,
+        @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
 impl CustomLayoutChild {

--- a/examples/custom_layout_manager/simple_widget/mod.rs
+++ b/examples/custom_layout_manager/simple_widget/mod.rs
@@ -10,7 +10,8 @@ use crate::custom_layout::CustomLayout;
 
 glib::wrapper! {
     pub struct SimpleWidget(ObjectSubclass<imp::SimpleWidget>)
-        @extends gtk::Widget;
+        @extends gtk::Widget,
+        @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
 impl Default for SimpleWidget {

--- a/examples/custom_orientable/custom_orientable/mod.rs
+++ b/examples/custom_orientable/custom_orientable/mod.rs
@@ -5,7 +5,7 @@ use gtk::glib;
 glib::wrapper! {
     pub struct CustomOrientable(ObjectSubclass<imp::CustomOrientable>)
         @extends gtk::Widget,
-        @implements gtk::Orientable;
+        @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget, gtk::Orientable;
 }
 
 impl Default for CustomOrientable {

--- a/examples/custom_widget/ex_button/mod.rs
+++ b/examples/custom_widget/ex_button/mod.rs
@@ -5,7 +5,7 @@ use gtk::glib;
 glib::wrapper! {
     pub struct ExButton(ObjectSubclass<imp::ExButton>)
         @extends gtk::Widget,
-        @implements gtk::Accessible;
+        @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
 impl Default for ExButton {

--- a/examples/femtovg_area/femtovg_area/mod.rs
+++ b/examples/femtovg_area/femtovg_area/mod.rs
@@ -4,7 +4,8 @@ use gtk::glib;
 
 glib::wrapper! {
     pub struct FemtoVGArea(ObjectSubclass<imp::FemtoVGArea>)
-        @extends gtk::Widget, gtk::GLArea;
+        @extends gtk::Widget, gtk::GLArea,
+        @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
 impl Default for FemtoVGArea {

--- a/examples/gif_paintable/gif_paintable_window/mod.rs
+++ b/examples/gif_paintable/gif_paintable_window/mod.rs
@@ -7,7 +7,8 @@ use crate::gif_paintable::GifPaintable;
 glib::wrapper! {
     pub struct GifPaintableWindow(ObjectSubclass<imp::GifPaintableWindow>)
         @extends gtk::Widget, gtk::Window, gtk::ApplicationWindow,
-        @implements gio::ActionMap, gio::ActionGroup;
+        @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget,
+        gtk::Native, gtk::Root, gtk::ShortcutManager, gio::ActionMap, gio::ActionGroup;
 }
 
 impl GifPaintableWindow {

--- a/examples/glium_gl_area/glium_gl_area/mod.rs
+++ b/examples/glium_gl_area/glium_gl_area/mod.rs
@@ -4,7 +4,8 @@ use gtk::{gdk, glib, prelude::*};
 
 glib::wrapper! {
     pub struct GliumGLArea(ObjectSubclass<imp::GliumGLArea>)
-        @extends gtk::GLArea, gtk::Widget;
+        @extends gtk::GLArea, gtk::Widget,
+        @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
 impl Default for GliumGLArea {

--- a/examples/list_box_model/list_box_row/mod.rs
+++ b/examples/list_box_model/list_box_row/mod.rs
@@ -6,7 +6,8 @@ use crate::row_data::RowData;
 
 glib::wrapper! {
     pub struct ListBoxRow(ObjectSubclass<imp::ListBoxRow>)
-        @extends gtk::Widget, gtk::ListBoxRow;
+        @extends gtk::Widget, gtk::ListBoxRow,
+        @implements gtk::Accessible, gtk::Actionable, gtk::Buildable, gtk::ConstraintTarget;
 }
 
 impl ListBoxRow {

--- a/examples/list_box_model/main.rs
+++ b/examples/list_box_model/main.rs
@@ -45,21 +45,13 @@ fn build_ui(application: &gtk::Application) {
     // The gtk::ListBoxRow can contain any possible widgets.
 
     let listbox = gtk::ListBox::new();
-    listbox.bind_model(
-        Some(&model),
-        clone!(
-            #[weak]
-            window,
-            #[upgrade_or_panic]
-            move |item| {
-                ListBoxRow::new(
-                    item.downcast_ref::<RowData>()
-                        .expect("RowData is of wrong type"),
-                )
-                .upcast::<gtk::Widget>()
-            }
-        ),
-    );
+    listbox.bind_model(Some(&model), move |item| {
+        ListBoxRow::new(
+            item.downcast_ref::<RowData>()
+                .expect("RowData is of wrong type"),
+        )
+        .upcast::<gtk::Widget>()
+    });
 
     let scrolled_window = gtk::ScrolledWindow::builder()
         .hscrollbar_policy(gtk::PolicyType::Never) // Disable horizontal scrolling

--- a/examples/list_view_apps_launcher/application_row/mod.rs
+++ b/examples/list_view_apps_launcher/application_row/mod.rs
@@ -4,7 +4,8 @@ use gtk::{gio, glib, prelude::*, subclass::prelude::*};
 
 glib::wrapper! {
     pub struct ApplicationRow(ObjectSubclass<imp::ApplicationRow>)
-        @extends gtk::Widget, gtk::Box;
+        @extends gtk::Widget, gtk::Box,
+        @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
 impl Default for ApplicationRow {

--- a/examples/rotation_bin/rotation_bin/mod.rs
+++ b/examples/rotation_bin/rotation_bin/mod.rs
@@ -46,7 +46,8 @@ impl From<Rotation> for f32 {
 
 glib::wrapper! {
     pub struct RotationBin(ObjectSubclass<imp::RotationBin>)
-        @extends gtk::Widget;
+        @extends gtk::Widget,
+        @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
 impl Default for RotationBin {

--- a/examples/scale_bin/scale_bin/mod.rs
+++ b/examples/scale_bin/scale_bin/mod.rs
@@ -4,7 +4,8 @@ use gtk::glib;
 
 glib::wrapper! {
     pub struct ScaleBin(ObjectSubclass<imp::ScaleBin>)
-        @extends gtk::Widget;
+        @extends gtk::Widget,
+        @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
 impl Default for ScaleBin {

--- a/examples/squares/squares_widget/mod.rs
+++ b/examples/squares/squares_widget/mod.rs
@@ -4,7 +4,8 @@ use gtk::glib;
 
 glib::wrapper! {
     pub struct SquaresWidget(ObjectSubclass<imp::SquaresWidget>)
-        @extends gtk::Widget;
+        @extends gtk::Widget,
+        @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
 impl Default for SquaresWidget {

--- a/examples/squeezer_bin/squeezer_bin/mod.rs
+++ b/examples/squeezer_bin/squeezer_bin/mod.rs
@@ -4,7 +4,8 @@ use gtk::glib;
 
 glib::wrapper! {
     pub struct SqueezerBin(ObjectSubclass<imp::SqueezerBin>)
-        @extends gtk::Widget;
+        @extends gtk::Widget,
+        @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
 impl Default for SqueezerBin {

--- a/examples/video_player/video_player_window/mod.rs
+++ b/examples/video_player/video_player_window/mod.rs
@@ -5,7 +5,8 @@ use gtk::{gio, glib, prelude::*, subclass::prelude::*};
 glib::wrapper! {
     pub struct VideoPlayerWindow(ObjectSubclass<imp::VideoPlayerWindow>)
         @extends gtk::Widget, gtk::Window, gtk::ApplicationWindow,
-        @implements gio::ActionMap, gio::ActionGroup;
+        @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget,
+        gtk::Native, gtk::Root, gtk::ShortcutManager, gio::ActionMap, gio::ActionGroup;
 }
 
 impl VideoPlayerWindow {

--- a/examples/virtual_methods/base_button/mod.rs
+++ b/examples/virtual_methods/base_button/mod.rs
@@ -11,7 +11,8 @@ pub type PinnedFuture<T> = Pin<Box<dyn Future<Output = T>>>;
 glib::wrapper! {
     /// Public type for the `BaseButton` instances.
     pub struct BaseButton(ObjectSubclass<imp::BaseButton>)
-        @extends gtk::Widget, gtk::Button;
+        @extends gtk::Widget, gtk::Button,
+        @implements gtk::Accessible, gtk::Actionable, gtk::Buildable, gtk::ConstraintTarget;
 }
 
 impl Default for BaseButton {

--- a/examples/virtual_methods/derived_button/mod.rs
+++ b/examples/virtual_methods/derived_button/mod.rs
@@ -4,7 +4,8 @@ use gtk::glib;
 
 glib::wrapper! {
     pub struct DerivedButton(ObjectSubclass<imp::DerivedButton>)
-        @extends gtk::Widget, gtk::Button, crate::base_button::BaseButton;
+        @extends gtk::Widget, gtk::Button, crate::base_button::BaseButton,
+        @implements gtk::Accessible, gtk::Actionable, gtk::Buildable, gtk::ConstraintTarget;
 }
 
 impl Default for DerivedButton {

--- a/gtk4-macros/src/lib.rs
+++ b/gtk4-macros/src/lib.rs
@@ -132,7 +132,9 @@ pub fn include_blueprint(input: TokenStream) -> TokenStream {
 /// }
 ///
 /// glib::wrapper! {
-///     pub struct MyWidget(ObjectSubclass<imp::MyWidget>) @extends gtk::Widget, gtk::Box;
+///     pub struct MyWidget(ObjectSubclass<imp::MyWidget>)
+///     @extends gtk::Widget, gtk::Box,
+///     @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 /// }
 ///
 /// impl MyWidget {
@@ -197,7 +199,9 @@ pub fn include_blueprint(input: TokenStream) -> TokenStream {
 /// }
 ///
 /// glib::wrapper! {
-///     pub struct MyWidget(ObjectSubclass<imp::MyWidget>) @extends gtk::Widget;
+///     pub struct MyWidget(ObjectSubclass<imp::MyWidget>)
+///     @extends gtk::Widget,
+///     @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 /// }
 /// ```
 #[proc_macro_derive(CompositeTemplate, attributes(template, template_child))]
@@ -351,7 +355,9 @@ pub fn composite_template_derive(input: TokenStream) -> TokenStream {
 /// }
 ///
 /// glib::wrapper! {
-///     pub struct MyWidget(ObjectSubclass<imp::MyWidget>) @extends gtk::Widget, gtk::Box;
+///     pub struct MyWidget(ObjectSubclass<imp::MyWidget>)
+///     @extends gtk::Widget, gtk::Box,
+///     @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 /// }
 ///
 /// #[gtk::template_callbacks]

--- a/gtk4-macros/tests/templates.rs
+++ b/gtk4-macros/tests/templates.rs
@@ -53,7 +53,9 @@ mod imp {
 }
 
 glib::wrapper! {
-    pub struct MyWidget(ObjectSubclass<imp::MyWidget>) @extends gtk::Widget;
+    pub struct MyWidget(ObjectSubclass<imp::MyWidget>)
+    @extends gtk::Widget,
+    @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
 #[gtk::test]
@@ -145,7 +147,9 @@ mod imp2 {
 }
 
 glib::wrapper! {
-    pub struct MyWidget2(ObjectSubclass<imp2::MyWidget2>) @extends gtk::Widget;
+    pub struct MyWidget2(ObjectSubclass<imp2::MyWidget2>)
+    @extends gtk::Widget,
+    @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
 #[gtk::test]
@@ -192,7 +196,9 @@ mod imp3 {
 }
 
 glib::wrapper! {
-    pub struct MyWidget3(ObjectSubclass<imp3::MyWidget3>) @extends gtk::Widget;
+    pub struct MyWidget3(ObjectSubclass<imp3::MyWidget3>)
+    @extends gtk::Widget,
+    @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
 #[gtk::test]
@@ -248,7 +254,9 @@ mod imp4 {
 
 #[cfg(feature = "blueprint")]
 glib::wrapper! {
-    pub struct MyWidget4(ObjectSubclass<imp4::MyWidget4>) @extends gtk::Widget;
+    pub struct MyWidget4(ObjectSubclass<imp4::MyWidget4>)
+    @extends gtk::Widget,
+    @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
 #[gtk::test]
@@ -295,7 +303,9 @@ mod imp5 {
 
 #[cfg(feature = "blueprint")]
 glib::wrapper! {
-    pub struct MyWidget5(ObjectSubclass<imp5::MyWidget5>) @extends gtk::Widget;
+    pub struct MyWidget5(ObjectSubclass<imp5::MyWidget5>)
+    @extends gtk::Widget,
+    @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
 #[gtk::test]
@@ -348,5 +358,6 @@ mod imp6 {
 
 glib::wrapper! {
     pub struct TestWidget(ObjectSubclass<imp6::TestWidget>)
-    @extends gtk::Widget;
+    @extends gtk::Widget,
+    @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }

--- a/gtk4/src/subclass/application_window.rs
+++ b/gtk4/src/subclass/application_window.rs
@@ -6,7 +6,9 @@
 use crate::{prelude::*, subclass::prelude::*, ApplicationWindow};
 
 pub trait ApplicationWindowImpl:
-    WindowImpl + ObjectSubclass<Type: IsA<ApplicationWindow>> + 'static
+    WindowImpl
+    + ObjectSubclass<Type: IsA<ApplicationWindow> + IsA<gio::ActionGroup> + IsA<gio::ActionMap>>
+    + 'static
 {
 }
 

--- a/gtk4/src/subclass/button.rs
+++ b/gtk4/src/subclass/button.rs
@@ -5,9 +5,9 @@
 
 use glib::translate::*;
 
-use crate::{ffi, prelude::*, subclass::prelude::*, Button};
+use crate::{ffi, prelude::*, subclass::prelude::*, Actionable, Button};
 
-pub trait ButtonImpl: WidgetImpl + ObjectSubclass<Type: IsA<Button>> {
+pub trait ButtonImpl: WidgetImpl + ObjectSubclass<Type: IsA<Button> + IsA<Actionable>> {
     fn activate(&self) {
         self.parent_activate()
     }

--- a/gtk4/src/subclass/cell_area.rs
+++ b/gtk4/src/subclass/cell_area.rs
@@ -8,8 +8,9 @@ use std::mem;
 use glib::{translate::*, ParamSpec, Value};
 
 use crate::{
-    ffi, prelude::*, subclass::prelude::*, CellArea, CellAreaContext, CellRenderer,
-    CellRendererState, DirectionType, SizeRequestMode, Snapshot, TreeIter, TreeModel, Widget,
+    ffi, prelude::*, subclass::prelude::*, Buildable, CellArea, CellAreaContext, CellLayout,
+    CellRenderer, CellRendererState, DirectionType, SizeRequestMode, Snapshot, TreeIter, TreeModel,
+    Widget,
 };
 
 #[derive(Debug)]
@@ -63,7 +64,9 @@ impl CellCallbackAllocate {
 
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait CellAreaImpl: ObjectImpl + ObjectSubclass<Type: IsA<CellArea>> {
+pub trait CellAreaImpl:
+    ObjectImpl + ObjectSubclass<Type: IsA<CellArea> + IsA<Buildable> + IsA<CellLayout>>
+{
     fn cell_properties() -> &'static [ParamSpec] {
         &[]
     }

--- a/gtk4/src/subclass/cell_editable.rs
+++ b/gtk4/src/subclass/cell_editable.rs
@@ -9,7 +9,7 @@ use crate::{ffi, prelude::*, subclass::prelude::*, CellEditable};
 
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait CellEditableImpl: ObjectImpl + ObjectSubclass<Type: IsA<CellEditable>> {
+pub trait CellEditableImpl: WidgetImpl + ObjectSubclass<Type: IsA<CellEditable>> {
     fn editing_done(&self) {
         self.parent_editing_done()
     }

--- a/gtk4/src/subclass/check_button.rs
+++ b/gtk4/src/subclass/check_button.rs
@@ -5,9 +5,11 @@
 
 use glib::translate::*;
 
-use crate::{ffi, prelude::*, subclass::prelude::*, CheckButton};
+use crate::{ffi, prelude::*, subclass::prelude::*, Actionable, CheckButton};
 
-pub trait CheckButtonImpl: WidgetImpl + ObjectSubclass<Type: IsA<CheckButton>> {
+pub trait CheckButtonImpl:
+    WidgetImpl + ObjectSubclass<Type: IsA<CheckButton> + IsA<Actionable>>
+{
     fn toggled(&self) {
         self.parent_toggled()
     }

--- a/gtk4/src/subclass/combo_box.rs
+++ b/gtk4/src/subclass/combo_box.rs
@@ -5,11 +5,13 @@
 
 use glib::{translate::*, GString};
 
-use crate::{ffi, prelude::*, subclass::prelude::*, ComboBox};
+use crate::{ffi, prelude::*, subclass::prelude::*, CellEditable, CellLayout, ComboBox};
 
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait ComboBoxImpl: WidgetImpl + ObjectSubclass<Type: IsA<ComboBox>> {
+pub trait ComboBoxImpl:
+    WidgetImpl + ObjectSubclass<Type: IsA<ComboBox> + IsA<CellEditable> + IsA<CellLayout>>
+{
     #[cfg(feature = "v4_6")]
     #[cfg_attr(docsrs, doc(cfg(feature = "v4_6")))]
     fn activate(&self) {

--- a/gtk4/src/subclass/entry.rs
+++ b/gtk4/src/subclass/entry.rs
@@ -5,9 +5,9 @@
 
 use glib::translate::*;
 
-use crate::{ffi, prelude::*, subclass::prelude::*, Entry};
+use crate::{ffi, prelude::*, subclass::prelude::*, CellEditable, Entry};
 
-pub trait EntryImpl: WidgetImpl + ObjectSubclass<Type: IsA<Entry>> {
+pub trait EntryImpl: WidgetImpl + ObjectSubclass<Type: IsA<Entry> + IsA<CellEditable>> {
     fn activate(&self) {
         self.parent_activate()
     }

--- a/gtk4/src/subclass/grid.rs
+++ b/gtk4/src/subclass/grid.rs
@@ -3,8 +3,8 @@
 // rustdoc-stripper-ignore-next
 //! Traits intended for subclassing [`Grid`].
 
-use crate::{prelude::*, subclass::prelude::*, Grid};
+use crate::{prelude::*, subclass::prelude::*, Grid, Orientable};
 
-pub trait GridImpl: WidgetImpl + ObjectSubclass<Type: IsA<Grid>> {}
+pub trait GridImpl: WidgetImpl + ObjectSubclass<Type: IsA<Grid> + IsA<Orientable>> {}
 
 unsafe impl<T: GridImpl> IsSubclassable<T> for Grid {}

--- a/gtk4/src/subclass/list_box_row.rs
+++ b/gtk4/src/subclass/list_box_row.rs
@@ -5,9 +5,11 @@
 
 use glib::translate::*;
 
-use crate::{ffi, prelude::*, subclass::prelude::*, ListBoxRow};
+use crate::{ffi, prelude::*, subclass::prelude::*, Actionable, ListBoxRow};
 
-pub trait ListBoxRowImpl: WidgetImpl + ObjectSubclass<Type: IsA<ListBoxRow>> {
+pub trait ListBoxRowImpl:
+    WidgetImpl + ObjectSubclass<Type: IsA<ListBoxRow> + IsA<Actionable>>
+{
     fn activate(&self) {
         self.parent_activate()
     }

--- a/gtk4/src/subclass/media_file.rs
+++ b/gtk4/src/subclass/media_file.rs
@@ -3,11 +3,14 @@
 // rustdoc-stripper-ignore-next
 //! Traits intended for subclassing [`MediaFile`].
 
+use gdk::Paintable;
 use glib::translate::*;
 
 use crate::{ffi, prelude::*, subclass::prelude::*, MediaFile};
 
-pub trait MediaFileImpl: MediaStreamImpl + ObjectSubclass<Type: IsA<MediaFile>> {
+pub trait MediaFileImpl:
+    MediaStreamImpl + ObjectSubclass<Type: IsA<MediaFile> + IsA<Paintable>>
+{
     fn close(&self) {
         self.parent_close()
     }

--- a/gtk4/src/subclass/media_stream.rs
+++ b/gtk4/src/subclass/media_stream.rs
@@ -3,11 +3,14 @@
 // rustdoc-stripper-ignore-next
 //! Traits intended for subclassing [`MediaStream`].
 
+use gdk::Paintable;
 use glib::translate::*;
 
 use crate::{ffi, prelude::*, subclass::prelude::*, MediaStream};
 
-pub trait MediaStreamImpl: ObjectImpl + ObjectSubclass<Type: IsA<MediaStream>> {
+pub trait MediaStreamImpl:
+    ObjectImpl + ObjectSubclass<Type: IsA<MediaStream> + IsA<Paintable>>
+{
     fn pause(&self) {
         self.parent_pause()
     }

--- a/gtk4/src/subclass/popover.rs
+++ b/gtk4/src/subclass/popover.rs
@@ -5,9 +5,11 @@
 
 use glib::translate::*;
 
-use crate::{ffi, prelude::*, subclass::prelude::*, Popover};
+use crate::{ffi, prelude::*, subclass::prelude::*, Native, Popover, ShortcutManager};
 
-pub trait PopoverImpl: WidgetImpl + ObjectSubclass<Type: IsA<Popover>> {
+pub trait PopoverImpl:
+    WidgetImpl + ObjectSubclass<Type: IsA<Popover> + IsA<Native> + IsA<ShortcutManager>>
+{
     fn activate_default(&self) {
         self.parent_activate_default()
     }

--- a/gtk4/src/subclass/print_operation.rs
+++ b/gtk4/src/subclass/print_operation.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 pub trait PrintOperationImpl:
-    PrintOperationPreviewImpl + ObjectSubclass<Type: IsA<PrintOperation>>
+    ObjectImpl + ObjectSubclass<Type: IsA<PrintOperation> + IsA<PrintOperationPreview>>
 {
     fn begin_print(&self, context: &PrintContext) {
         self.parent_begin_print(context)

--- a/gtk4/src/subclass/range.rs
+++ b/gtk4/src/subclass/range.rs
@@ -5,9 +5,9 @@
 
 use glib::translate::*;
 
-use crate::{ffi, prelude::*, subclass::prelude::*, Border, Range, ScrollType};
+use crate::{ffi, prelude::*, subclass::prelude::*, Border, Orientable, Range, ScrollType};
 
-pub trait RangeImpl: WidgetImpl + ObjectSubclass<Type: IsA<Range>> {
+pub trait RangeImpl: WidgetImpl + ObjectSubclass<Type: IsA<Range> + IsA<Orientable>> {
     fn adjust_bounds(&self, new_value: f64) {
         self.parent_adjust_bounds(new_value)
     }

--- a/gtk4/src/subclass/scale.rs
+++ b/gtk4/src/subclass/scale.rs
@@ -5,9 +5,9 @@
 
 use glib::translate::*;
 
-use crate::{ffi, prelude::*, subclass::prelude::*, Scale};
+use crate::{ffi, prelude::*, subclass::prelude::*, Orientable, Scale};
 
-pub trait ScaleImpl: RangeImpl + ObjectSubclass<Type: IsA<Scale>> {
+pub trait ScaleImpl: RangeImpl + ObjectSubclass<Type: IsA<Scale> + IsA<Orientable>> {
     #[doc(alias = "get_layout_offsets")]
     fn layout_offsets(&self) -> (i32, i32) {
         self.parent_layout_offsets()

--- a/gtk4/src/subclass/scale_button.rs
+++ b/gtk4/src/subclass/scale_button.rs
@@ -5,9 +5,11 @@
 
 use glib::translate::*;
 
-use crate::{ffi, prelude::*, subclass::prelude::*, ScaleButton};
+use crate::{ffi, prelude::*, subclass::prelude::*, Orientable, ScaleButton};
 
-pub trait ScaleButtonImpl: WidgetImpl + ObjectSubclass<Type: IsA<ScaleButton>> {
+pub trait ScaleButtonImpl:
+    WidgetImpl + ObjectSubclass<Type: IsA<ScaleButton> + IsA<Orientable>>
+{
     fn value_changed(&self, new_value: f64) {
         self.parent_value_changed(new_value)
     }

--- a/gtk4/src/subclass/text_view.rs
+++ b/gtk4/src/subclass/text_view.rs
@@ -6,11 +6,11 @@
 use glib::translate::*;
 
 use crate::{
-    ffi, prelude::*, subclass::prelude::*, DeleteType, MovementStep, Snapshot, TextExtendSelection,
-    TextIter, TextView, TextViewLayer,
+    ffi, prelude::*, subclass::prelude::*, DeleteType, MovementStep, Scrollable, Snapshot,
+    TextExtendSelection, TextIter, TextView, TextViewLayer,
 };
 
-pub trait TextViewImpl: WidgetImpl + ObjectSubclass<Type: IsA<TextView>> {
+pub trait TextViewImpl: WidgetImpl + ObjectSubclass<Type: IsA<TextView> + IsA<Scrollable>> {
     fn backspace(&self) {
         self.parent_backspace()
     }

--- a/gtk4/src/subclass/toggle_button.rs
+++ b/gtk4/src/subclass/toggle_button.rs
@@ -5,9 +5,11 @@
 
 use glib::translate::*;
 
-use crate::{ffi, prelude::*, subclass::prelude::*, ToggleButton};
+use crate::{ffi, prelude::*, subclass::prelude::*, Actionable, ToggleButton};
 
-pub trait ToggleButtonImpl: ButtonImpl + ObjectSubclass<Type: IsA<ToggleButton>> {
+pub trait ToggleButtonImpl:
+    ButtonImpl + ObjectSubclass<Type: IsA<ToggleButton> + IsA<Actionable>>
+{
     fn toggled(&self) {
         self.parent_toggled()
     }

--- a/gtk4/src/subclass/tree_view.rs
+++ b/gtk4/src/subclass/tree_view.rs
@@ -6,13 +6,13 @@
 use glib::translate::*;
 
 use crate::{
-    ffi, prelude::*, subclass::prelude::*, MovementStep, TreeIter, TreePath, TreeView,
+    ffi, prelude::*, subclass::prelude::*, MovementStep, Scrollable, TreeIter, TreePath, TreeView,
     TreeViewColumn,
 };
 
 #[cfg_attr(feature = "v4_10", deprecated = "Since 4.10")]
 #[allow(deprecated)]
-pub trait TreeViewImpl: WidgetImpl + ObjectSubclass<Type: IsA<TreeView>> {
+pub trait TreeViewImpl: WidgetImpl + ObjectSubclass<Type: IsA<TreeView> + IsA<Scrollable>> {
     fn columns_changed(&self) {
         self.parent_columns_changed()
     }

--- a/gtk4/src/subclass/widget.rs
+++ b/gtk4/src/subclass/widget.rs
@@ -8,9 +8,9 @@ use std::{boxed::Box as Box_, collections::HashMap, fmt, future::Future};
 use glib::{clone::Downgrade, subclass::SignalId, translate::*, GString, Variant};
 
 use crate::{
-    ffi, prelude::*, subclass::prelude::*, AccessibleRole, BuilderRustScope, BuilderScope,
-    DirectionType, LayoutManager, Orientation, Shortcut, SizeRequestMode, Snapshot, StateFlags,
-    SystemSetting, TextDirection, Tooltip, Widget,
+    ffi, prelude::*, subclass::prelude::*, Accessible, AccessibleRole, Buildable, BuilderRustScope,
+    BuilderScope, ConstraintTarget, DirectionType, LayoutManager, Orientation, Shortcut,
+    SizeRequestMode, Snapshot, StateFlags, SystemSetting, TextDirection, Tooltip, Widget,
 };
 
 #[derive(Debug, Default)]
@@ -104,7 +104,10 @@ impl Iterator for WidgetActionIter {
 
 impl std::iter::FusedIterator for WidgetActionIter {}
 
-pub trait WidgetImpl: ObjectImpl + ObjectSubclass<Type: IsA<Widget>> {
+pub trait WidgetImpl:
+    ObjectImpl
+    + ObjectSubclass<Type: IsA<Widget> + IsA<Accessible> + IsA<Buildable> + IsA<ConstraintTarget>>
+{
     fn compute_expand(&self, hexpand: &mut bool, vexpand: &mut bool) {
         self.parent_compute_expand(hexpand, vexpand)
     }

--- a/gtk4/src/subclass/window.rs
+++ b/gtk4/src/subclass/window.rs
@@ -5,9 +5,11 @@
 
 use glib::translate::*;
 
-use crate::{ffi, prelude::*, subclass::prelude::*, Window};
+use crate::{ffi, prelude::*, subclass::prelude::*, Native, Root, ShortcutManager, Window};
 
-pub trait WindowImpl: WidgetImpl + ObjectSubclass<Type: IsA<Window>> {
+pub trait WindowImpl:
+    WidgetImpl + ObjectSubclass<Type: IsA<Window> + IsA<Native> + IsA<Root> + IsA<ShortcutManager>>
+{
     fn activate_focus(&self) {
         self.parent_activate_focus()
     }


### PR DESCRIPTION
**What this does**

- Require everyone to specify the `@implements` directive for all interfaces that are implemented by the object, even interfaces implemented by the parent. (positive check)

**What this doesn't do**

- Check whether the interface is *actually* implemented (negative check), you can still write whatever in the `wrapper` macro and nothing checks this. This is a hard problem, and if at all only solveable at runtime. (not sure how, but it could be possible by doing some assertions on type_init maybe, needs more research)
- I think the error messages could be better, which would be possible by adding `#[diagnostic::on_unimplemented]` for the IsA trait (it is stable since 1.78).

See also https://github.com/gtk-rs/gtk-rs-core/pull/1551