### PR TITLE
gtk: don't leak snapshots

### DIFF
--- a/gtk4/Gir.toml
+++ b/gtk4/Gir.toml
@@ -2081,19 +2081,20 @@ status = "generate"
 final_type = false
 manual_traits = ["SnapshotExtManual"]
     [[object.function]]
-    pattern = "free_to_(node|paintable)"
-    ignore = true # C convenience functions
-    [[object.function]]
     name = "append_border"
     manual = true
     [[object.function]]
     name = "push_debug"
     manual = true # ignore format args
     [[object.function]]
+    pattern = "free_to_node"
+    rename = "to_node"
+    [[object.function]]
+    pattern = "free_to_paintable"
+    rename = "to_paintable"
+    [[object.function]]
     pattern = "to_(node|paintable)"
-        [[object.function.parameter]]
-        name = "snapshot"
-        move = true
+    ignore = true
 
 [[object]]
 name = "Gtk.SortListModel"

--- a/gtk4/src/auto/snapshot.rs
+++ b/gtk4/src/auto/snapshot.rs
@@ -295,6 +295,27 @@ pub trait SnapshotExt: IsA<Snapshot> + 'static {
         }
     }
 
+    #[doc(alias = "gtk_snapshot_free_to_node")]
+    #[doc(alias = "free_to_node")]
+    fn to_node(self) -> Option<gsk::RenderNode> {
+        unsafe {
+            from_glib_full(ffi::gtk_snapshot_free_to_node(
+                self.upcast().into_glib_ptr(),
+            ))
+        }
+    }
+
+    #[doc(alias = "gtk_snapshot_free_to_paintable")]
+    #[doc(alias = "free_to_paintable")]
+    fn to_paintable(self, size: Option<&graphene::Size>) -> Option<gdk::Paintable> {
+        unsafe {
+            from_glib_full(ffi::gtk_snapshot_free_to_paintable(
+                self.upcast().into_glib_ptr(),
+                size.to_glib_none().0,
+            ))
+        }
+    }
+
     #[cfg_attr(feature = "v4_16", deprecated = "Since 4.16")]
     #[allow(deprecated)]
     #[doc(alias = "gtk_snapshot_gl_shader_pop_texture")]
@@ -614,21 +635,6 @@ pub trait SnapshotExt: IsA<Snapshot> + 'static {
                 factor_y,
                 factor_z,
             );
-        }
-    }
-
-    #[doc(alias = "gtk_snapshot_to_node")]
-    fn to_node(self) -> Option<gsk::RenderNode> {
-        unsafe { from_glib_full(ffi::gtk_snapshot_to_node(self.upcast().into_glib_ptr())) }
-    }
-
-    #[doc(alias = "gtk_snapshot_to_paintable")]
-    fn to_paintable(self, size: Option<&graphene::Size>) -> Option<gdk::Paintable> {
-        unsafe {
-            from_glib_full(ffi::gtk_snapshot_to_paintable(
-                self.upcast().into_glib_ptr(),
-                size.to_glib_none().0,
-            ))
         }
     }
 


### PR DESCRIPTION
Not much to it really, for some reason we bound `to_{node,paintable}` as if it were `free_to_{node,paintable}` and thus leaked snapshots all over the place.

Bind `free_to_{node,paintable}` instead.