### PR TITLE
gtk: add gnome_49 features

### DIFF
--- a/gtk4/Cargo.toml
+++ b/gtk4/Cargo.toml
@@ -35,6 +35,7 @@ unsafe-assume-initialized = []
 # Versions from https://gitlab.gnome.org/GNOME/gnome-build-meta/-/tree/gnome-43/elements/sdk
 # gtk takes care of setting the versions of gsk and gdk
 # gio takes care of setting the version of glib
+gnome_49 = ["v4_20", "gio/v2_86", "gnome_48"]
 gnome_48 = ["v4_18", "gio/v2_84", "gnome_47"]
 gnome_47 = ["v4_16", "gio/v2_82", "gnome_46"]
 gnome_46 = ["v4_14", "cairo-rs/v1_16", "pango/v1_52", "gdk-pixbuf/v2_42", "gio_v2_80"]

--- a/gtk4/README.md
+++ b/gtk4/README.md
@@ -192,6 +192,7 @@ gtk = { git = "https://github.com/gtk-rs/gtk4-rs.git", package = "gtk4" }
 | `v4_6` | Enable the new APIs part of GTK 4.6 |
 | `v4_4` | Enable the new APIs part of GTK 4.4 |
 | `v4_2` | Enable the new APIs part of GTK 4.2 |
+| `gnome_49` | Enable all version feature flags of this crate and its dependencies to match the GNOME 49 SDK |
 | `gnome_48` | Enable all version feature flags of this crate and its dependencies to match the GNOME 48 SDK |
 | `gnome_47` | Enable all version feature flags of this crate and its dependencies to match the GNOME 47 SDK |
 | `gnome_46` | Enable all version feature flags of this crate and its dependencies to match the GNOME 46 SDK |


### PR DESCRIPTION
Just adding `gnome_49`'s features to `gtk`'s Cargo.toml, and to the README file as well.