### PR TITLE
gdk-x11: Use dynamically linked variant of x11 crate

### DIFF
--- a/gdk4-x11/Cargo.toml
+++ b/gdk4-x11/Cargo.toml
@@ -27,7 +27,7 @@ gdk.workspace = true
 gio.workspace = true
 glib.workspace = true
 libc.workspace = true
-x11 = {version = "2.20", optional = true }
+x11 = {package = "x11-dl", version = "2.20", optional = true }
 khronos-egl = {version = "6.0", optional = true}
 
 [dev-dependencies]


### PR DESCRIPTION
The other one is statically linked and causes issues...