### PR TITLE
Fix ownership handling in Cursor::from_callback callback return value

### DIFF
--- a/gdk4/src/cursor.rs
+++ b/gdk4/src/cursor.rs
@@ -41,9 +41,7 @@ impl Cursor {
                     &mut *hotspot_x,
                     &mut *hotspot_y,
                 )
-                /*Not checked*/
-                .to_glib_none()
-                .0
+                .to_glib_full()
             }
         }
         let callback = Some(callback_func::<P> as _);


### PR DESCRIPTION
When using Cursor::from_callback, I got a crash.
For example code, see:
https://github.com/gtk-rs/gtk4-rs/discussions/2205

With the help of an AI, I discovered, that ownership is not handled correctly in the wrapper code for the callback.
According to [GDK docs](https://docs.gtk.org/gdk4/callback.CursorGetTextureCallback.html) the caller of the callback takes ownership of the texture, that is return. Put the code uses to_glib_none, which does not pass the ownership on.

I verified, that the crash indeed disappears after applying the proposed change.
