### PR TITLE
gtk: Restore widget class methods on WidgetClassExt

### DIFF
--- a/gtk4/src/subclass/widget.rs
+++ b/gtk4/src/subclass/widget.rs
@@ -15,7 +15,7 @@ use glib::{
 
 use crate::{
     AccessibleRole, Buildable, BuilderRustScope, BuilderScope, ConstraintTarget, DirectionType,
-    LayoutManager, Orientation, SizeRequestMode, Snapshot, StateFlags, SystemSetting,
+    LayoutManager, Orientation, Shortcut, SizeRequestMode, Snapshot, StateFlags, SystemSetting,
     TextDirection, Tooltip, Widget, ffi, prelude::*, subclass::prelude::*,
 };
 
@@ -1077,6 +1077,12 @@ pub unsafe trait WidgetClassExt: ClassStruct {
         }
     }
 
+    #[doc(alias = "gtk_widget_class_query_action")]
+    fn query_action(&self) -> WidgetActionIter {
+        let widget_class = self as *const _ as *mut ffi::GtkWidgetClass;
+        WidgetActionIter::new(widget_class)
+    }
+
     #[doc(alias = "gtk_widget_class_set_template_scope")]
     fn set_template_scope<S: IsA<BuilderScope>>(&mut self, scope: &S) {
         unsafe {
@@ -1102,10 +1108,16 @@ pub unsafe trait WidgetClassExt: ClassStruct {
                 },
             )),
         );
-        unsafe {
-            let widget_class = self as *mut _ as *mut ffi::GtkWidgetClass;
-            ffi::gtk_widget_class_add_shortcut(widget_class, shortcut.to_glib_none().0);
-        }
+        self.add_shortcut(&shortcut);
+    }
+
+    #[doc(alias = "gtk_widget_class_add_binding_action")]
+    fn add_binding_action(&mut self, keyval: gdk::Key, mods: gdk::ModifierType, action_name: &str) {
+        let shortcut = crate::Shortcut::new(
+            Some(crate::KeyvalTrigger::new(keyval, mods)),
+            Some(crate::NamedAction::new(action_name)),
+        );
+        self.add_shortcut(&shortcut);
     }
 
     #[doc(alias = "gtk_widget_class_add_binding_signal")]
@@ -1120,9 +1132,40 @@ pub unsafe trait WidgetClassExt: ClassStruct {
             Some(crate::KeyvalTrigger::new(keyval, mods)),
             Some(crate::SignalAction::new(signal_name)),
         );
+        self.add_shortcut(&shortcut);
+    }
+
+    #[doc(alias = "gtk_widget_class_add_shortcut")]
+    fn add_shortcut(&mut self, shortcut: &Shortcut) {
         unsafe {
             let widget_class = self as *mut _ as *mut ffi::GtkWidgetClass;
             ffi::gtk_widget_class_add_shortcut(widget_class, shortcut.to_glib_none().0);
+        }
+    }
+
+    #[doc(alias = "gtk_widget_class_install_property_action")]
+    fn install_property_action(&mut self, action_name: &str, property_name: &str) {
+        unsafe {
+            let widget_class = self as *mut _ as *mut ffi::GtkWidgetClass;
+            ffi::gtk_widget_class_install_property_action(
+                widget_class,
+                action_name.to_glib_none().0,
+                property_name.to_glib_none().0,
+            );
+        }
+    }
+
+    #[doc(alias = "gtk_widget_class_get_activate_signal")]
+    #[doc(alias = "get_activate_signal")]
+    fn activate_signal(&self) -> Option<SignalId> {
+        unsafe {
+            let widget_class = self as *const _ as *mut ffi::GtkWidgetClass;
+            let signal_id = ffi::gtk_widget_class_get_activate_signal(widget_class);
+            if signal_id == 0 {
+                None
+            } else {
+                Some(from_glib(signal_id))
+            }
         }
     }
 
@@ -1162,6 +1205,15 @@ pub unsafe trait WidgetClassExt: ClassStruct {
         }
     }
 
