### PR TITLE
book: use `Rc::clone` to make reference-counting explicit

### DIFF
--- a/book/listings/g_object_memory_management/2/main.rs
+++ b/book/listings/g_object_memory_management/2/main.rs
@@ -38,7 +38,7 @@ fn build_ui(app: &Application) {
     let number = Rc::new(Cell::new(0));
 
     // Connect callbacks, when a button is clicked `number` will be changed
-    let number_copy = number.clone();
+    let number_copy = Rc::clone(&number);
     button_increase.connect_clicked(move |_| number_copy.set(number_copy.get() + 1));
     button_decrease.connect_clicked(move |_| number.set(number.get() - 1));
     // ANCHOR_END: callback


### PR DESCRIPTION
>  By using Rc::clone for reference counting, we can visually distinguish between the deep-copy kinds of clones and the kinds of clones that increase the reference count. 

The Rust Programming Language, p. 640