### PR TITLE
gtk: Do not assume parent impl of `GLArea.create_context` returns non-null pointer

### DIFF
--- a/gtk4/src/subclass/gl_area.rs
+++ b/gtk4/src/subclass/gl_area.rs
@@ -30,11 +30,7 @@ pub trait GLAreaImplExt: GLAreaImpl {
             let data = Self::type_data();
             let parent_class = data.as_ref().parent_class() as *mut ffi::GtkGLAreaClass;
             if let Some(f) = (*parent_class).create_context {
-                return Some(from_glib_none(f(self
-                    .obj()
-                    .unsafe_cast_ref::<GLArea>()
-                    .to_glib_none()
-                    .0)));
+                return from_glib_none(f(self.obj().unsafe_cast_ref::<GLArea>().to_glib_none().0));
             };
             None
         }


### PR DESCRIPTION
Fixes GL context creation failure causing a panic (if debug assertions are enabled) or UB (otherwise).

```
thread 'main' panicked at /home/USER/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/gdk4-0.10.1/src/auto/gl_context.rs:18:1:
assertion failed: !ptr.is_null()
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:697:5
   1: core::panicking::panic_fmt
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/panicking.rs:75:14
   2: core::panicking::panic
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/panicking.rs:145:5
   3: <gdk4::auto::gl_context::GLContext as glib::translate::FromGlibPtrNone<*mut gdk4_sys::GdkGLContext>>::from_glib_none
             at /home/USER/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/glib-0.21.3/src/object.rs:899:17
   4: glib::translate::from_glib_none
             at /home/USER/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/glib-0.21.3/src/translate.rs:1630:5
   5: gtk4::subclass::gl_area::GLAreaImplExt::parent_create_context
             at /home/USER/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/gtk4-0.10.1/src/subclass/gl_area.rs:33:29
   6: gtk4::subclass::gl_area::GLAreaImpl::create_context
             at /home/USER/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/gtk4-0.10.1/src/subclass/gl_area.rs:14:14
   7: gtk4::subclass::gl_area::gl_area_create_context
             at /home/USER/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/gtk4-0.10.1/src/subclass/gl_area.rs:91:9
```