+    #[doc(alias = "gtk_widget_class_get_layout_manager_type")]
+    #[doc(alias = "get_layout_manager_type")]
+    fn layout_manager_type(&self) -> glib::Type {
+        unsafe {
+            let widget_class = self as *const _ as *mut ffi::GtkWidgetClass;
+            from_glib(ffi::gtk_widget_class_get_layout_manager_type(widget_class))
+        }
+    }
+
     #[doc(alias = "gtk_widget_class_set_css_name")]
     fn set_css_name(&mut self, name: &str) {
         unsafe {
@@ -1170,11 +1222,29 @@ pub unsafe trait WidgetClassExt: ClassStruct {
         }
     }
 
+    #[doc(alias = "gtk_widget_class_get_css_name")]
+    #[doc(alias = "get_css_name")]
+    fn css_name(&self) -> glib::GString {
+        unsafe {
+            let widget_class = self as *const _ as *mut ffi::GtkWidgetClass;
+            from_glib_none(ffi::gtk_widget_class_get_css_name(widget_class))
+        }
+    }
+
     #[doc(alias = "gtk_widget_class_set_accessible_role")]
     fn set_accessible_role(&mut self, role: AccessibleRole) {
         unsafe {
             let widget_class = self as *mut _ as *mut ffi::GtkWidgetClass;
             ffi::gtk_widget_class_set_accessible_role(widget_class, role.into_glib());
+        }
+    }
+
+    #[doc(alias = "gtk_widget_class_get_accessible_role")]
+    #[doc(alias = "get_accessible_role")]
+    fn accessible_role(&self) -> AccessibleRole {
+        unsafe {
+            let widget_class = self as *const _ as *mut ffi::GtkWidgetClass;
+            from_glib(ffi::gtk_widget_class_get_accessible_role(widget_class))
         }
     }
 
@@ -1473,5 +1543,124 @@ impl<T: WidgetImpl + CompositeTemplate> CompositeTemplateDisposeExt for T {
                 <T as ObjectSubclass>::Type::static_type().into_glib(),
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{self as gtk4};
+
+    // Regression test for https://github.com/gtk-rs/gtk4-rs/issues/2345:
+    // widget class methods must stay callable on a custom `ClassStruct`, not
+    // only on `glib::Class<T>`.
+    mod imp {
+        use super::*;
+
+        #[derive(Default)]
+        pub struct CustomClassWidget;
+
+        #[glib::object_subclass]
+        impl ObjectSubclass for CustomClassWidget {
+            const NAME: &'static str = "GtkRsTestCustomClassWidget";
+            type Type = super::CustomClassWidget;
+            type ParentType = Widget;
+            type Class = super::CustomClassWidgetClass;
+
+            fn class_init(klass: &mut Self::Class) {
+                klass.set_css_name("gtkrstestcustomclasswidget");
+                klass.set_accessible_role(AccessibleRole::Group);
+                klass.set_layout_manager_type::<crate::BinLayout>();
+
+                klass.install_property_action("test.visible", "visible");
+                klass.add_binding_action(
+                    gdk::Key::a,
+                    gdk::ModifierType::CONTROL_MASK,
+                    "test.visible",
+                );
+                klass.add_shortcut(&crate::Shortcut::new(
+                    Some(crate::KeyvalTrigger::new(
+                        gdk::Key::b,
+                        gdk::ModifierType::CONTROL_MASK,
+                    )),
+                    Some(crate::NamedAction::new("test.visible")),
+                ));
+
+                // The `&self` getters must be callable on a custom class struct
+                // too. Deliberately no assertions here: a panic inside
+                // `class_init()` unwinds across an `extern "C"` boundary and
+                // aborts the whole test binary instead of reporting a single
+                // failed test. Every value below is read back and asserted on
+                // in the test body, where a failure is reported normally.
+                let _ = klass.css_name();
+                let _ = klass.accessible_role();
+                let _ = klass.layout_manager_type();
+                let _ = klass.activate_signal();
+                let _ = klass.query_action();
+            }
+        }
+
+        impl ObjectImpl for CustomClassWidget {}
+        impl WidgetImpl for CustomClassWidget {}
+    }
+
+    #[cfg(feature = "v4_10")]
+    glib::wrapper! {
+        pub struct CustomClassWidget(ObjectSubclass<imp::CustomClassWidget>)
+            @extends gtk4::Widget,
+            @implements gtk4::Accessible, gtk4::Buildable, gtk4::ConstraintTarget;
+    }
+
+    #[cfg(not(feature = "v4_10"))]
+    glib::wrapper! {
+        pub struct CustomClassWidget(ObjectSubclass<imp::CustomClassWidget>)
+            @extends gtk4::Widget,
+            @implements gtk4::Buildable, gtk4::ConstraintTarget;
+    }
+
+    // A user-defined class struct, i.e. *not* `glib::Class<Self>`. It
+    // deliberately has no `Deref` impl, so nothing can be reached through
+    // auto-deref.
+    #[repr(C)]
+    pub struct CustomClassWidgetClass {
+        pub parent_class: ffi::GtkWidgetClass,
+    }
+
+    unsafe impl ClassStruct for CustomClassWidgetClass {
+        type Type = imp::CustomClassWidget;
+    }
+
+    #[crate::test]
+    fn class_methods_on_custom_class_struct() {
+        // Instantiating runs `class_init()`, which is where the class methods
+        // are called on the custom class struct.
+        let widget = glib::Object::new::<CustomClassWidget>();
+
+        // Read the results back through `glib::Class<T>`, which is what
+        // https://github.com/gtk-rs/gtk4-rs/pull/2319 added. This checks both
+        // trait impls against the same `GtkWidgetClass`.
+        let class = widget.class();
+        assert_eq!(class.css_name(), "gtkrstestcustomclasswidget");
+        assert_eq!(class.accessible_role(), AccessibleRole::Group);
+        assert_eq!(class.layout_manager_type(), crate::BinLayout::static_type());
+        assert!(class.activate_signal().is_none());
+
+        // `query_action()` also enumerates actions inherited from parent
+        // classes, so only assert that the action we installed is present --
+        // a future GTK may well add class actions to `GtkWidget` itself.
+        let actions: Vec<_> = class.query_action().map(|a| a.name().to_owned()).collect();
+        assert!(
+            actions.iter().any(|name| name == "test.visible"),
+            "installed action missing from {actions:?}"
+        );
+
+        // ... and on a class looked up by type rather than via an instance.
+        // Deliberately our own test type: `from_type()` hands out the
+        // process-global class, so binding a shortcut on e.g. `GtkTextView`
+        // here would leak into every other test in this binary.
+        let class = glib::Class::<CustomClassWidget>::from_type(CustomClassWidget::static_type())
+            .expect("CustomClassWidget class");
+        class.add_binding_action(gdk::Key::c, gdk::ModifierType::CONTROL_MASK, "test.visible");
+        assert!(class.query_action().any(|a| a.name() == "test.visible"));
     }
 }

--- a/gtk4/src/widget.rs
+++ b/gtk4/src/widget.rs
@@ -95,6 +95,13 @@ impl TickCallbackId {
 /// This trait is implemented for `glib::Class<T>` for any `T: IsA<Widget>`
 /// (e.g., `Class<Widget>`, `Class<TextView>`, `Class<Button>`).
 ///
+/// Inside [`ObjectSubclass::class_init()`](glib::subclass::types::ObjectSubclass::class_init)
+/// the same methods are provided by
+/// [`WidgetClassExt`](crate::subclass::widget::WidgetClassExt), which is
+/// implemented for every [`ClassStruct`](glib::subclass::types::ClassStruct)
+/// whose type implements [`WidgetImpl`](crate::subclass::widget::WidgetImpl) --
+/// including user-defined class structs.
+///
 /// # Example
 ///
 /// ```no_run


### PR DESCRIPTION
Fixes #2345.

## What broke

Since **0.11.4**, a widget subclass that uses a custom class struct can no longer call `add_binding_action` (or seven sibling methods) from `ObjectSubclass::class_init()`:

```
error[E0599]: no method named `add_binding_action` found for mutable reference `&mut TestClass` in the current scope
   = note: the following trait defines an item `add_binding_action`, perhaps you need to implement it:
           candidate #1: `gtk4::prelude::WidgetClassManualExt`
```

0.11.0-0.11.3 have these methods on `WidgetClassExt` and no `WidgetClassManualExt`; 0.11.4 has the moved form. (`git tag --contains e38a336` is empty, so the version window was established by inspecting the released tags.)

The issue reports only `add_binding_action`, but **all eight** methods are affected: `add_shortcut`, `add_binding_action`, `install_property_action`, `query_action`, `activate_signal`, `layout_manager_type`, `css_name` and `accessible_role`.

## Root cause

e38a336 ("gtk: Allow calling Class methods on any widget", #2319, Fixes #1793) moved these eight methods from

```rust
pub unsafe trait WidgetClassExt: ClassStruct { fn add_binding_action(&mut self, ...) }
unsafe impl<T: ClassStruct> WidgetClassExt for T where T::Type: WidgetImpl {}
```

to

```rust
pub trait WidgetClassManualExt { fn add_binding_action(&self, ...); }
impl<T: IsA<Widget> + IsClass> WidgetClassManualExt for glib::Class<T> { ... }
```

The new impl is keyed on the concrete type constructor `glib::Class<_>`, not on a `ClassStruct` bound. Those are disjoint: in gtk-rs-core the *only* `ClassStruct` impl is `unsafe impl<T: ObjectSubclass> ClassStruct for basic::ClassStruct<T>`, and `glib::object::Class<T>` never implements `ClassStruct`. Subclasses with the **default** class struct kept working purely by accident of `impl Deref for basic::ClassStruct<T> { type Target = glib::Class<T::Type> }`, which lets method probing auto-deref one step into the new impl. A user-defined `#[repr(C)]` class struct has no such `Deref` obligation, so it matches neither impl.

Widening `WidgetClassManualExt` to cover both is impossible rather than merely awkward:

```
error[E0119]: conflicting implementations of trait `Foo` for type `Class<_>`
  = note: upstream crates may add a new impl of trait `ClassStruct` for type `glib::Class<_>` in future versions
```

Both types are foreign to `gtk4`, so no negative reasoning is available. The class-struct-side methods have to go back on `WidgetClassExt`.

## The fix

Restores the eight methods on `WidgetClassExt` and re-points `add_binding` / `add_binding_signal` at `add_shortcut` instead of duplicating the FFI call. `WidgetClassManualExt` is untouched, so everything #2319 gained still works; both of its use cases are asserted in the new test.

## One tradeoff, and I am happy either way

I restored the **0.11.3 signatures verbatim**, so `add_shortcut`, `add_binding_action` and `install_property_action` take `&mut self`. The alternative is `&self`, matching what `WidgetClassManualExt` already does on main.

`&mut self` (this PR) is the exact 0.11.3 restoration and is consistent with every other mutator on `WidgetClassExt` — note that `add_binding_signal(&mut self)` calls `add_shortcut`. Its cost is that this is *not* a strict superset of 0.11.4: calling a mutating class method through a **shared** reference to the default class struct, e.g. `fn f(k: &glib::subclass::basic::ClassStruct<T>) { k.add_binding_action(...) }`, compiles on 0.11.4 via the `Deref` but fails here with ``error[E0596]: cannot borrow `*k` as mutable``. That pattern did not compile on 0.11.3 either, `class_init` never hands you a shared reference, and `WidgetClassManualExt::add_binding_action(&**k, ...)` is a one-line escape hatch — but it is a real narrowing and I would rather flag it than hide it.

`&self` would be a strict superset of 0.11.3 and 0.11.4 with no E0596 at all, at the cost of making `WidgetClassExt` internally inconsistent about receivers.

I built and ran the full matrix for **both** variants; both are green on everything except that the `&mut self` one rejects the shared-reference case above. Say the word and I will switch to `&self` — it is three signatures and two `*mut` to `*const` casts.

## Verification

The regression was established by bisect, not inference: one unchanged reproducer compiles against `e38a336^` (`c175f55`) and fails against main, with the same `Cargo.lock`, rustc and system GTK.

The new test `subclass::widget::tests::class_methods_on_custom_class_struct` uses a `#[repr(C)]` class struct with **no `Deref` impl at all**, so the auto-deref escape route is deliberately unavailable. It also asserts both #2319 use cases (`widget.class()` and `glib::Class::<T>::from_type`).

It is mutation-tested: reverting the source change while keeping the test yields eight `E0599`s, one per restored method. Note the gate is a *compile* failure, so CI reports it as a build break rather than a failing test — that is the only possible shape for a trait-resolution regression.

`query_action()` enumerates inherited actions, so the test asserts the installed action is *present* rather than that it is the only one, and it binds shortcuts on its own type rather than mutating a process-global `GtkTextView` class.

Green: `cargo test -p gtk4` (20 lib / 1 / 10 doctests) and `--features v4_14` (24 / 1 / 11), exercising both `cfg(feature = "v4_10")` branches; the full workspace build including `examples/virtual_methods`, the repo's only existing custom-`ClassStruct` user, so no method-resolution ambiguity is introduced; `cargo fmt --check`; `cargo clippy -p gtk4 --all-targets` with zero warnings; `cargo doc` warning count unchanged from main.

## What I did not verify

Only tested against **GTK 4.14.5** on Linux with default features and `v4_14` — I could not reproduce CI's `v4_18`+ / `v4_24` matrix. The one version-sensitive assertion (`query_action`) is written to tolerate GTK adding class actions to `GtkWidget`; the others assert values the test itself sets.

The `abi.rs` `cross_validate_*` tests fail in my environment on this branch *and* on pristine main (the generated `layout.c` will not compile against 4.14.5 headers), so that is pre-existing and unrelated.

Happy to reshape any of this — including splitting the CHANGELOG entry out or switching the receivers as described above.