### PR TITLE
Remove `using Gtk 4.0` declaration from blueprint include

### DIFF
--- a/gtk4-macros/src/blueprint.rs
+++ b/gtk4-macros/src/blueprint.rs
@@ -14,7 +14,6 @@ pub(crate) fn compile_blueprint(blueprint: &[u8]) -> Result<String> {
         .unwrap_or_else(|_| panic!("blueprint-compiler not found"));
 
     let mut stdin = compiler.stdin.take().unwrap();
-    stdin.write_all(b"using Gtk 4.0;\n")?;
     stdin.write_all(blueprint)?;
     drop(stdin);
 

--- a/gtk4-macros/tests/my_widget.blp
+++ b/gtk4-macros/tests/my_widget.blp
@@ -1,3 +1,5 @@
+using Gtk 4.0;
+
 template $MyWidget5 {
     Label label {
         label: 'foobar';

--- a/gtk4-macros/tests/templates.rs
+++ b/gtk4-macros/tests/templates.rs
@@ -212,6 +212,8 @@ mod imp4 {
 
     #[derive(Debug, Default, gtk::CompositeTemplate)]
     #[template(string = "
+    using Gtk 4.0;
+
     template $MyWidget4 : Widget {
         Label label {
             label: 'foobar';


### PR DESCRIPTION
Fix for #1933. Should make IDE completion usable again with Blueprint files.