### PR TITLE
fix(gtk4): remove deprecated warnings on style_context methods

### DIFF
--- a/gtk4/src/style_context.rs
+++ b/gtk4/src/style_context.rs
@@ -5,8 +5,6 @@ use glib::translate::*;
 use crate::{ffi, prelude::*, StyleContext, StyleProvider};
 
 impl StyleContext {
-    #[deprecated(note = "Use gtk::style_context_add_provider_for_display instead.")]
-    #[doc(alias = "gtk_style_context_add_provider_for_display")]
     pub fn add_provider_for_display(
         display: &impl IsA<gdk::Display>,
         provider: &impl IsA<StyleProvider>,
@@ -22,8 +20,6 @@ impl StyleContext {
         }
     }
 
-    #[deprecated(note = "Use gtk::style_context_remove_provider_for_display instead.")]
-    #[doc(alias = "gtk_style_context_remove_provider_for_display")]
     pub fn remove_provider_for_display(
         display: &impl IsA<gdk::Display>,
         provider: &impl IsA<StyleProvider>,


### PR DESCRIPTION
The crate incorrectly marks the bindings to `gtk_style_context_add_provider_for_display` and `gtk_style_context_remove_provider_for_display` as deprecated, linking to the same methods as alternatives.

The official docs do not mark this functions as deprecated:
https://docs.gtk.org/gtk4/type_func.StyleContext.add_provider_for_display.html
https://docs.gtk.org/gtk4/type_func.StyleContext.remove_provider_for_display.html

