### PR TITLE
gdk4-macos: manually implement native_window method

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -59,14 +59,14 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --features v4_8 --manifest-path ./gdk4-macos/Cargo.toml
+          args: --features cocoa,v4_8 --manifest-path ./gdk4-macos/Cargo.toml
       - name: Clippy gdk4-macos
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --features v4_8 --manifest-path ./gdk4-macos/Cargo.toml
+          args: --features cocoa,v4_8 --manifest-path ./gdk4-macos/Cargo.toml
       - name: Tests gdk4-macos
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --features v4_8 --manifest-path ./gdk4-macos/Cargo.toml
+          args: --features cocoa,v4_8 --manifest-path ./gdk4-macos/Cargo.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,6 +218,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "cocoa"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79398230a6e2c08f5c9760610eb6924b52aa9e7950a619602baba59dcbbdbb2"
+dependencies = [
+ "bitflags 2.6.0",
+ "block",
+ "cocoa-foundation",
+ "core-foundation",
+ "core-graphics",
+ "foreign-types",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa-foundation"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14045fb83be07b5acf1c0884b2180461635b433455fa35d1cd6f17f1450679d"
+dependencies = [
+ "bitflags 2.6.0",
+ "block",
+ "core-foundation",
+ "core-graphics-types",
+ "libc",
+ "objc",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,10 +263,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation",
+ "libc",
+]
 
 [[package]]
 name = "core_maths"
@@ -367,6 +437,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +577,7 @@ dependencies = [
 name = "gdk4-macos"
 version = "0.10.0"
 dependencies = [
+ "cocoa",
  "gdk4",
  "gdk4-macos-sys",
  "gio",
@@ -1314,6 +1412,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,6 +1468,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
 ]
 
 [[package]]

--- a/gdk4-macos/Cargo.toml
+++ b/gdk4-macos/Cargo.toml
@@ -15,6 +15,7 @@ version.workspace = true
 
 [features]
 v4_8 = ["gdk4-macos-sys/v4_8"]
+cocoa = ["dep:cocoa"]
 
 [dependencies]
 gdk4-macos-sys.workspace = true
@@ -22,6 +23,7 @@ gdk.workspace = true
 gio.workspace = true
 glib.workspace = true
 libc.workspace = true
+cocoa = { version = "0.26", default-features = false, optional = true }
 
 [dev-dependencies]
 gir-format-check.workspace = true

--- a/gdk4-macos/Gir.toml
+++ b/gdk4-macos/Gir.toml
@@ -17,7 +17,6 @@ generate = [
     "GdkMacos.MacosGLContext",
     "GdkMacos.MacosKeymap",
     "GdkMacos.MacosSeat",
-    "GdkMacos.MacosSurface",
 ]
 
 manual = [
@@ -37,3 +36,14 @@ status = "generate"
     [[object.function]]
     name = "get_geometry"
     ignore = true # The function does not exists
+
+[[object]]
+name = "GdkMacos.MacosSurface"
+status = "generate"
+    [[object.function]]
+    name = "get_native_window"
+    manual = true
+    rename = "native"
+    [[object.property]]
+    name = "native"
+    generate = ["notify"]

--- a/gdk4-macos/README.md
+++ b/gdk4-macos/README.md
@@ -27,7 +27,7 @@ If you want to track the bleeding edge, use the git dependency instead:
 
 ```toml
 [dependencies]
-gdk-wayland = { git = "https://github.com/gtk-rs/gtk4-rs.git", package = "gdk4-wayland" }
+gdk-macos = { git = "https://github.com/gtk-rs/gtk4-rs.git", package = "gdk4-macos" }
 ```
 
 Avoid mixing versioned and git crates like this:

--- a/gdk4-macos/README.md
+++ b/gdk4-macos/README.md
@@ -44,6 +44,7 @@ gdk-wayland = { git = "https://github.com/gtk-rs/gtk4-rs.git", package = "gdk4-w
 | Feature | Description |
 | ---     | ----------- |
 | `v4_8` | Enable the new APIs part of GTK 4.8 |
+| `cocoa` | Integration with the [cocoa](https://crates.io/crates/cocoa) crate |
 
 ### See Also
 

--- a/gdk4-macos/src/auto/macos_surface.rs
+++ b/gdk4-macos/src/auto/macos_surface.rs
@@ -20,18 +20,6 @@ glib::wrapper! {
 }
 
 impl MacosSurface {
-    //#[cfg(feature = "v4_8")]
-    //#[cfg_attr(docsrs, doc(cfg(feature = "v4_8")))]
-    //#[doc(alias = "gdk_macos_surface_get_native_window")]
-    //#[doc(alias = "get_native_window")]
-    //pub fn native_window(&self) -> /*Unimplemented*/Option<Basic: Pointer> {
-    //    unsafe { TODO: call ffi:gdk_macos_surface_get_native_window() }
-    //}
-
-    //pub fn native(&self) -> /*Unimplemented*/Basic: Pointer {
-    //    ObjectExt::property(self, "native")
-    //}
-
     #[doc(alias = "native")]
     pub fn connect_native_notify<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
         unsafe extern "C" fn notify_native_trampoline<F: Fn(&MacosSurface) + 'static>(

--- a/gdk4-macos/src/lib.rs
+++ b/gdk4-macos/src/lib.rs
@@ -4,6 +4,9 @@
 #![allow(deprecated)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+#[cfg(not(feature = "cocoa"))]
+use std::ffi::c_void;
+
 pub use gdk;
 pub use gdk4_macos_sys as ffi;
 pub use gio;
@@ -16,3 +19,12 @@ mod auto;
 pub mod prelude;
 
 pub use auto::*;
+
+mod macos_surface;
+
+#[cfg(not(feature = "cocoa"))]
+#[allow(non_camel_case_types)]
+pub type id = *mut c_void;
+
+#[cfg(feature = "cocoa")]
+pub use cocoa::base::id;

--- a/gdk4-macos/src/macos_surface.rs
+++ b/gdk4-macos/src/macos_surface.rs
@@ -1,0 +1,29 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+#[cfg(feature = "v4_8")]
+use crate::ffi;
+#[cfg(not(feature = "v4_8"))]
+use crate::prelude::*;
+use crate::{id, MacosSurface};
+#[cfg(feature = "v4_8")]
+use glib::translate::*;
+#[cfg(not(feature = "v4_8"))]
+use std::ffi::c_void;
+
+impl MacosSurface {
+    #[doc(alias = "gdk_macos_surface_get_native_window")]
+    #[doc(alias = "get_native_window")]
+    pub fn native(&self) -> id {
+        #[cfg(feature = "v4_8")]
+        unsafe {
+            let native_window_ptr = ffi::gdk_macos_surface_get_native_window(self.to_glib_none().0);
+            native_window_ptr as id
+        }
+
+        #[cfg(not(feature = "v4_8"))]
+        {
+            let native_window_ptr: *mut c_void = ObjectExt::property(self, "native");
+            native_window_ptr as id
+        }
+    }
+}


### PR DESCRIPTION
For now we need to depend on the cocoa crate in order to implement this method since it is the only decent crate implementing the cocoa api.