### PR TITLE
ci: enhance Docker workflow with QEMU and Buildx setup

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -28,6 +28,12 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to the Container registry
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
         with:
@@ -49,6 +55,7 @@ jobs:
         with:
           push: ${{ github.event_name != 'pull_request' }}
           context: .
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 


### PR DESCRIPTION
Added steps to set up QEMU and Docker Buildx in the GitHub Actions workflow for improved multi-platform builds. Updated the platforms to include linux/amd64 and linux/arm64.