### PR TITLE
gtk4-macros: Fix link to Blueprint homepage

### DIFF
--- a/gtk4-macros/src/lib.rs
+++ b/gtk4-macros/src/lib.rs
@@ -144,7 +144,7 @@ pub fn include_blueprint(input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// The [`CompositeTemplate`] macro can also be used with [Blueprint](https://jwestman.pages.gitlab.gnome.org/blueprint-compiler/)
+/// The [`CompositeTemplate`] macro can also be used with [Blueprint](https://gnome.pages.gitlab.gnome.org/blueprint-compiler/)
 /// if the feature `blueprint` is enabled.
 /// you can use `string` or `file` relative to the project directory but not
 /// `resource`


### PR DESCRIPTION
Since Blueprint has moved to the GNOME namespace on GitLab, the previous link didn't work anymore.