### PR TITLE
Change to_string() to as_str() in widget.rs

### DIFF
--- a/gtk4/src/subclass/widget.rs
+++ b/gtk4/src/subclass/widget.rs
@@ -1049,7 +1049,7 @@ pub unsafe trait WidgetClassExt: ClassStruct {
                         .unwrap();
                     let activate_callback = *internal
                         .actions
-                        .get(&action_name.to_string())
+                        .get(action_name.as_str())
                         .unwrap_or_else(|| {
                             panic!("Action name '{}' was not found", action_name.as_str());
                         });


### PR DESCRIPTION
The method `to_string()` allocates new memory even if you are not writing to the string. `to_string()` is well suited for events where you are writing to the string, but because this function just reads an immutable variable, `as_str()` is more appropriate, mainly because `as_str()` is meant for read-only operations and does not allocate new memory.

Cargo test and cargo check passed.