### PR TITLE
Fix Panic due to wrong image path in examples/clipboard

### DIFF
--- a/examples/clipboard/main.rs
+++ b/examples/clipboard/main.rs
@@ -107,7 +107,7 @@ fn build_ui(application: &gtk::Application) {
         .spacing(24)
         .build();
 
-    let file = gio::File::for_path("./examples/clipboard/asset.png");
+    let file = gio::File::for_path("./clipboard/asset.png");
     let asset_paintable = gdk::Texture::from_file(&file).unwrap();
 
     let image_from = gtk::Image::builder()


### PR DESCRIPTION
Updated with correct image path to FIX **Panic Error:**

thread 'main' panicked at examples\clipboard\main.rs:111:58:
called `Result::unwrap()` on an `Err` value: Error { domain: g-io-error-quark, code: 1, message: "Error opening file C:\\github.com\\gtk-rs\\gtk4-rs\\examples\\examples\\clipboard\\asset.png: No such file or directory" }